### PR TITLE
[#5] Feature: /create 촬영 화면 실카메라 연동

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6030,7 +6030,7 @@ button.plip-bottom-nav__item {
 
 .dl-camera__shutter {
   position: absolute;
-  bottom: 36px;
+  bottom: 20px;
   left: 50%;
   width: 84px;
   height: 84px;
@@ -6045,6 +6045,32 @@ button.plip-bottom-nav__item {
   inset: 10px;
   border-radius: 999px;
   background: #fff;
+  transition: inset 0.15s ease, background-color 0.15s ease;
+}
+
+.dl-camera__shutter.is-recording {
+  background: rgba(239, 68, 68, 0.38);
+}
+
+.dl-camera__shutter.is-recording .dl-camera__shutter-inner {
+  inset: 16px;
+  background: #ef4444;
+}
+
+.dl-camera__timer {
+  position: absolute;
+  bottom: 142px;
+  left: 50%;
+  z-index: 10;
+  transform: translateX(-50%);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  color: #fff;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.85);
+  pointer-events: none;
 }
 
 .dl-shorts-meta {

--- a/components/molecules/CaptureVideoFrame.tsx
+++ b/components/molecules/CaptureVideoFrame.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+type CaptureVideoFrameProps = {
+  children: ReactNode;
+  /** step 2 확인 화면 · /video lab */
+  variant?: "card" | "lab";
+  className?: string;
+};
+
+/** Recorded playback — step2 / lab 공통 9:16 프레임 */
+export function CaptureVideoFrame({
+  children,
+  variant = "card",
+  className = "",
+}: CaptureVideoFrameProps) {
+  const base =
+    variant === "lab"
+      ? "relative mx-auto w-full max-w-2xl aspect-[9/16] max-h-[420px] overflow-hidden rounded-lg border bg-black"
+      : "relative w-full aspect-[9/16] max-h-[min(72dvh,680px)] overflow-hidden rounded-2xl bg-black";
+
+  return <div className={`${base} ${className}`.trim()}>{children}</div>;
+}

--- a/components/organisms/CaptureCameraStage.tsx
+++ b/components/organisms/CaptureCameraStage.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { DailyIcon } from "@/components/atoms";
+import { AuthTopBar } from "@/components/molecules/AuthTopBar";
+import type { RecorderStatus } from "@/hooks/useVideoRecorder";
+import { formatRecordTimer } from "@/lib/video/formatRecordTimer";
+import type { RefCallback } from "react";
+
+type CaptureCameraStageProps = {
+  videoRef: RefCallback<HTMLVideoElement>;
+  status: RecorderStatus;
+  error: string | null;
+  elapsedMs: number;
+  maxDurationMs: number;
+  onBack: () => void;
+  onStartRecording: () => void;
+  onFlipCamera: () => void;
+};
+
+export function CaptureCameraStage({
+  videoRef,
+  status,
+  error,
+  elapsedMs,
+  maxDurationMs,
+  onBack,
+  onStartRecording,
+  onFlipCamera,
+}: CaptureCameraStageProps) {
+  const isRecording = status === "recording";
+  const isBusy = status === "requesting" || isRecording;
+  const showTimer = isRecording;
+
+  return (
+    <section className="dl-camera -mx-5 -mt-6" aria-label="카메라">
+      <video
+        ref={videoRef}
+        className="absolute inset-0 h-full w-full object-contain"
+        autoPlay
+        playsInline
+        muted
+      />
+
+      <div className="absolute inset-x-0 top-0 z-10">
+        <AuthTopBar title="" onBack={onBack} />
+      </div>
+
+      {error ? (
+        <p
+          className="absolute inset-x-4 top-20 z-10 rounded bg-red-600/90 px-3 py-2 text-center text-xs text-white"
+          role="alert"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {showTimer ? (
+        <p className="dl-camera__timer" aria-live="polite">
+          {formatRecordTimer(elapsedMs, maxDurationMs)}
+        </p>
+      ) : null}
+
+      <div className="absolute inset-x-6 bottom-8 z-10 flex items-center justify-between">
+        <button type="button" className="dl-icon-sq" aria-label="플래시" disabled={isBusy}>
+          <DailyIcon name="alert" size={20} />
+        </button>
+        <button
+          type="button"
+          className={`dl-camera__shutter${isRecording ? " is-recording" : ""}`}
+          aria-label={isRecording ? "촬영 중" : "촬영"}
+          disabled={status === "requesting"}
+          onClick={() => {
+            if (!isRecording) {
+              onStartRecording();
+            }
+          }}
+        >
+          <span className="dl-camera__shutter-inner" />
+        </button>
+        <button
+          type="button"
+          className="dl-icon-sq"
+          aria-label="전환"
+          disabled={isBusy}
+          onClick={() => void onFlipCamera()}
+        >
+          <DailyIcon name="camera" size={20} />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/organisms/UploadWizard.tsx
+++ b/components/organisms/UploadWizard.tsx
@@ -3,12 +3,14 @@
 import { DailyIcon, SubmitButton, TextLink } from "@/components/atoms";
 import { AuthField } from "@/components/molecules";
 import { AuthTopBar } from "@/components/molecules/AuthTopBar";
+import { CaptureVideoFrame } from "@/components/molecules/CaptureVideoFrame";
 import { DestinationToggle, type DestinationId } from "@/components/molecules/DestinationToggle";
 import { NoticeCard } from "@/components/molecules/NoticeCard";
 import { TopicChip } from "@/components/molecules/TopicChip";
+import { CaptureCameraStage } from "@/components/organisms/CaptureCameraStage";
 import { ROUTES } from "@/config/routes";
-import Image from "next/image";
-import { useState } from "react";
+import { useVideoRecorder } from "@/hooks/useVideoRecorder";
+import { useCallback, useState } from "react";
 
 const TOPICS = ["#7시_러닝_인증", "#아침_식단"] as const;
 
@@ -17,35 +19,67 @@ export function UploadWizard() {
   const [destination, setDestination] = useState<DestinationId>("azit");
   const [topic, setTopic] = useState<(typeof TOPICS)[number]>("#7시_러닝_인증");
 
+  const handleRecordingComplete = useCallback(() => {
+    setStep(2);
+  }, []);
+
+  const {
+    videoRef,
+    status,
+    error,
+    elapsedMs,
+    maxDurationMs,
+    previewUrl,
+    startRecording,
+    flipCamera,
+    discardRecording,
+  } = useVideoRecorder({
+    autoPrepare: true,
+    onRecordingComplete: handleRecordingComplete,
+  });
+
+  const handleRetake = () => {
+    void discardRecording();
+    setStep(1);
+  };
+
+  const handleBackToCapture = () => {
+    void discardRecording();
+    setStep(1);
+  };
+
   if (step === 1) {
     return (
-      <section className="dl-camera -mx-5 -mt-6" aria-label="카메라">
-        <Image src="/plip/figma/camera.png" alt="" fill className="object-cover" sizes="402px" />
-        <AuthTopBar title="" onBack={() => history.back()} />
-        <div className="absolute inset-x-6 bottom-8 flex items-center justify-between">
-          <button type="button" className="dl-icon-sq" aria-label="플래시">
-            <DailyIcon name="alert" size={20} />
-          </button>
-          <button type="button" className="dl-camera__shutter" aria-label="촬영" onClick={() => setStep(2)}>
-            <span className="dl-camera__shutter-inner" />
-          </button>
-          <button type="button" className="dl-icon-sq" aria-label="전환">
-            <DailyIcon name="camera" size={20} />
-          </button>
-        </div>
-      </section>
+      <CaptureCameraStage
+        videoRef={videoRef}
+        status={status}
+        error={error}
+        elapsedMs={elapsedMs}
+        maxDurationMs={maxDurationMs}
+        onBack={() => history.back()}
+        onStartRecording={() => void startRecording()}
+        onFlipCamera={() => void flipCamera()}
+      />
     );
   }
 
   if (step === 2) {
     return (
       <section className="flex w-full flex-col gap-3.5">
-        <AuthTopBar title="영상 확인" onBack={() => setStep(1)} />
-        <div className="relative h-[450px] overflow-hidden rounded-2xl">
-          <Image src="/plip/daily-loop/recent-video-1.png" alt="" fill className="object-cover" sizes="354px" />
-        </div>
+        <AuthTopBar title="영상 확인" onBack={handleBackToCapture} />
+        <CaptureVideoFrame variant="card">
+          <video
+            key={previewUrl ?? "preview-empty"}
+            ref={videoRef}
+            src={previewUrl ?? undefined}
+            className="h-full w-full object-contain"
+            autoPlay
+            playsInline
+            controls
+          />
+        </CaptureVideoFrame>
         <div className="grid grid-cols-2 gap-3">
-          <SubmitButton type="button" variant="outline" onClick={() => setStep(1)}>
+          <SubmitButton type="button" variant="outline" onClick={handleRetake}>
             다시 촬영
           </SubmitButton>
           <SubmitButton type="button" variant="brand" onClick={() => setStep(3)}>

--- a/components/organisms/VideoCaptureSection.tsx
+++ b/components/organisms/VideoCaptureSection.tsx
@@ -2,6 +2,7 @@
 
 import { ROUTES } from "@/config/routes";
 import { useVideoCaptureFlow } from "@/hooks/useVideoCaptureFlow";
+import { CaptureVideoFrame } from "@/components/molecules/CaptureVideoFrame";
 import { formatBlobSummary } from "@/lib/video/recorderMime";
 import Link from "next/link";
 
@@ -46,16 +47,16 @@ export function VideoCaptureSection() {
         </p>
       </header>
 
-      <div className="overflow-hidden rounded-lg border bg-black">
+      <CaptureVideoFrame variant="lab">
         <video
           ref={videoRef}
-          className="aspect-[9/16] max-h-[420px] w-full object-cover"
+          className="h-full w-full object-contain"
           autoPlay
           playsInline
           muted={flowPhase !== "complete"}
           controls={flowPhase === "preview" || flowPhase === "complete"}
         />
-      </div>
+      </CaptureVideoFrame>
 
       <div className="space-y-1 text-xs text-black/60">
         <p>phase: {flowPhase}</p>

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -1,8 +1,9 @@
 "use client";
 
-import { MAX_RECORD_MS } from "@/lib/video/constants";
+import { MAX_RECORD_MS, RECORD_STOP_MS, RECORD_TIMESLICE_MS } from "@/lib/video/constants";
 import { pickRecorderMimeType, requestCameraStream } from "@/lib/video/recorderMime";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { isIgnorablePlayError, safeVideoPlay } from "@/lib/video/safeVideoPlay";
+import { useCallback, useEffect, useRef, useState, type RefCallback } from "react";
 
 export type RecorderStatus =
   | "idle"
@@ -17,11 +18,34 @@ export type UseVideoRecorderOptions = {
   facingMode?: "user" | "environment";
   /** Mount 시 카메라 권한 요청 (default: true) */
   autoPrepare?: boolean;
+  /** MediaRecorder stop 후 preview blob 준비 시 */
+  onRecordingComplete?: () => void;
 };
+
+function attachLiveStream(node: HTMLVideoElement, stream: MediaStream) {
+  node.pause();
+  node.removeAttribute("src");
+  node.srcObject = stream;
+  node.muted = true;
+  safeVideoPlay(node);
+}
+
+function attachPreviewUrl(node: HTMLVideoElement, previewUrl: string) {
+  node.pause();
+  node.srcObject = null;
+  if (node.src !== previewUrl) {
+    node.src = previewUrl;
+  }
+  node.muted = false;
+  node.load();
+  safeVideoPlay(node);
+}
 
 export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   const maxDurationMs = options.maxDurationMs ?? MAX_RECORD_MS;
+  const recordStopMs = RECORD_STOP_MS;
   const autoPrepare = options.autoPrepare ?? true;
+  const onRecordingComplete = options.onRecordingComplete;
 
   const [facingMode, setFacingMode] = useState<"user" | "environment">(
     options.facingMode ?? "user",
@@ -43,6 +67,35 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   const startedAtRef = useRef<number>(0);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const autoPrepareStartedRef = useRef(false);
+
+  const syncVideoElement = useCallback(
+    (node: HTMLVideoElement | null) => {
+      videoRef.current = node;
+      if (!node) {
+        return;
+      }
+
+      if (
+        liveStream &&
+        (status === "requesting" || status === "ready" || status === "recording")
+      ) {
+        attachLiveStream(node, liveStream);
+        return;
+      }
+
+      if (status === "preview" && previewUrl) {
+        attachPreviewUrl(node, previewUrl);
+      }
+    },
+    [liveStream, previewUrl, status],
+  );
+
+  const bindVideoElement = useCallback<RefCallback<HTMLVideoElement>>(
+    (node) => {
+      syncVideoElement(node);
+    },
+    [syncVideoElement],
+  );
 
   const clearTimers = useCallback(() => {
     if (stopTimerRef.current !== null) {
@@ -148,13 +201,26 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     recorder.onstop = () => {
       clearTimers();
 
-      const recordedBlob = new Blob(chunksRef.current, { type: selectedMimeType });
+      const maxChunks = Math.ceil(maxDurationMs / RECORD_TIMESLICE_MS);
+      const trimmedChunks = chunksRef.current.slice(0, maxChunks);
+      const recordedBlob = new Blob(trimmedChunks, { type: selectedMimeType });
+
+      if (recordedBlob.size === 0) {
+        stopStream();
+        setError("녹화 데이터가 비어 있습니다. 다시 촬영해 주세요.");
+        setStatus("error");
+        void prepareCamera();
+        return;
+      }
+
       const nextPreviewUrl = URL.createObjectURL(recordedBlob);
 
+      stopStream();
+      setError(null);
       setBlob(recordedBlob);
       setPreviewUrl(nextPreviewUrl);
       setStatus("preview");
-      stopStream();
+      onRecordingComplete?.();
     };
 
     recorder.onerror = () => {
@@ -166,16 +232,29 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     setElapsedMs(0);
     setStatus("recording");
 
-    recorder.start(250);
+    recorder.start(RECORD_TIMESLICE_MS);
 
     tickTimerRef.current = window.setInterval(() => {
-      setElapsedMs(Date.now() - startedAtRef.current);
-    }, 100);
+      setElapsedMs(Math.min(Date.now() - startedAtRef.current, maxDurationMs));
+    }, 50);
 
     stopTimerRef.current = window.setTimeout(() => {
+      const activeRecorder = recorderRef.current;
+      if (activeRecorder && activeRecorder.state === "recording") {
+        activeRecorder.requestData();
+      }
       stopRecording();
-    }, maxDurationMs);
-  }, [clearTimers, maxDurationMs, prepareCamera, resetPreview, stopRecording, stopStream]);
+    }, recordStopMs);
+  }, [
+    clearTimers,
+    maxDurationMs,
+    onRecordingComplete,
+    prepareCamera,
+    recordStopMs,
+    resetPreview,
+    stopRecording,
+    stopStream,
+  ]);
 
   const discardRecording = useCallback(async () => {
     clearTimers();
@@ -209,36 +288,16 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       stopStream();
       const message =
         cause instanceof Error ? cause.message : "Camera flip failed";
-      setError(message);
+      if (!isIgnorablePlayError(cause)) {
+        setError(message);
+      }
       setStatus("error");
     }
   }, [facingMode, resetPreview, status, stopStream]);
 
   useEffect(() => {
-    const node = videoRef.current;
-    if (!node) {
-      return;
-    }
-
-    if (liveStream && (status === "requesting" || status === "ready" || status === "recording")) {
-      node.src = "";
-      node.srcObject = liveStream;
-      node.muted = true;
-      void node.play().catch((playError) => {
-        const message =
-          playError instanceof Error ? playError.message : "Video preview failed";
-        setError(message);
-      });
-      return;
-    }
-
-    if (status === "preview" && previewUrl) {
-      node.srcObject = null;
-      node.src = previewUrl;
-      node.muted = false;
-      void node.play().catch(() => undefined);
-    }
-  }, [liveStream, previewUrl, status]);
+    syncVideoElement(videoRef.current);
+  }, [syncVideoElement]);
 
   useEffect(() => {
     if (!autoPrepare || autoPrepareStartedRef.current) {
@@ -263,7 +322,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   }, [clearTimers, stopStream]);
 
   return {
-    videoRef,
+    videoRef: bindVideoElement,
     status,
     error,
     elapsedMs,

--- a/lib/video/constants.ts
+++ b/lib/video/constants.ts
@@ -1,5 +1,10 @@
-/** plip-video backend contract: max 5 seconds */
+/** plip-video backend contract: max 5 seconds (saved / displayed) */
 export const MAX_RECORD_MS = 5_000;
+
+/** MediaRecorder stop — 0.2s buffer so last frame isn't cut */
+export const RECORD_STOP_MS = 5_200;
+
+export const RECORD_TIMESLICE_MS = 250;
 
 export const RECORDER_MIME_CANDIDATES = [
   "video/mp4",

--- a/lib/video/formatRecordTimer.ts
+++ b/lib/video/formatRecordTimer.ts
@@ -1,0 +1,16 @@
+/** 촬영 타이머 표시 — `00.02.50/00.05.00` (분.초.1/100초) */
+export function formatRecordTimer(elapsedMs: number, maxMs: number): string {
+  const formatParts = (totalMs: number) => {
+    const clamped = Math.max(0, Math.min(totalMs, maxMs));
+    const totalCentis = Math.floor(clamped / 10);
+    const centis = totalCentis % 100;
+    const totalSeconds = Math.floor(totalCentis / 100);
+    const seconds = totalSeconds % 60;
+    const minutes = Math.floor(totalSeconds / 60);
+
+    const pad = (value: number) => String(value).padStart(2, "0");
+    return `${pad(minutes)}.${pad(seconds)}.${pad(centis)}`;
+  };
+
+  return `${formatParts(elapsedMs)}/${formatParts(maxMs)}`;
+}

--- a/lib/video/recorderMime.ts
+++ b/lib/video/recorderMime.ts
@@ -3,7 +3,16 @@ import { DEFAULT_UPLOAD_CONTENT_TYPE } from "@/lib/video/constants";
 export async function requestCameraStream(
   facingMode: "user" | "environment" = "user",
 ): Promise<MediaStream> {
+  const portraitVideo: MediaTrackConstraints = {
+    facingMode,
+    width: { ideal: 1080 },
+    height: { ideal: 1920 },
+    aspectRatio: { ideal: 9 / 16 },
+  };
+
   const attempts: MediaStreamConstraints[] = [
+    { video: portraitVideo, audio: true },
+    { video: { facingMode, aspectRatio: { ideal: 9 / 16 } }, audio: true },
     { video: { facingMode }, audio: true },
     { video: true, audio: true },
   ];

--- a/lib/video/safeVideoPlay.ts
+++ b/lib/video/safeVideoPlay.ts
@@ -1,0 +1,18 @@
+/** play() 중 src 변경 등으로 발생하는 AbortError는 무시 */
+export function safeVideoPlay(node: HTMLVideoElement): void {
+  void node.play().catch((playError) => {
+    if (playError instanceof DOMException && playError.name === "AbortError") {
+      return;
+    }
+
+    if (playError instanceof Error && playError.name === "AbortError") {
+      return;
+    }
+  });
+}
+
+export function isIgnorablePlayError(error: unknown): boolean {
+  return (
+    error instanceof DOMException && error.name === "AbortError"
+  ) || (error instanceof Error && error.name === "AbortError");
+}


### PR DESCRIPTION
## 작업 내용

Phase 0-F Step 8로 `/create` UploadWizard step 1~2에 실카메라·5초 녹화를 연동했습니다.  
기존 `dl-camera` UI shell(닫기·셔터·전환)은 유지하고, mock PNG를 live preview·촬영 blob preview로 교체했습니다.  
step 3~4 업로드 API 연동은 Step 9에서 진행하며, `/video` lab 회귀는 Step 7과 동일하게 확인했습니다.

## 관련 이슈

Close #5

## 변경 사항

### 1. CaptureCameraStage — /create step1 카메라 UI

- **파일:** `components/organisms/CaptureCameraStage.tsx` (new)
- **설명:** `dl-camera` 레이아웃 위에 live `<video>`, `AuthTopBar`(history.back), 셔터·전환·녹화 타이머 UI를 분리했습니다.

```tsx
// components/organisms/CaptureCameraStage.tsx
<section className="dl-camera -mx-5 -mt-6" aria-label="카메라">
  <video ref={videoRef} className="absolute inset-0 h-full w-full object-contain" ... />
  <div className="absolute inset-x-0 top-0 z-10">
    <AuthTopBar title="" onBack={onBack} />
  </div>
  {showTimer ? (
    <p className="dl-camera__timer">{formatRecordTimer(elapsedMs, maxDurationMs)}</p>
  ) : null}
  <button className={`dl-camera__shutter${isRecording ? " is-recording" : ""}`} ... />
</section>
```

### 2. UploadWizard step1~2 — useVideoRecorder wiring

- **파일:** `components/organisms/UploadWizard.tsx`
- **설명:** step1 mock 이미지 → `CaptureCameraStage`, 촬영 완료 시 step2 자동 전환. step2는 `CaptureVideoFrame` + `previewUrl`로 재생합니다. step3~4는 mock 유지.

```tsx
// components/organisms/UploadWizard.tsx
const handleRecordingComplete = useCallback(() => {
  setStep(2);
}, []);

const { videoRef, previewUrl, ... } = useVideoRecorder({
  autoPrepare: true,
  onRecordingComplete: handleRecordingComplete,
});

// step2
<CaptureVideoFrame variant="card">
  <video
    key={previewUrl ?? "preview-empty"}
    ref={videoRef}
    src={previewUrl ?? undefined}
    className="h-full w-full object-contain"
    controls
  />
</CaptureVideoFrame>
```

### 3. useVideoRecorder — 녹화·preview 안정화

- **파일:** `hooks/useVideoRecorder.ts`, `lib/video/constants.ts`, `lib/video/safeVideoPlay.ts`
- **설명:** timeslice 250ms 복원(0KB blob 방지), 5.2s stop 후 앞 5s chunk만 저장, callback ref로 step 전환 시 preview 재바인딩, `AbortError` 무시.

```typescript
// lib/video/constants.ts
export const MAX_RECORD_MS = 5_000;
export const RECORD_STOP_MS = 5_200;
export const RECORD_TIMESLICE_MS = 250;

// hooks/useVideoRecorder.ts
recorder.start(RECORD_TIMESLICE_MS);
const maxChunks = Math.ceil(maxDurationMs / RECORD_TIMESLICE_MS);
const recordedBlob = new Blob(chunksRef.current.slice(0, maxChunks), { type: selectedMimeType });
```

### 4. 공통 프레임·카메라 constraints·CSS

- **파일:** `components/molecules/CaptureVideoFrame.tsx` (new), `lib/video/recorderMime.ts`, `lib/video/formatRecordTimer.ts`, `app/globals.css`, `components/organisms/VideoCaptureSection.tsx`
- **설명:** step2·`/video` lab 9:16 프레임 통일, 카메라 9:16 constraints, 셔터 recording 스타일·타이머 위치 조정.

```typescript
// lib/video/recorderMime.ts
const portraitVideo: MediaTrackConstraints = {
  facingMode,
  width: { ideal: 1080 },
  height: { ideal: 1920 },
  aspectRatio: { ideal: 9 / 16 },
};
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] `/create` step1 — live 카메라, 5초 촬영, 타이머·셔터 recording UI
  - [x] `/create` step1 — 닫기 `history.back()`
  - [x] `/create` step2 — 촬영본 재생
  - [x] `/create` step2 — 다시 촬영 / 뒤로가기 후 재촬영
  - [x] `/video` lab 회귀 (Step 7 E2E, blob 0KB 없음)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과