### PR TITLE
[#2] Feature: plip-video API types 및 videoService 추가

### DIFF
--- a/lib/api/videoApi.ts
+++ b/lib/api/videoApi.ts
@@ -1,0 +1,62 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { apiFetch, apiFetchWithStatus } from "@/lib/api/apiFetch";
+import type {
+  VideoCompleteRequest,
+  VideoCompleteResponse,
+  VideoDetailResponse,
+  VideoDownloadUrlProcessingResponse,
+  VideoDownloadUrlResponse,
+  VideoDownloadUrlResult,
+  VideoUploadUrlResponse,
+} from "@/types/video/api";
+
+export async function postUploadUrl(
+  userUuid: string,
+  contentType?: string,
+): Promise<VideoUploadUrlResponse> {
+  return apiFetch<VideoUploadUrlResponse>(API_ENDPOINTS.video.uploadUrl, {
+    method: "POST",
+    searchParams: {
+      userUuid,
+      contentType,
+    },
+  });
+}
+
+export async function postComplete(
+  videoUuid: string,
+  userUuid: string,
+  request?: VideoCompleteRequest,
+): Promise<VideoCompleteResponse> {
+  return apiFetch<VideoCompleteResponse>(API_ENDPOINTS.video.complete(videoUuid), {
+    method: "POST",
+    searchParams: { userUuid },
+    body: request ?? {},
+  });
+}
+
+export async function getVideoDetail(videoUuid: string): Promise<VideoDetailResponse> {
+  return apiFetch<VideoDetailResponse>(API_ENDPOINTS.video.detail(videoUuid), {
+    method: "GET",
+  });
+}
+
+export async function getDownloadUrl(videoUuid: string): Promise<VideoDownloadUrlResult> {
+  const { status, data } = await apiFetchWithStatus<
+    VideoDownloadUrlResponse | VideoDownloadUrlProcessingResponse
+  >(API_ENDPOINTS.video.downloadUrl(videoUuid), {
+    method: "GET",
+  });
+
+  if (status === 202) {
+    return {
+      kind: "processing",
+      body: data as VideoDownloadUrlProcessingResponse,
+    };
+  }
+
+  return {
+    kind: "ready",
+    body: data as VideoDownloadUrlResponse,
+  };
+}

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -1,0 +1,88 @@
+import * as videoApi from "@/lib/api/videoApi";
+import type {
+  VideoCompleteResponse,
+  VideoDetailResponse,
+  VideoDownloadUrlResult,
+  VideoUploadUrlResponse,
+} from "@/types/video/api";
+import type {
+  VideoCompleteUi,
+  VideoDetailUi,
+  VideoDownloadUrlUi,
+  VideoUploadUrlUi,
+} from "@/types/video/ui";
+
+function mapUploadUrl(api: VideoUploadUrlResponse): VideoUploadUrlUi {
+  return {
+    videoUuid: api.videoUuid,
+    rawS3Key: api.rawS3Key,
+    uploadUrl: api.uploadUrl,
+    expiresAt: new Date(api.expiresAt),
+  };
+}
+
+function mapComplete(api: VideoCompleteResponse): VideoCompleteUi {
+  return {
+    videoUuid: api.videoUuid,
+    caption: api.caption,
+    createdAt: new Date(api.createdAt),
+    overlayTime: api.overlayTime,
+  };
+}
+
+function mapDetail(api: VideoDetailResponse): VideoDetailUi {
+  return {
+    videoUuid: api.videoUuid,
+    userUuid: api.userUuid,
+    caption: api.caption,
+    createdAt: new Date(api.createdAt),
+    rawPlaybackUrl: api.rawPlaybackUrl,
+    thumbnailUrl: api.thumbnailUrl,
+    overlayTime: api.overlayTime,
+    downloadReady: api.downloadReady,
+  };
+}
+
+function mapDownloadUrl(result: VideoDownloadUrlResult): VideoDownloadUrlUi {
+  if (result.kind === "processing") {
+    return {
+      status: "processing",
+      videoUuid: result.body.videoUuid,
+      retryAfterSeconds: result.body.retryAfterSeconds,
+      message: result.body.message,
+    };
+  }
+
+  return {
+    status: "ready",
+    videoUuid: result.body.videoUuid,
+    downloadUrl: result.body.downloadUrl,
+  };
+}
+
+export async function issueUploadUrl(
+  userUuid: string,
+  contentType?: string,
+): Promise<VideoUploadUrlUi> {
+  const response = await videoApi.postUploadUrl(userUuid, contentType);
+  return mapUploadUrl(response);
+}
+
+export async function completeVideo(
+  videoUuid: string,
+  userUuid: string,
+  caption?: string,
+): Promise<VideoCompleteUi> {
+  const response = await videoApi.postComplete(videoUuid, userUuid, { caption });
+  return mapComplete(response);
+}
+
+export async function getVideoDetail(videoUuid: string): Promise<VideoDetailUi> {
+  const response = await videoApi.getVideoDetail(videoUuid);
+  return mapDetail(response);
+}
+
+export async function getDownloadUrl(videoUuid: string): Promise<VideoDownloadUrlUi> {
+  const response = await videoApi.getDownloadUrl(videoUuid);
+  return mapDownloadUrl(response);
+}

--- a/types/action-result.ts
+++ b/types/action-result.ts
@@ -1,0 +1,11 @@
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+export function actionSuccess<T>(data: T): ActionResult<T> {
+  return { ok: true, data };
+}
+
+export function actionFailure(error: string): ActionResult<never> {
+  return { ok: false, error };
+}

--- a/types/video/api.ts
+++ b/types/video/api.ts
@@ -1,0 +1,46 @@
+/** plip-video REST DTO mirrors (com.plip.video.adapter.in.web.dto) */
+
+export type VideoUploadUrlResponse = {
+  videoUuid: string;
+  rawS3Key: string;
+  uploadUrl: string;
+  expiresAt: string;
+};
+
+export type VideoCompleteRequest = {
+  caption?: string | null;
+};
+
+export type VideoCompleteResponse = {
+  videoUuid: string;
+  caption: string | null;
+  createdAt: string;
+  overlayTime: string;
+};
+
+export type VideoDetailResponse = {
+  videoUuid: string;
+  userUuid: string;
+  caption: string | null;
+  createdAt: string;
+  rawPlaybackUrl: string;
+  thumbnailUrl: string | null;
+  overlayTime: string;
+  downloadReady: boolean;
+};
+
+export type VideoDownloadUrlResponse = {
+  videoUuid: string;
+  downloadUrl: string;
+};
+
+export type VideoDownloadUrlProcessingResponse = {
+  status: "PROCESSING";
+  videoUuid: string;
+  retryAfterSeconds: number;
+  message: string;
+};
+
+export type VideoDownloadUrlResult =
+  | { kind: "ready"; body: VideoDownloadUrlResponse }
+  | { kind: "processing"; body: VideoDownloadUrlProcessingResponse };

--- a/types/video/ui.ts
+++ b/types/video/ui.ts
@@ -1,0 +1,42 @@
+export type VideoUploadUrlUi = {
+  videoUuid: string;
+  rawS3Key: string;
+  uploadUrl: string;
+  expiresAt: Date;
+};
+
+export type VideoCompleteUi = {
+  videoUuid: string;
+  caption: string | null;
+  createdAt: Date;
+  overlayTime: string;
+};
+
+export type VideoDetailUi = {
+  videoUuid: string;
+  userUuid: string;
+  caption: string | null;
+  createdAt: Date;
+  rawPlaybackUrl: string;
+  thumbnailUrl: string | null;
+  overlayTime: string;
+  downloadReady: boolean;
+};
+
+export type VideoDownloadUrlUi =
+  | { status: "ready"; videoUuid: string; downloadUrl: string }
+  | {
+      status: "processing";
+      videoUuid: string;
+      retryAfterSeconds: number;
+      message: string;
+    };
+
+export type CaptureFlowPhase =
+  | "initializing"
+  | "ready"
+  | "recording"
+  | "preview"
+  | "uploading"
+  | "complete"
+  | "error";


### PR DESCRIPTION
## 작업 내용

plip-video 백엔드 REST DTO와 UI 모델을 정의하고, Step 1의 `apiFetch` 위에 **video HTTP 클라이언트(`videoApi`)** 와 **서비스(`videoService`)** 을 추가했습니다.

README 3-Layer 규칙에 따라 `videoApi`만 `fetch`를 호출하고, `videoService`는 Api DTO → Ui 모델(`Date` 변환 등) 매핑을 담당합니다. Server Actions(Step 3)는 이 PR 이후 추가됩니다.

## 관련 이슈

Related to #9 

## 변경 사항

### 1. ActionResult 공통 타입

- **파일:** `types/action-result.ts`
- **설명:** Step 3 Server Actions에서 사용할 `{ ok, data } | { ok, error }` 패턴

```typescript
export type ActionResult<T> =
  | { ok: true; data: T }
  | { ok: false; error: string };
```

### 2. plip-video REST DTO (api layer)

- **파일:** `types/video/api.ts`
- **설명:** 백엔드 `VideoUploadUrlResponse`, `VideoDetailResponse`, `VideoDownloadUrl*` 등 mirror

```typescript
export type VideoUploadUrlResponse = {
  videoUuid: string;
  rawS3Key: string;
  uploadUrl: string;
  expiresAt: string;
};

export type VideoDownloadUrlResult =
  | { kind: "ready"; body: VideoDownloadUrlResponse }
  | { kind: "processing"; body: VideoDownloadUrlProcessingResponse };
```

### 3. UI 모델

- **파일:** `types/video/ui.ts`
- **설명:** Service/Client에서 쓸 Ui 타입. API의 ISO string → `Date` 변환은 `videoService`에서 수행

```typescript
export type VideoUploadUrlUi = {
  videoUuid: string;
  rawS3Key: string;
  uploadUrl: string;
  expiresAt: Date;
};
```

### 4. videoApi — HTTP 호출

- **파일:** `lib/api/videoApi.ts`
- **설명:** `API_ENDPOINTS` + `apiFetch`로 upload-url / complete / GET detail / GET download-url 호출. download-url은 200/202 분기 처리

```typescript
export async function postUploadUrl(
  userUuid: string,
  contentType?: string,
): Promise<VideoUploadUrlResponse> {
  return apiFetch<VideoUploadUrlResponse>(API_ENDPOINTS.video.uploadUrl, {
    method: "POST",
    searchParams: { userUuid, contentType },
  });
}
```

### 5. videoService — Api → Ui 매핑

- **파일:** `services/videoService.ts`
- **설명:** `videoApi` 조합 + DTO를 Ui 모델로 변환. `"use server"` 없음 (Actions에서 호출)

```typescript
export async function issueUploadUrl(
  userUuid: string,
  contentType?: string,
): Promise<VideoUploadUrlUi> {
  const response = await videoApi.postUploadUrl(userUuid, contentType);
  return mapUploadUrl(response);
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [x] Step 2 단독 브랜치(Step 3+ 파일 없음)에서 pre-push 통과

### 의존성

- **선행 PR:** Step 1 (`feature/1-video-api-env`) — `lib/api/apiFetch`, `config/api-endpoints`, `lib/api/env`

## 머지 전 체크
- [x] base branch: **develop** (Step 1 머지 포함)
- [x] CI Test workflow 통과