### PR TITLE
[#4] Feature: 5초 촬영 및 capture flow 추가

### DIFF
--- a/app/(capture)/layout.tsx
+++ b/app/(capture)/layout.tsx
@@ -1,0 +1,3 @@
+export default function CaptureLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-dvh bg-white text-black">{children}</div>;
+}

--- a/app/(capture)/video/page.tsx
+++ b/app/(capture)/video/page.tsx
@@ -1,0 +1,5 @@
+import { CaptureVideoTemplate } from "@/components/templates/CaptureVideoTemplate";
+
+export default function CaptureVideoPage() {
+  return <CaptureVideoTemplate />;
+}

--- a/components/organisms/VideoApiLabSection.tsx
+++ b/components/organisms/VideoApiLabSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ROUTES } from "@/config/routes";
 import {
   completeVideoAction,
   getDownloadUrlAction,
@@ -123,8 +124,8 @@ export function VideoApiLabSection() {
         </p>
         <p className="text-xs text-black/50">
           촬영 Phase 0-F (Step 4 PR):{" "}
-          <a href="/video" className="underline">
-            /video
+          <a href={ROUTES.capture.video} className="underline">
+            {ROUTES.capture.video}
           </a>
         </p>
       </header>

--- a/components/organisms/VideoCaptureSection.tsx
+++ b/components/organisms/VideoCaptureSection.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { ROUTES } from "@/config/routes";
+import { useVideoCaptureFlow } from "@/hooks/useVideoCaptureFlow";
+import { formatBlobSummary } from "@/lib/video/recorderMime";
+import Link from "next/link";
+
+export function VideoCaptureSection() {
+  const {
+    videoRef,
+    status,
+    elapsedMs,
+    maxDurationMs,
+    blob,
+    mimeType,
+    facingMode,
+    flowPhase,
+    flowError,
+    uploadResult,
+    uploading,
+    prepareCamera,
+    startRecording,
+    stopRecording,
+    flipCamera,
+    retake,
+    uploadCapture,
+  } = useVideoCaptureFlow();
+
+  const progressPct = Math.min(100, Math.round((elapsedMs / maxDurationMs) * 100));
+
+  return (
+    <section className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6 font-mono text-sm">
+      <header className="space-y-2">
+        <p className="text-xs text-black/50">
+          <Link href={ROUTES.capture.videoApi} className="underline">
+            {ROUTES.capture.videoApi}
+          </Link>{" "}
+          · Actions lab
+        </p>
+        <h1 className="text-lg font-semibold">Video Capture (Phase 0-F)</h1>
+        <p className="text-black/60">
+          5초 촬영 → upload-url → PUT → complete → GET → download-url poll
+        </p>
+        <p className="text-xs text-amber-700">
+          (capture) route group — user-app 본 UI(/, /create)와 분리
+        </p>
+      </header>
+
+      <div className="overflow-hidden rounded-lg border bg-black">
+        <video
+          ref={videoRef}
+          className="aspect-[9/16] max-h-[420px] w-full object-cover"
+          autoPlay
+          playsInline
+          muted={flowPhase !== "complete"}
+          controls={flowPhase === "preview" || flowPhase === "complete"}
+        />
+      </div>
+
+      <div className="space-y-1 text-xs text-black/60">
+        <p>phase: {flowPhase}</p>
+        <p>recorder: {status}</p>
+        <p>
+          elapsed: {Math.min(elapsedMs, maxDurationMs)}ms / {maxDurationMs}ms ({progressPct}
+          %)
+        </p>
+        <p>camera: {facingMode}</p>
+        {mimeType ? <p>mime: {mimeType}</p> : null}
+        {blob ? <p>blob: {formatBlobSummary(blob)}</p> : null}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading || status === "recording"}
+          onClick={() => void prepareCamera()}
+        >
+          카메라 재시작
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading || status === "recording"}
+          onClick={() => void flipCamera()}
+        >
+          카메라 전환
+        </button>
+        <button
+          type="button"
+          className="rounded bg-black px-3 py-2 text-white disabled:opacity-50"
+          disabled={
+            uploading ||
+            status === "recording" ||
+            status === "requesting" ||
+            flowPhase === "complete"
+          }
+          onClick={() => void startRecording()}
+        >
+          {status === "recording" ? "촬영 중…" : "5초 촬영"}
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading || status !== "recording"}
+          onClick={stopRecording}
+        >
+          조기 종료
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading || flowPhase !== "preview" || !blob}
+          onClick={() => void uploadCapture()}
+        >
+          {uploading ? "업로드 중…" : "업로드 · complete"}
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading}
+          onClick={() => void retake()}
+        >
+          다시 촬영
+        </button>
+      </div>
+
+      {flowError ? (
+        <p className="rounded bg-red-50 px-3 py-2 text-xs text-red-700" role="alert">
+          {flowError}
+        </p>
+      ) : null}
+
+      {uploadResult ? (
+        <div className="space-y-2 rounded bg-green-50 px-3 py-2 text-xs text-green-900">
+          <p>videoUuid: {uploadResult.videoUuid}</p>
+          <p>overlayTime: {uploadResult.complete.overlayTime}</p>
+          <p>put: {uploadResult.putResult}</p>
+          <p>downloadReady (GET): {String(uploadResult.detail.downloadReady)}</p>
+          <p>
+            download-url: {uploadResult.download.status}
+            {uploadResult.download.status === "processing"
+              ? ` · ${uploadResult.download.message}`
+              : ""}
+          </p>
+          <p>download poll attempts: {uploadResult.downloadPollAttempts}</p>
+          <p>playback: {uploadResult.playback.kind}</p>
+          {uploadResult.playback.note ? (
+            <p className="text-green-800">{uploadResult.playback.note}</p>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/components/templates/CaptureVideoTemplate.tsx
+++ b/components/templates/CaptureVideoTemplate.tsx
@@ -1,0 +1,5 @@
+import { VideoCaptureSection } from "@/components/organisms/VideoCaptureSection";
+
+export function CaptureVideoTemplate() {
+  return <VideoCaptureSection />;
+}

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -56,3 +56,5 @@ export {
 } from "./ShopTemplates";
 export { SignUpTemplate } from "./SignUpTemplate";
 export { ClipEditTemplate, ClipViewerTemplate } from "./ViewerTemplates";
+export { CaptureApiTemplate } from "./CaptureApiTemplate";
+export { CaptureVideoTemplate } from "./CaptureVideoTemplate";

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -60,4 +60,9 @@ export const ROUTES = {
     notifications: "/mypage/notifications",
     settings: "/mypage/settings",
   },
+  /** plip-video Phase 0-F — user-app 본 UI와 분리 (route group `(capture)`) */
+  capture: {
+    video: "/video",
+    videoApi: "/video-api",
+  },
 } as const;

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useVideoRecorder } from "@/hooks/useVideoRecorder";
+import { DEFAULT_CAPTURE_CAPTION } from "@/lib/video/constants";
+import { runPhase0FUpload, type Phase0FUploadResult } from "@/lib/video/uploadPipeline";
+import type { CaptureFlowPhase } from "@/types/video/ui";
+import { useCallback, useMemo, useState } from "react";
+
+function mapRecorderStatusToFlowPhase(
+  recorderStatus: ReturnType<typeof useVideoRecorder>["status"],
+  uploading: boolean,
+  uploadResult: Phase0FUploadResult | null,
+  flowError: string | null,
+): CaptureFlowPhase {
+  if (flowError) {
+    return "error";
+  }
+
+  if (uploadResult) {
+    return "complete";
+  }
+
+  if (uploading) {
+    return "uploading";
+  }
+
+  switch (recorderStatus) {
+    case "requesting":
+      return "initializing";
+    case "ready":
+      return "ready";
+    case "recording":
+      return "recording";
+    case "preview":
+      return "preview";
+    case "error":
+      return "error";
+    default:
+      return "initializing";
+  }
+}
+
+export function useVideoCaptureFlow() {
+  const recorder = useVideoRecorder({ autoPrepare: true });
+  const [uploading, setUploading] = useState(false);
+  const [flowError, setFlowError] = useState<string | null>(null);
+  const [uploadResult, setUploadResult] = useState<Phase0FUploadResult | null>(null);
+
+  const effectiveError = flowError ?? recorder.error;
+
+  const flowPhase = useMemo(
+    () =>
+      mapRecorderStatusToFlowPhase(
+        recorder.status,
+        uploading,
+        uploadResult,
+        effectiveError,
+      ),
+    [recorder.status, uploading, uploadResult, effectiveError],
+  );
+
+  const resetFlow = useCallback(() => {
+    setFlowError(null);
+    setUploadResult(null);
+    setUploading(false);
+  }, []);
+
+  const retake = useCallback(async () => {
+    resetFlow();
+    await recorder.discardRecording();
+  }, [recorder, resetFlow]);
+
+  const uploadCapture = useCallback(
+    async (caption = DEFAULT_CAPTURE_CAPTION) => {
+      if (!recorder.blob) {
+        setFlowError("Recorded blob is missing");
+        return null;
+      }
+
+      setUploading(true);
+      setFlowError(null);
+      setUploadResult(null);
+
+      try {
+        const result = await runPhase0FUpload(recorder.blob, {
+          caption,
+          recorderMimeType: recorder.mimeType,
+          localPreviewUrl: recorder.previewUrl,
+        });
+
+        setUploadResult(result);
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Upload failed";
+        setFlowError(message);
+        return null;
+      } finally {
+        setUploading(false);
+      }
+    },
+    [recorder.blob, recorder.mimeType, recorder.previewUrl],
+  );
+
+  return {
+    ...recorder,
+    flowPhase,
+    flowError: effectiveError,
+    uploadResult,
+    uploading,
+    retake,
+    uploadCapture,
+    resetFlow,
+  };
+}

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -1,0 +1,281 @@
+"use client";
+
+import { MAX_RECORD_MS } from "@/lib/video/constants";
+import { pickRecorderMimeType, requestCameraStream } from "@/lib/video/recorderMime";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type RecorderStatus =
+  | "idle"
+  | "requesting"
+  | "ready"
+  | "recording"
+  | "preview"
+  | "error";
+
+export type UseVideoRecorderOptions = {
+  maxDurationMs?: number;
+  facingMode?: "user" | "environment";
+  /** Mount 시 카메라 권한 요청 (default: true) */
+  autoPrepare?: boolean;
+};
+
+export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
+  const maxDurationMs = options.maxDurationMs ?? MAX_RECORD_MS;
+  const autoPrepare = options.autoPrepare ?? true;
+
+  const [facingMode, setFacingMode] = useState<"user" | "environment">(
+    options.facingMode ?? "user",
+  );
+
+  const [status, setStatus] = useState<RecorderStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [blob, setBlob] = useState<Blob | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [mimeType, setMimeType] = useState<string | undefined>();
+  const [liveStream, setLiveStream] = useState<MediaStream | null>(null);
+
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const stopTimerRef = useRef<number | null>(null);
+  const tickTimerRef = useRef<number | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const autoPrepareStartedRef = useRef(false);
+
+  const clearTimers = useCallback(() => {
+    if (stopTimerRef.current !== null) {
+      window.clearTimeout(stopTimerRef.current);
+      stopTimerRef.current = null;
+    }
+
+    if (tickTimerRef.current !== null) {
+      window.clearInterval(tickTimerRef.current);
+      tickTimerRef.current = null;
+    }
+  }, []);
+
+  const stopStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+    setLiveStream(null);
+  }, []);
+
+  const resetPreview = useCallback(() => {
+    setPreviewUrl((current) => {
+      if (current) {
+        URL.revokeObjectURL(current);
+      }
+      return null;
+    });
+    setBlob(null);
+    setElapsedMs(0);
+  }, []);
+
+  const prepareCamera = useCallback(async () => {
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setError("카메라는 HTTPS 또는 localhost에서만 사용할 수 있습니다.");
+      setStatus("error");
+      return;
+    }
+
+    setError(null);
+    setStatus("requesting");
+
+    try {
+      stopStream();
+      resetPreview();
+
+      const stream = await requestCameraStream(facingMode);
+      streamRef.current = stream;
+      setLiveStream(stream);
+      setStatus("ready");
+    } catch (cause) {
+      stopStream();
+      const message =
+        cause instanceof Error
+          ? cause.message
+          : "Camera permission denied or unavailable";
+      setError(message);
+      setStatus("error");
+    }
+  }, [facingMode, resetPreview, stopStream]);
+
+  const stopRecording = useCallback(() => {
+    clearTimers();
+
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+  }, [clearTimers]);
+
+  const startRecording = useCallback(async () => {
+    setError(null);
+
+    if (!streamRef.current) {
+      await prepareCamera();
+    }
+
+    const stream = streamRef.current;
+    if (!stream) {
+      setError("Camera stream is not ready");
+      setStatus("error");
+      return;
+    }
+
+    const selectedMimeType = pickRecorderMimeType();
+    if (!selectedMimeType) {
+      setError("MediaRecorder is not supported in this browser");
+      setStatus("error");
+      return;
+    }
+
+    resetPreview();
+    chunksRef.current = [];
+
+    const recorder = new MediaRecorder(stream, { mimeType: selectedMimeType });
+    recorderRef.current = recorder;
+    setMimeType(selectedMimeType);
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        chunksRef.current.push(event.data);
+      }
+    };
+
+    recorder.onstop = () => {
+      clearTimers();
+
+      const recordedBlob = new Blob(chunksRef.current, { type: selectedMimeType });
+      const nextPreviewUrl = URL.createObjectURL(recordedBlob);
+
+      setBlob(recordedBlob);
+      setPreviewUrl(nextPreviewUrl);
+      setStatus("preview");
+      stopStream();
+    };
+
+    recorder.onerror = () => {
+      setError("Recording failed");
+      setStatus("error");
+    };
+
+    startedAtRef.current = Date.now();
+    setElapsedMs(0);
+    setStatus("recording");
+
+    recorder.start(250);
+
+    tickTimerRef.current = window.setInterval(() => {
+      setElapsedMs(Date.now() - startedAtRef.current);
+    }, 100);
+
+    stopTimerRef.current = window.setTimeout(() => {
+      stopRecording();
+    }, maxDurationMs);
+  }, [clearTimers, maxDurationMs, prepareCamera, resetPreview, stopRecording, stopStream]);
+
+  const discardRecording = useCallback(async () => {
+    clearTimers();
+    recorderRef.current = null;
+    resetPreview();
+    stopStream();
+    setError(null);
+    setStatus("idle");
+    await prepareCamera();
+  }, [clearTimers, prepareCamera, resetPreview, stopStream]);
+
+  const flipCamera = useCallback(async () => {
+    if (status === "recording") {
+      return;
+    }
+
+    const nextFacing = facingMode === "user" ? "environment" : "user";
+    setFacingMode(nextFacing);
+    setError(null);
+    setStatus("requesting");
+
+    try {
+      stopStream();
+      resetPreview();
+
+      const stream = await requestCameraStream(nextFacing);
+      streamRef.current = stream;
+      setLiveStream(stream);
+      setStatus("ready");
+    } catch (cause) {
+      stopStream();
+      const message =
+        cause instanceof Error ? cause.message : "Camera flip failed";
+      setError(message);
+      setStatus("error");
+    }
+  }, [facingMode, resetPreview, status, stopStream]);
+
+  useEffect(() => {
+    const node = videoRef.current;
+    if (!node) {
+      return;
+    }
+
+    if (liveStream && (status === "requesting" || status === "ready" || status === "recording")) {
+      node.src = "";
+      node.srcObject = liveStream;
+      node.muted = true;
+      void node.play().catch((playError) => {
+        const message =
+          playError instanceof Error ? playError.message : "Video preview failed";
+        setError(message);
+      });
+      return;
+    }
+
+    if (status === "preview" && previewUrl) {
+      node.srcObject = null;
+      node.src = previewUrl;
+      node.muted = false;
+      void node.play().catch(() => undefined);
+    }
+  }, [liveStream, previewUrl, status]);
+
+  useEffect(() => {
+    if (!autoPrepare || autoPrepareStartedRef.current) {
+      return;
+    }
+
+    autoPrepareStartedRef.current = true;
+    void prepareCamera();
+  }, [autoPrepare, prepareCamera]);
+
+  useEffect(() => {
+    return () => {
+      clearTimers();
+      stopStream();
+      setPreviewUrl((current) => {
+        if (current) {
+          URL.revokeObjectURL(current);
+        }
+        return null;
+      });
+    };
+  }, [clearTimers, stopStream]);
+
+  return {
+    videoRef,
+    status,
+    error,
+    elapsedMs,
+    maxDurationMs,
+    blob,
+    previewUrl,
+    mimeType,
+    facingMode,
+    prepareCamera,
+    startRecording,
+    stopRecording,
+    discardRecording,
+    flipCamera,
+  };
+}

