### PR TITLE
Feature: plip-video Server Actions 및 video-api lab 추가

### DIFF
--- a/actions/videoActions.ts
+++ b/actions/videoActions.ts
@@ -1,0 +1,144 @@
+"use server";
+
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import type {
+  VideoCompleteActionData,
+  VideoDetailActionData,
+  VideoDownloadUrlActionData,
+  VideoUploadUrlActionData,
+} from "@/types/video/action";
+import { getDevUserUuid, getVideoApiBaseUrl } from "@/lib/api/env";
+import { ApiError } from "@/lib/api/apiFetch";
+import {
+  toCompleteActionData,
+  toDetailActionData,
+  toDownloadUrlActionData,
+  toUploadUrlActionData,
+} from "@/lib/video/actionPayload";
+import * as videoService from "@/services/videoService";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const ALLOWED_CONTENT_TYPES = new Set(["video/mp4", "video/quicktime"]);
+
+function resolveUserUuid(userUuid?: string): string | null {
+  const resolved = userUuid?.trim() || getDevUserUuid();
+  return UUID_PATTERN.test(resolved) ? resolved : null;
+}
+
+function resolveVideoUuid(videoUuid: string): string | null {
+  const trimmed = videoUuid.trim();
+  return UUID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+function resolveContentType(contentType?: string): string | undefined {
+  if (!contentType?.trim()) {
+    return "video/mp4";
+  }
+
+  const normalized = contentType.trim().toLowerCase();
+  return ALLOWED_CONTENT_TYPES.has(normalized) ? normalized : undefined;
+}
+
+function toActionError(error: unknown): ActionResult<never> {
+  if (error instanceof ApiError) {
+    return actionFailure(`[${error.status}] ${error.message}`);
+  }
+
+  if (error instanceof Error) {
+    const cause = error.cause instanceof Error ? error.cause.message : "";
+    if (error.message.includes("fetch failed") || cause.includes("ECONNREFUSED")) {
+      return actionFailure(
+        `plip-video에 연결할 수 없습니다 (${getVideoApiBaseUrl()}). 백엔드 bootRun 여부를 확인하세요.`,
+      );
+    }
+
+    return actionFailure(error.message);
+  }
+
+  return actionFailure("Unknown error");
+}
+
+export async function issueUploadUrlAction(
+  contentType?: string,
+  userUuid?: string,
+): Promise<ActionResult<VideoUploadUrlActionData>> {
+  const resolvedUserUuid = resolveUserUuid(userUuid);
+  if (!resolvedUserUuid) {
+    return actionFailure("Invalid userUuid");
+  }
+
+  const resolvedContentType = resolveContentType(contentType);
+  if (!resolvedContentType) {
+    return actionFailure("contentType must be video/mp4 or video/quicktime");
+  }
+
+  try {
+    const data = await videoService.issueUploadUrl(resolvedUserUuid, resolvedContentType);
+    return actionSuccess(toUploadUrlActionData(data));
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function completeVideoAction(
+  videoUuid: string,
+  caption?: string,
+  userUuid?: string,
+): Promise<ActionResult<VideoCompleteActionData>> {
+  const resolvedVideoUuid = resolveVideoUuid(videoUuid);
+  if (!resolvedVideoUuid) {
+    return actionFailure("Invalid videoUuid");
+  }
+
+  const resolvedUserUuid = resolveUserUuid(userUuid);
+  if (!resolvedUserUuid) {
+    return actionFailure("Invalid userUuid");
+  }
+
+  const normalizedCaption = caption?.trim() || undefined;
+
+  try {
+    const data = await videoService.completeVideo(
+      resolvedVideoUuid,
+      resolvedUserUuid,
+      normalizedCaption,
+    );
+    return actionSuccess(toCompleteActionData(data));
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function getVideoAction(
+  videoUuid: string,
+): Promise<ActionResult<VideoDetailActionData>> {
+  const resolvedVideoUuid = resolveVideoUuid(videoUuid);
+  if (!resolvedVideoUuid) {
+    return actionFailure("Invalid videoUuid");
+  }
+
+  try {
+    const data = await videoService.getVideoDetail(resolvedVideoUuid);
+    return actionSuccess(toDetailActionData(data));
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function getDownloadUrlAction(
+  videoUuid: string,
+): Promise<ActionResult<VideoDownloadUrlActionData>> {
+  const resolvedVideoUuid = resolveVideoUuid(videoUuid);
+  if (!resolvedVideoUuid) {
+    return actionFailure("Invalid videoUuid");
+  }
+
+  try {
+    const data = await videoService.getDownloadUrl(resolvedVideoUuid);
+    return actionSuccess(toDownloadUrlActionData(data));
+  } catch (error) {
+    return toActionError(error);
+  }
+}

--- a/app/(capture)/video-api/page.tsx
+++ b/app/(capture)/video-api/page.tsx
@@ -1,0 +1,5 @@
+import { CaptureApiTemplate } from "@/components/templates/CaptureApiTemplate";
+
+export default function CaptureVideoApiPage() {
+  return <CaptureApiTemplate />;
+}

--- a/components/organisms/VideoApiLabSection.tsx
+++ b/components/organisms/VideoApiLabSection.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import {
+  completeVideoAction,
+  getDownloadUrlAction,
+  getVideoAction,
+  issueUploadUrlAction,
+} from "@/actions/videoActions";
+import {
+  extractActionError,
+  extractVideoUuidFromActionResult,
+} from "@/lib/video/actionPayload";
+import { useState } from "react";
+
+type LogEntry = {
+  id: number;
+  label: string;
+  payload: unknown;
+};
+
+type StatusMessage = {
+  kind: "success" | "error";
+  text: string;
+};
+
+export function VideoApiLabSection() {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [videoUuid, setVideoUuid] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+
+  function appendLog(label: string, payload: unknown) {
+    setLogs((prev) => [{ id: Date.now(), label, payload }, ...prev].slice(0, 10));
+  }
+
+  function applyActionResult(label: string, payload: unknown) {
+    appendLog(label, payload);
+
+    const nextVideoUuid = extractVideoUuidFromActionResult(payload);
+    if (nextVideoUuid) {
+      setVideoUuid(nextVideoUuid);
+    }
+
+    const error = extractActionError(payload);
+    if (error) {
+      setStatus({ kind: "error", text: error });
+      return;
+    }
+
+    if (nextVideoUuid && label === "issueUploadUrlAction") {
+      setStatus({ kind: "success", text: `videoUuid 입력됨: ${nextVideoUuid}` });
+      return;
+    }
+
+    setStatus({ kind: "success", text: `${label} 성공` });
+  }
+
+  async function run(label: string, task: () => Promise<unknown>) {
+    setBusy(true);
+    setStatus(null);
+
+    try {
+      const result = await task();
+      applyActionResult(label, result);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      applyActionResult(label, { ok: false, error: message });
+      return { ok: false as const, error: message };
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleIssueUploadUrl() {
+    await run("issueUploadUrlAction", () => issueUploadUrlAction("video/mp4"));
+  }
+
+  async function handleComplete() {
+    if (!videoUuid.trim()) {
+      applyActionResult("completeVideoAction", {
+        ok: false,
+        error: "videoUuid가 비어 있습니다. 1. upload-url을 먼저 실행하세요.",
+      });
+      return;
+    }
+
+    await run("completeVideoAction", () =>
+      completeVideoAction(videoUuid.trim(), "Phase 0-F lab caption"),
+    );
+  }
+
+  async function handleGetVideo() {
+    if (!videoUuid.trim()) {
+      applyActionResult("getVideoAction", {
+        ok: false,
+        error: "videoUuid가 비어 있습니다.",
+      });
+      return;
+    }
+
+    await run("getVideoAction", () => getVideoAction(videoUuid.trim()));
+  }
+
+  async function handleGetDownloadUrl() {
+    if (!videoUuid.trim()) {
+      applyActionResult("getDownloadUrlAction", {
+        ok: false,
+        error: "videoUuid가 비어 있습니다.",
+      });
+      return;
+    }
+
+    await run("getDownloadUrlAction", () => getDownloadUrlAction(videoUuid.trim()));
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6 font-mono text-sm">
+      <header>
+        <h1 className="text-lg font-semibold">Video API Lab (Step 1–3)</h1>
+        <p className="text-black/60">
+          Server Actions → videoService → videoApi → plip-video (:8085)
+        </p>
+        <p className="text-xs text-black/50">
+          촬영 Phase 0-F (Step 4 PR):{" "}
+          <a href="/video" className="underline">
+            /video
+          </a>
+        </p>
+      </header>
+
+      {status ? (
+        <p
+          className={`rounded px-3 py-2 text-xs ${
+            status.kind === "error" ? "bg-red-50 text-red-700" : "bg-green-50 text-green-800"
+          }`}
+          role="status"
+        >
+          {status.text}
+        </p>
+      ) : null}
+
+      <label className="flex flex-col gap-1">
+        <span>videoUuid</span>
+        <input
+          className="rounded border px-3 py-2"
+          value={videoUuid}
+          onChange={(event) => setVideoUuid(event.target.value)}
+          placeholder="1. upload-url 클릭 시 자동 입력"
+        />
+      </label>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded bg-black px-3 py-2 text-white disabled:opacity-50"
+          disabled={busy}
+          onClick={handleIssueUploadUrl}
+        >
+          1. upload-url
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={busy}
+          onClick={handleComplete}
+        >
+          2. complete (NoOp PUT 생략)
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={busy}
+          onClick={handleGetVideo}
+        >
+          3. GET detail
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={busy}
+          onClick={handleGetDownloadUrl}
+        >
+          4. GET download-url
+        </button>
+      </div>
+
+      <p className="text-xs text-black/50">
+        순서: 1 → 2 → 3 → 4. 2번(complete) 전에 3·4번을 누르면 404/202만 나올 수 있습니다.
+      </p>
+
+      <ol className="list-decimal space-y-2 pl-5 text-black/70">
+        {logs.map((entry) => (
+          <li key={entry.id}>
+            <strong>{entry.label}</strong>
+            <pre className="mt-1 overflow-x-auto rounded bg-black/5 p-2 text-xs">
+              {JSON.stringify(entry.payload, null, 2)}
+            </pre>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/components/templates/CaptureApiTemplate.tsx
+++ b/components/templates/CaptureApiTemplate.tsx
@@ -1,0 +1,5 @@
+import { VideoApiLabSection } from "@/components/organisms/VideoApiLabSection";
+
+export function CaptureApiTemplate() {
+  return <VideoApiLabSection />;
+}

--- a/lib/video/actionPayload.ts
+++ b/lib/video/actionPayload.ts
@@ -1,0 +1,98 @@
+import type {
+  VideoCompleteActionData,
+  VideoDetailActionData,
+  VideoDownloadUrlActionData,
+  VideoUploadUrlActionData,
+} from "@/types/video/action";
+import type {
+  VideoCompleteUi,
+  VideoDetailUi,
+  VideoDownloadUrlUi,
+  VideoUploadUrlUi,
+} from "@/types/video/ui";
+
+export function toUploadUrlActionData(data: VideoUploadUrlUi): VideoUploadUrlActionData {
+  return {
+    videoUuid: data.videoUuid,
+    rawS3Key: data.rawS3Key,
+    uploadUrl: data.uploadUrl,
+    expiresAt: data.expiresAt.toISOString(),
+  };
+}
+
+export function toCompleteActionData(data: VideoCompleteUi): VideoCompleteActionData {
+  return {
+    videoUuid: data.videoUuid,
+    caption: data.caption,
+    createdAt: data.createdAt.toISOString(),
+    overlayTime: data.overlayTime,
+  };
+}
+
+export function toDetailActionData(data: VideoDetailUi): VideoDetailActionData {
+  return {
+    videoUuid: data.videoUuid,
+    userUuid: data.userUuid,
+    caption: data.caption,
+    createdAt: data.createdAt.toISOString(),
+    rawPlaybackUrl: data.rawPlaybackUrl,
+    thumbnailUrl: data.thumbnailUrl,
+    overlayTime: data.overlayTime,
+    downloadReady: data.downloadReady,
+  };
+}
+
+export function toDownloadUrlActionData(data: VideoDownloadUrlUi): VideoDownloadUrlActionData {
+  if (data.status === "ready") {
+    return {
+      status: "ready",
+      videoUuid: data.videoUuid,
+      downloadUrl: data.downloadUrl,
+    };
+  }
+
+  return {
+    status: "processing",
+    videoUuid: data.videoUuid,
+    retryAfterSeconds: data.retryAfterSeconds,
+    message: data.message,
+  };
+}
+
+export function extractVideoUuidFromActionResult(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  if (!("ok" in payload) || payload.ok !== true) {
+    return null;
+  }
+
+  if (!("data" in payload) || !payload.data || typeof payload.data !== "object") {
+    return null;
+  }
+
+  const data = payload.data as Record<string, unknown>;
+  if (typeof data.videoUuid !== "string") {
+    return null;
+  }
+
+  const trimmed = data.videoUuid.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function extractActionError(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  if (!("ok" in payload) || payload.ok !== false) {
+    return null;
+  }
+
+  if (!("error" in payload) || typeof payload.error !== "string") {
+    return "Unknown error";
+  }
+
+  return payload.error;
+}

--- a/types/video/action.ts
+++ b/types/video/action.ts
@@ -1,0 +1,35 @@
+/** Server Action → Client 직렬화용 (Date 금지) */
+
+export type VideoUploadUrlActionData = {
+  videoUuid: string;
+  rawS3Key: string;
+  uploadUrl: string;
+  expiresAt: string;
+};
+
+export type VideoCompleteActionData = {
+  videoUuid: string;
+  caption: string | null;
+  createdAt: string;
+  overlayTime: string;
+};
+
+export type VideoDetailActionData = {
+  videoUuid: string;
+  userUuid: string;
+  caption: string | null;
+  createdAt: string;
+  rawPlaybackUrl: string;
+  thumbnailUrl: string | null;
+  overlayTime: string;
+  downloadReady: boolean;
+};
+
+export type VideoDownloadUrlActionData =
+  | { status: "ready"; videoUuid: string; downloadUrl: string }
+  | {
+      status: "processing";
+      videoUuid: string;
+      retryAfterSeconds: number;
+      message: string;
+    };


### PR DESCRIPTION
## 작업 내용

Step 2의 `videoService` 위에 **Server Actions**를 추가하고, Client에서 Actions만 호출하도록 README 3-Layer 규칙을 적용했습니다.  
`(capture)/video-api` lab 페이지에서 upload-url → complete → GET detail → GET download-url을 수동 검증할 수 있습니다.

Action 반환값은 Client 직렬화를 위해 `Date` 대신 ISO string(`types/video/action.ts`)을 사용합니다.

## 관련 이슈

Related to #9 
Related to #10 

## 변경 사항

### 1. Server Action 직렬화 타입

- **파일:** `types/video/action.ts`
- **설명:** `VideoUploadUrlActionData`, `VideoCompleteActionData` 등 (Date → string)

### 2. Action payload helper

- **파일:** `lib/video/actionPayload.ts`
- **설명:** Ui → ActionData 변환, `extractActionError`, `extractVideoUuidFromActionResult`

```typescript
export function extractActionError(payload: unknown): string | null {
  if (!payload || typeof payload !== "object") return null;
  if (!("ok" in payload) || payload.ok !== false) return null;
  return typeof payload.error === "string" ? payload.error : "Unknown error";
}
```

### 3. videoActions (4종)

- **파일:** `actions/videoActions.ts`
- **설명:** `issueUploadUrlAction`, `completeVideoAction`, `getVideoAction`, `getDownloadUrlAction`. UUID/contentType 검증, `ActionResult` 반환

```typescript
export async function issueUploadUrlAction(
  contentType?: string,
  userUuid?: string,
): Promise<ActionResult<VideoUploadUrlActionData>> {
  // resolveUserUuid → videoService.issueUploadUrl → toUploadUrlActionData
}
```

### 4. video-api lab UI

- **파일:** `components/organisms/VideoApiLabSection.tsx`, `components/templates/CaptureApiTemplate.tsx`, `app/(capture)/video-api/page.tsx`
- **설명:** Server Actions 버튼 lab. URL `/video-api` (route group `(capture)`)

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [X] `/video-api` 수동 E2E (plip-video `:8085` + `.env.local`)

### E2E 순서

1. `POST upload-url` (버튼 1)
2. `POST complete` (버튼 2, NoOp PUT 생략 가능)
3. `GET detail` (버튼 3)
4. `GET download-url` (버튼 4 → 202 PROCESSING 정상)

## 머지 전 체크
- [ ] CI Test 통과