### PR TITLE
[#18] Feature : 내 아지트 목록 API 연결

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,12 @@
+# = 앞뒤 공백 없이 작성. 활성 값만 주석 해제.
+# 이 값을 .env.local 파일에 복사해 사용합니다.
+
+# --- API_URL ---
+# README.MD 참고해 해당 환경변수를 사용합니다.
+# 통합 테스트용 develop 환경 gateway (기본)
+API_URL=http://192.168.10.144:8080
+# 로컬
+# API_URL=http://localhost:8080
+
+# --- Actor (JWT 연동 전, X-User-Uuid) ---
+DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/app/(agit)/agit/page.tsx
+++ b/app/(agit)/agit/page.tsx
@@ -1,5 +1,18 @@
 import { AgitListTemplate } from "@/components/templates";
+import { listMyAgits } from "@/services/agitService";
+import type { UiMyAgit } from "@/types/agit/ui";
 
-export default function AgitListPage() {
-  return <AgitListTemplate />;
+export default async function AgitListPage() {
+  let items: UiMyAgit[] = [];
+  let error: string | undefined;
+
+  try {
+    items = await listMyAgits();
+  } catch (caught) {
+    items = [];
+    error =
+      caught instanceof Error ? caught.message : "아지트 목록을 불러오지 못했습니다.";
+  }
+
+  return <AgitListTemplate items={items} error={error} />;
 }

--- a/components/organisms/AgitListSection.tsx
+++ b/components/organisms/AgitListSection.tsx
@@ -1,11 +1,14 @@
 import { DailyIcon, TextLink } from "@/components/atoms";
 import { AgitListRow } from "@/components/molecules/AgitListRow";
-import { AGIT_LIST } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiMyAgit } from "@/types/agit/ui";
 
-export function AgitListSection() {
-  const rooms = AGIT_LIST;
+type AgitListSectionProps = {
+  items: UiMyAgit[];
+  error?: string;
+};
 
+export function AgitListSection({ items, error }: AgitListSectionProps) {
   return (
     <section aria-label="내 아지트" className="flex flex-1 flex-col gap-4 px-6 pb-8 pt-3">
       <header className="dl-page-head">
@@ -17,15 +20,25 @@ export function AgitListSection() {
 
       <label className="dl-field">
         <span className="dl-field__label">내 아지트 검색</span>
-        <input className="dl-input" placeholder="제목 또는 프로필로 검색" />
+        <input
+          className="dl-input"
+          placeholder="제목 또는 프로필로 검색"
+          disabled
+        />
       </label>
 
+      {error ? (
+        <p className="m-0 text-[14px] text-[var(--dl-color-text-secondary)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+
       <p className="m-0 text-[16px] font-semibold text-[var(--dl-color-text-primary)]">
-        참여 중인 아지트  {rooms.length}
+        참여 중인 아지트  {items.length}
       </p>
       <div className="flex flex-col gap-2.5">
-        {rooms.map((room) => (
-          <AgitListRow key={room.id} id={room.id} name={room.name} />
+        {items.map((item) => (
+          <AgitListRow key={item.id} id={item.id} name={item.name} />
         ))}
       </div>
     </section>

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -9,11 +9,18 @@ import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiMyAgit } from "@/types/agit/ui";
 
-export function AgitListTemplate() {
+export function AgitListTemplate({
+  items,
+  error,
+}: {
+  items: UiMyAgit[];
+  error?: string;
+}) {
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
-      <AgitListSection />
+      <AgitListSection items={items} error={error} />
     </AppChromeTemplate>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -1,4 +1,7 @@
 export const API_ENDPOINTS = {
+  agit: {
+    me: "/api/v1/agits/me",
+  },
   video: {
     uploadUrl: "/api/videos/upload-url",
     complete: (videoUuid: string) => `/api/videos/${videoUuid}/complete` as const,

--- a/docs/video-local.env.example
+++ b/docs/video-local.env.example
@@ -1,3 +1,5 @@
 # Copy to project root as .env.local (gitignored)
+# = 앞뒤 공백 없이 작성
+API_URL=http://localhost:8080
 VIDEO_API_BASE_URL=http://localhost:8085
 DEV_USER_UUID=00000000-0000-4000-8000-000000000001

--- a/lib/api/actorHeaders.ts
+++ b/lib/api/actorHeaders.ts
@@ -1,0 +1,8 @@
+import { getDevUserUuid } from "@/lib/api/env";
+
+/** RSC/API 레이어 전용. JWT 연동 시 Gateway 추출 헤더로 교체한다. */
+export function getActorUserHeaders(): Record<string, string> {
+  return {
+    "X-User-Uuid": getDevUserUuid(),
+  };
+}

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -1,0 +1,13 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { apiFetch } from "@/lib/api/apiFetch";
+import { getActorUserHeaders } from "@/lib/api/actorHeaders";
+import { getApiUrl } from "@/lib/api/env";
+import type { ApiMyAgitItem } from "@/types/agit/api";
+
+export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
+  return apiFetch<ApiMyAgitItem[]>(API_ENDPOINTS.agit.me, {
+    method: "GET",
+    baseUrl: getApiUrl(),
+    headers: getActorUserHeaders(),
+  });
+}

--- a/lib/api/apiFetch.ts
+++ b/lib/api/apiFetch.ts
@@ -14,10 +14,16 @@ export class ApiError extends Error {
 type ApiFetchOptions = Omit<RequestInit, "body"> & {
   body?: unknown;
   searchParams?: Record<string, string | undefined>;
+  /** 생략 시 기존처럼 VIDEO_API_BASE_URL */
+  baseUrl?: string;
 };
 
-function buildUrl(path: string, searchParams?: Record<string, string | undefined>): string {
-  const base = getVideoApiBaseUrl().replace(/\/$/, "");
+function buildUrl(
+  path: string,
+  searchParams?: Record<string, string | undefined>,
+  baseUrl?: string,
+): string {
+  const base = (baseUrl ?? getVideoApiBaseUrl()).replace(/\/$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   const url = new URL(`${base}${normalizedPath}`);
 
@@ -33,10 +39,10 @@ function buildUrl(path: string, searchParams?: Record<string, string | undefined
 }
 
 export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
-  const { body, searchParams, headers, ...rest } = options;
+  const { body, searchParams, headers, baseUrl, ...rest } = options;
   const hasJsonBody = body !== undefined;
 
-  const response = await fetch(buildUrl(path, searchParams), {
+  const response = await fetch(buildUrl(path, searchParams, baseUrl), {
     ...rest,
     headers: {
       ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
@@ -70,10 +76,10 @@ export async function apiFetchWithStatus<T>(
   path: string,
   options: ApiFetchOptions = {},
 ): Promise<{ status: number; data: T }> {
-  const { body, searchParams, headers, ...rest } = options;
+  const { body, searchParams, headers, baseUrl, ...rest } = options;
   const hasJsonBody = body !== undefined;
 
-  const response = await fetch(buildUrl(path, searchParams), {
+  const response = await fetch(buildUrl(path, searchParams, baseUrl), {
     ...rest,
     headers: {
       ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),

--- a/lib/api/env.ts
+++ b/lib/api/env.ts
@@ -1,5 +1,10 @@
+const DEFAULT_API_URL = "http://localhost:8080";
 const DEFAULT_VIDEO_API_BASE_URL = "http://localhost:8085";
 const DEFAULT_DEV_USER_UUID = "00000000-0000-4000-8000-000000000001";
+
+export function getApiUrl(): string {
+  return process.env.API_URL?.trim() || DEFAULT_API_URL;
+}
 
 export function getVideoApiBaseUrl(): string {
   return process.env.VIDEO_API_BASE_URL?.trim() || DEFAULT_VIDEO_API_BASE_URL;

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -1,0 +1,15 @@
+import * as agitApi from "@/lib/api/agitApi";
+import type { ApiMyAgitItem } from "@/types/agit/api";
+import type { UiMyAgit } from "@/types/agit/ui";
+
+function mapMyAgit(item: ApiMyAgitItem): UiMyAgit {
+  return {
+    id: item.agitUuid,
+    name: item.agitName,
+  };
+}
+
+export async function listMyAgits(): Promise<UiMyAgit[]> {
+  const items = await agitApi.getMyAgits();
+  return items.map(mapMyAgit);
+}

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -1,0 +1,4 @@
+export type ApiMyAgitItem = {
+  agitUuid: string;
+  agitName: string;
+};

--- a/types/agit/ui.ts
+++ b/types/agit/ui.ts
@@ -1,5 +1,10 @@
 export type UiAgitVisibility = "public" | "private";
 
+export type UiMyAgit = {
+  id: string;
+  name: string;
+};
+
 export type UiAgit = {
   id: string;
   name: string;


### PR DESCRIPTION
## 작업 내용

내 아지트 화면(`/agit`)을 `GET /api/v1/agits/me`에 연결한다. 비디오 `apiFetch` 기본값(`VIDEO_API_BASE_URL`)은 유지하고, agit HTTP만 `API_URL`과 `X-User-Uuid`를 쓴다. 검색·생성·상세 API와 JWT는 범위 밖이며, 실패 시 목업 폴백 없이 빈 목록과 에러만 보여 준다.

## 관련 이슈

Close #18

## 변경 사항

### 1. 로컬 env 템플릿과 gitignore 예외

- **파일:** `.env.local.example`, `.gitignore`, `docs/video-local.env.example`
- **설명:** `.env*` ignore를 유지하되 `.env.local.example`은 커밋 가능하게 했다. 예시 값은 Gateway `API_URL`과 `DEV_USER_UUID`를 안내한다.

```gitignore
# env files (can opt-in for committing if needed)
.env*
!.env.local.example
```

### 2. API_URL과 apiFetch optional baseUrl

- **파일:** `lib/api/env.ts`, `lib/api/apiFetch.ts`
- **설명:** `getApiUrl()`을 추가하고 `apiFetch`에 `baseUrl`을 넣었다. 생략 시 기존처럼 비디오 URL을 쓴다.

```ts
export function getApiUrl(): string {
  return process.env.API_URL?.trim() || DEFAULT_API_URL;
}

const base = (baseUrl ?? getVideoApiBaseUrl()).replace(/\/$/, "");
```

### 3. 내 아지트 목록 API 계층

- **파일:** `config/api-endpoints.ts`, `types/agit/api.ts`, `types/agit/ui.ts`, `lib/api/actorHeaders.ts`, `lib/api/agitApi.ts`, `services/agitService.ts`
- **설명:** `agit.me` 경로, `ApiMyAgitItem` → `UiMyAgit` 매핑, actor는 서버 헬퍼에서 `X-User-Uuid`만 붙인다.

```ts
export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
  return apiFetch<ApiMyAgitItem[]>(API_ENDPOINTS.agit.me, {
    method: "GET",
    baseUrl: getApiUrl(),
    headers: getActorUserHeaders(),
  });
}
```

### 4. `/agit` RSC에서 목록 렌더

- **파일:** `app/(agit)/agit/page.tsx`, `components/templates/AgitTemplates.tsx`, `components/organisms/AgitListSection.tsx`
- **설명:** RSC에서 `listMyAgits()` 후 `items`를 넘긴다. 실패 시 빈 목록+에러, 검색 input은 disabled.

```tsx
export default async function AgitListPage() {
  let items: UiMyAgit[] = [];
  let error: string | undefined;
  try {
    items = await listMyAgits();
  } catch (caught) {
    items = [];
    error =
      caught instanceof Error ? caught.message : "아지트 목록을 불러오지 못했습니다.";
  }
  return <AgitListTemplate items={items} error={error} />;
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — `/agit`이 `GET /api/v1/agits/me` 결과를 보여 주는지, 실패 시 빈 목록+에러인지, 비디오 호출이 그대로인지

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