--- a/lib/video/constants.ts
+++ b/lib/video/constants.ts
@@ -1,0 +1,19 @@
+/** plip-video backend contract: max 5 seconds */
+export const MAX_RECORD_MS = 5_000;
+
+export const RECORDER_MIME_CANDIDATES = [
+  "video/mp4",
+  "video/webm;codecs=vp9",
+  "video/webm",
+] as const;
+
+/** Presigned PUT Content-Type must match upload-url query param */
+export const DEFAULT_UPLOAD_CONTENT_TYPE = "video/mp4";
+
+export const DEFAULT_CAPTURE_CAPTION = "Phase 0-F capture";
+
+/**
+ * download-url 202 probe count.
+ * 로컬 NoOp에서는 PROCESSING만 반환하므로 1회로 endpoint 검증만 수행 (3회×3s 대기 제거).
+ */
+export const DOWNLOAD_URL_MAX_ATTEMPTS = 1;

--- a/lib/video/downloadUrlPoll.ts
+++ b/lib/video/downloadUrlPoll.ts
@@ -1,0 +1,48 @@
+import { getDownloadUrlAction } from "@/actions/videoActions";
+import { extractActionError } from "@/lib/video/actionPayload";
+import { DOWNLOAD_URL_MAX_ATTEMPTS } from "@/lib/video/constants";
+import type { VideoDownloadUrlActionData } from "@/types/video/action";
+
+export type DownloadUrlPollResult = {
+  data: VideoDownloadUrlActionData;
+  attempts: number;
+};
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+export async function pollDownloadUrl(
+  videoUuid: string,
+  maxAttempts = DOWNLOAD_URL_MAX_ATTEMPTS,
+): Promise<DownloadUrlPollResult> {
+  let lastResult: VideoDownloadUrlActionData | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const response = await getDownloadUrlAction(videoUuid);
+    const error = extractActionError(response);
+
+    if (error || !response.ok) {
+      throw new Error(error ?? "download-url failed");
+    }
+
+    lastResult = response.data;
+
+    if (response.data.status === "ready") {
+      return { data: response.data, attempts: attempt };
+    }
+
+    if (attempt < maxAttempts) {
+      const delayMs = Math.max(response.data.retryAfterSeconds, 1) * 1000;
+      await wait(delayMs);
+    }
+  }
+
+  if (!lastResult) {
+    throw new Error("download-url poll exhausted with no response");
+  }
+
+  return { data: lastResult, attempts: maxAttempts };
+}

