### PR TITLE
[#1] Feature : plip-video API env 및 apiFetch 추가

### DIFF
--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -1,0 +1,8 @@
+export const API_ENDPOINTS = {
+  video: {
+    uploadUrl: "/api/videos/upload-url",
+    complete: (videoUuid: string) => `/api/videos/${videoUuid}/complete` as const,
+    detail: (videoUuid: string) => `/api/videos/${videoUuid}` as const,
+    downloadUrl: (videoUuid: string) => `/api/videos/${videoUuid}/download-url` as const,
+  },
+} as const;

--- a/docs/video-local.env.example
+++ b/docs/video-local.env.example
@@ -1,0 +1,3 @@
+# Copy to project root as .env.local (gitignored)
+VIDEO_API_BASE_URL=http://localhost:8085
+DEV_USER_UUID=00000000-0000-4000-8000-000000000001

--- a/lib/api/apiFetch.ts
+++ b/lib/api/apiFetch.ts
@@ -1,0 +1,104 @@
+import { getVideoApiBaseUrl } from "@/lib/api/env";
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+type ApiFetchOptions = Omit<RequestInit, "body"> & {
+  body?: unknown;
+  searchParams?: Record<string, string | undefined>;
+};
+
+function buildUrl(path: string, searchParams?: Record<string, string | undefined>): string {
+  const base = getVideoApiBaseUrl().replace(/\/$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${base}${normalizedPath}`);
+
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (value !== undefined && value !== "") {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  return url.toString();
+}
+
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const { body, searchParams, headers, ...rest } = options;
+  const hasJsonBody = body !== undefined;
+
+  const response = await fetch(buildUrl(path, searchParams), {
+    ...rest,
+    headers: {
+      ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
+      ...headers,
+    },
+    body: hasJsonBody ? JSON.stringify(body) : undefined,
+    cache: "no-store",
+  });
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const parsedBody = contentType.includes("application/json")
+    ? await response.json().catch(() => undefined)
+    : await response.text().catch(() => undefined);
+
+  if (!response.ok) {
+    const message =
+      typeof parsedBody === "object" &&
+      parsedBody !== null &&
+      "message" in parsedBody &&
+      typeof parsedBody.message === "string"
+        ? parsedBody.message
+        : `API request failed (${response.status})`;
+
+    throw new ApiError(message, response.status, parsedBody);
+  }
+
+  return parsedBody as T;
+}
+
+export async function apiFetchWithStatus<T>(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<{ status: number; data: T }> {
+  const { body, searchParams, headers, ...rest } = options;
+  const hasJsonBody = body !== undefined;
+
+  const response = await fetch(buildUrl(path, searchParams), {
+    ...rest,
+    headers: {
+      ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
+      ...headers,
+    },
+    body: hasJsonBody ? JSON.stringify(body) : undefined,
+    cache: "no-store",
+  });
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const parsedBody = contentType.includes("application/json")
+    ? await response.json().catch(() => undefined)
+    : await response.text().catch(() => undefined);
+
+  if (!response.ok) {
+    const message =
+      typeof parsedBody === "object" &&
+      parsedBody !== null &&
+      "message" in parsedBody &&
+      typeof parsedBody.message === "string"
+        ? parsedBody.message
+        : `API request failed (${response.status})`;
+
+    throw new ApiError(message, response.status, parsedBody);
+  }
+
+  return { status: response.status, data: parsedBody as T };
+}

--- a/lib/api/env.ts
+++ b/lib/api/env.ts
@@ -1,0 +1,10 @@
+const DEFAULT_VIDEO_API_BASE_URL = "http://localhost:8085";
+const DEFAULT_DEV_USER_UUID = "00000000-0000-4000-8000-000000000001";
+
+export function getVideoApiBaseUrl(): string {
+  return process.env.VIDEO_API_BASE_URL?.trim() || DEFAULT_VIDEO_API_BASE_URL;
+}
+
+export function getDevUserUuid(): string {
+  return process.env.DEV_USER_UUID?.trim() || DEFAULT_DEV_USER_UUID;
+}


### PR DESCRIPTION
## 작업 내용

plip-video 백엔드 연동을 위한 **HTTP 클라이언트 기반(Step 1)** 을 추가했습니다.  
README 3-Layer 규칙에 따라 `fetch` 호출은 `lib/api/*`에만 두고, API 경로는 `config/api-endpoints.ts`에 상수로 정의합니다.

로컬 개발 시 `.env.local`에 `VIDEO_API_BASE_URL`, `DEV_USER_UUID`를 설정합니다. 템플릿은 `docs/video-local.env.example`에 포함했습니다.

## 관련 이슈

Related to #1

## 변경 사항

### 1. API 경로 상수

- **파일:** `config/api-endpoints.ts`
- **설명:** plip-video REST 경로(upload-url, complete, detail, download-url)를 `API_ENDPOINTS.video`로 정의

```typescript
export const API_ENDPOINTS = {
  video: {
    uploadUrl: "/api/videos/upload-url",
    complete: (videoUuid: string) => `/api/videos/${videoUuid}/complete` as const,
    detail: (videoUuid: string) => `/api/videos/${videoUuid}` as const,
    downloadUrl: (videoUuid: string) => `/api/videos/${videoUuid}/download-url` as const,
  },
} as const;
```

### 2. env helper

- **파일:** `lib/api/env.ts`
- **설명:** `VIDEO_API_BASE_URL`(기본 `http://localhost:8085`), `DEV_USER_UUID`(auth 전 mock user) 읽기

```typescript
export function getVideoApiBaseUrl(): string {
  return process.env.VIDEO_API_BASE_URL?.trim() || DEFAULT_VIDEO_API_BASE_URL;
}

export function getDevUserUuid(): string {
  return process.env.DEV_USER_UUID?.trim() || DEFAULT_DEV_USER_UUID;
}
```

### 3. apiFetch wrapper

- **파일:** `lib/api/apiFetch.ts`
- **설명:** 공통 `fetch` wrapper. JSON body, query param, `ApiError`(status + body) 처리

```typescript
export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
  const response = await fetch(buildUrl(path, searchParams), { ... });
  if (!response.ok) {
    throw new ApiError(message, response.status, parsedBody);
  }
  return parsedBody as T;
}
```

### 4. 로컬 env 템플릿

- **파일:** `docs/video-local.env.example`
- **설명:** `.env.local` 복사용 (Git 제외). `VIDEO_API_BASE_URL`, `DEV_USER_UUID` 예시

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [x] Step 1 단독 브랜치에서 pre-push 통과 확인

### 로컬 설정

```bash
cp docs/video-local.env.example .env.local
```

## 머지 전 체크

- [x] PR 제목 형식: `[#1] Feature : plip-video API env 및 apiFetch 추가`
- [x] base branch: **develop**
- [x] CI Test workflow 통과