### PR TITLE
Disable credential persistence in sync workflow

### DIFF
--- a/.github/workflows/sync-to-personal.yml
+++ b/.github/workflows/sync-to-personal.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Force Push to repoB
         env:


### PR DESCRIPTION
## 작업 내용

<!-- 무엇을 왜 바꿨는지 (2–4문장) -->
봇이 기본 토큰을 간섭해서 sync가 안 되는 것이라고 함
그래서 그거 막으려고 persist-credentials: false 추가
## 관련 이슈

Close #

## 변경 사항

<!-- 변경마다: 제목 → 파일 → 설명 → 코드 스니펫 -->

### 1. {변경 제목}

- **파일:** `path/to/file.ts`
- **설명:** …

```typescript
// path/to/file.ts
// 핵심 변경 코드 (10~30줄 이내)
```

### 2. {변경 제목}

- **파일:** …
- **설명:** …

```yaml
# 설정/워크플로 예시
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