--- a/lib/video/playback.ts
+++ b/lib/video/playback.ts
@@ -1,0 +1,44 @@
+export function isStubPlaybackUrl(url: string): boolean {
+  return url.includes("/stub-presigned-get/") || url.startsWith("/stub-media/");
+}
+
+export type PlaybackSource = {
+  kind: "local" | "remote" | "none";
+  url: string | null;
+  note: string | null;
+};
+
+export function resolvePlaybackSource(
+  localPreviewUrl: string | null | undefined,
+  rawPlaybackUrl: string | null | undefined,
+): PlaybackSource {
+  if (localPreviewUrl) {
+    return {
+      kind: "local",
+      url: localPreviewUrl,
+      note: "촬영 직후 로컬 preview (Phase 0-F 기본 재생)",
+    };
+  }
+
+  if (rawPlaybackUrl && !isStubPlaybackUrl(rawPlaybackUrl)) {
+    return {
+      kind: "remote",
+      url: rawPlaybackUrl,
+      note: null,
+    };
+  }
+
+  if (rawPlaybackUrl && isStubPlaybackUrl(rawPlaybackUrl)) {
+    return {
+      kind: "none",
+      url: null,
+      note: "로컬 NoOp stub URL — AWS 연동 후 rawPlaybackUrl 재생 가능",
+    };
+  }
+
+  return {
+    kind: "none",
+    url: null,
+    note: "재생 URL 없음",
+  };
+}

--- a/lib/video/putPresigned.ts
+++ b/lib/video/putPresigned.ts
@@ -1,0 +1,28 @@
+export function isStubPresignedPutUrl(uploadUrl: string): boolean {
+  return uploadUrl.includes("/stub-presigned-put/");
+}
+
+export type PresignedPutResult = "uploaded" | "skipped-stub";
+
+export async function putPresignedUpload(
+  uploadUrl: string,
+  blob: Blob,
+  contentType: string,
+): Promise<PresignedPutResult> {
+  if (isStubPresignedPutUrl(uploadUrl)) {
+    // NoOp S3: HeadObject stub succeeds without uploading the blob body.
+    return "skipped-stub";
+  }
+
+  const response = await fetch(uploadUrl, {
+    method: "PUT",
+    body: blob,
+    headers: { "Content-Type": contentType },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Presigned PUT failed (${response.status})`);
+  }
+
+  return "uploaded";
+}

--- a/lib/video/recorderMime.ts
+++ b/lib/video/recorderMime.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_UPLOAD_CONTENT_TYPE } from "@/lib/video/constants";
+
+export async function requestCameraStream(
+  facingMode: "user" | "environment" = "user",
+): Promise<MediaStream> {
+  const attempts: MediaStreamConstraints[] = [
+    { video: { facingMode }, audio: true },
+    { video: true, audio: true },
+  ];
+
+  let lastError: unknown;
+
+  for (const constraints of attempts) {
+    try {
+      return await navigator.mediaDevices.getUserMedia(constraints);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError instanceof DOMException) {
+    if (lastError.name === "NotAllowedError") {
+      throw new Error("카메라·마이크 권한이 거부되었습니다. 브라우저 설정에서 허용해 주세요.");
+    }
+
+    if (lastError.name === "NotFoundError") {
+      throw new Error("카메라 또는 마이크를 찾을 수 없습니다.");
+    }
+
+    throw new Error(lastError.message);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Camera unavailable");
+}
+
+export function pickRecorderMimeType(): string | undefined {
+  if (typeof MediaRecorder === "undefined") {
+    return undefined;
+  }
+
+  for (const mimeType of ["video/mp4", "video/webm;codecs=vp9", "video/webm"] as const) {
+    if (MediaRecorder.isTypeSupported(mimeType)) {
+      return mimeType;
+    }
+  }
+
+  return undefined;
+}
+
+/** Map recorder output to backend-allowed upload-url contentType */
+export function resolveUploadContentType(recorderMimeType?: string): string {
+  if (recorderMimeType?.toLowerCase().startsWith("video/quicktime")) {
+    return "video/quicktime";
+  }
+
+  return DEFAULT_UPLOAD_CONTENT_TYPE;
+}
+
+export function formatBlobSummary(blob: Blob): string {
+  const sizeKb = Math.round(blob.size / 1024);
+  return `${blob.type || "application/octet-stream"} · ${sizeKb} KB`;
+}

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -1,0 +1,83 @@
+import {
+  completeVideoAction,
+  getVideoAction,
+  issueUploadUrlAction,
+} from "@/actions/videoActions";
+import { extractActionError } from "@/lib/video/actionPayload";
+import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";
+import { resolvePlaybackSource, type PlaybackSource } from "@/lib/video/playback";
+import { putPresignedUpload } from "@/lib/video/putPresigned";
+import { resolveUploadContentType } from "@/lib/video/recorderMime";
+import type {
+  VideoCompleteActionData,
+  VideoDetailActionData,
+  VideoDownloadUrlActionData,
+} from "@/types/video/action";
+
+export type VideoUploadPipelineResult = {
+  videoUuid: string;
+  putResult: "uploaded" | "skipped-stub";
+  complete: VideoCompleteActionData;
+  detail: VideoDetailActionData;
+};
+
+export type Phase0FUploadResult = VideoUploadPipelineResult & {
+  download: VideoDownloadUrlActionData;
+  downloadPollAttempts: number;
+  playback: PlaybackSource;
+};
+
+export async function uploadRecordedVideo(
+  blob: Blob,
+  options?: { caption?: string; recorderMimeType?: string },
+): Promise<VideoUploadPipelineResult> {
+  const contentType = resolveUploadContentType(options?.recorderMimeType ?? blob.type);
+
+  const uploadUrlResult = await issueUploadUrlAction(contentType);
+  const uploadUrlError = extractActionError(uploadUrlResult);
+  if (uploadUrlError || !uploadUrlResult.ok) {
+    throw new Error(uploadUrlError ?? "upload-url failed");
+  }
+
+  const { videoUuid, uploadUrl } = uploadUrlResult.data;
+  const putResult = await putPresignedUpload(uploadUrl, blob, contentType);
+
+  const completeResult = await completeVideoAction(videoUuid, options?.caption);
+  const completeError = extractActionError(completeResult);
+  if (completeError || !completeResult.ok) {
+    throw new Error(completeError ?? "complete failed");
+  }
+
+  const detailResult = await getVideoAction(videoUuid);
+  const detailError = extractActionError(detailResult);
+  if (detailError || !detailResult.ok) {
+    throw new Error(detailError ?? "get video failed");
+  }
+
+  return {
+    videoUuid,
+    putResult,
+    complete: completeResult.data,
+    detail: detailResult.data,
+  };
+}
+
+/** Phase 0-F E2E: upload-url → PUT → complete → GET → download-url poll */
+export async function runPhase0FUpload(
+  blob: Blob,
+  options?: {
+    caption?: string;
+    recorderMimeType?: string;
+    localPreviewUrl?: string | null;
+  },
+): Promise<Phase0FUploadResult> {
+  const base = await uploadRecordedVideo(blob, options);
+  const poll = await pollDownloadUrl(base.videoUuid);
+
+  return {
+    ...base,
+    download: poll.data,
+    downloadPollAttempts: poll.attempts,
+    playback: resolvePlaybackSource(options?.localPreviewUrl, base.detail.rawPlaybackUrl),
+  };
+}


### PR DESCRIPTION
## 작업 내용

plip-video 백엔드(Phase 0)와 연동하는 **5초 브라우저 촬영 → Presigned 업로드 → complete → GET → download-url 검증** 플로우를 프론트에 추가했습니다.

user-app 본 UI(`/, /create`, `/azit/*`)는 수정하지 않고, `(capture)` route group의 **`/video`** 에서만 개발·검증할 수 있도록 분리했습니다. Step 1–3(PR #9–#12)에서 구축한 Server Actions·videoService 위에 촬영·업로드 클라이언트 레이어를 연결합니다.

로컬 NoOp S3 환경에서는 stub PUT skip 및 download-url 1회 probe로 불필요한 대기를 줄였습니다.

## 관련 이슈

Close #9 
Close #10 
Close #12 

## 변경 사항

### 1. `(capture)` /video 라우트 및 템플릿

- **파일:** `app/(capture)/layout.tsx`, `app/(capture)/video/page.tsx`, `components/templates/CaptureVideoTemplate.tsx`, `config/routes.ts`
- **설명:** route group `(capture)` → URL `/video`. `ROUTES.capture` 상수 추가.

```typescript
// config/routes.ts
capture: {
  video: "/video",
  videoApi: "/video-api",
},
```

### 2. MediaRecorder 5초 촬영 hook

- **파일:** `hooks/useVideoRecorder.ts`, `lib/video/constants.ts`, `lib/video/recorderMime.ts`
- **설명:** 최대 5초 촬영, 카메라 전환(user/environment), live preview, blob/mimeType 반환.

```typescript
// lib/video/constants.ts
export const MAX_RECORD_MS = 5_000;
export const DEFAULT_UPLOAD_CONTENT_TYPE = "video/mp4";
```

### 3. Phase 0-F 업로드 파이프라인

- **파일:** `lib/video/uploadPipeline.ts`, `lib/video/putPresigned.ts`, `lib/video/downloadUrlPoll.ts`, `lib/video/playback.ts`, `hooks/useVideoCaptureFlow.ts`
- **설명:** upload-url → PUT → complete → GET → download-url probe. `userUuid`는 Server Action에서 `DEV_USER_UUID`(`.env.local`) 사용.

```typescript
// lib/video/uploadPipeline.ts
export async function runPhase0FUpload(blob, options?) {
  const base = await uploadRecordedVideo(blob, options);
  const poll = await pollDownloadUrl(base.videoUuid);
  return { ...base, download: poll.data, playback: resolvePlaybackSource(...) };
}
```

### 4. 촬영 UI (capture lab)

- **파일:** `components/organisms/VideoCaptureSection.tsx`
- **설명:** 5초 촬영·재촬영·업로드·결과(videoUuid, overlayTime, download-url status) 표시.

### 5. video-api lab 링크 연동

- **파일:** `components/organisms/VideoApiLabSection.tsx`, `components/templates/index.ts`
- **설명:** `/video-api`에서 `ROUTES.capture.video`로 촬영 lab 링크. `CaptureVideoTemplate` export 추가.

### 6. 로컬 NoOp 성능 보완

- **파일:** `lib/video/putPresigned.ts`, `lib/video/constants.ts`
- **설명:** stub presigned PUT URL은 blob 업로드 skip (`skipped-stub`). download-url은 로컬에서 1회 probe.

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - plip-video `:8085` + `.env.local` (`VIDEO_API_BASE_URL`, `DEV_USER_UUID`)
  - `http://localhost:3000/video` — 5초 촬영 → 업로드 → complete 성공
  - `http://localhost:3000/video-api` — Actions lab ↔ `/video` 링크

## 머지 전 체크

- [x] base branch: **develop**
- [ ] CI Test workflow 통과