### PR TITLE
[#23] Feature : Gateway 포트 수정 및 개발용 로컬 로그인 연동

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,15 +3,17 @@
 
 # --- API_URL ---
 # README.MD 참고해 해당 환경변수를 사용합니다.
-# 통합 테스트용 develop 환경 gateway (기본)
+# 통합 테스트용 develop 환경 gateway (기본/권장)
 API_URL=http://192.168.10.144:8000
-# 로컬
-# API_URL=http://localhost:8000
+
+# 로컬 테스트용 (no gateway에서 임시 테스트용으로 사용하는 경우, 포트 번호와 서비스명은 변경해 사용하세요.)
+# API_URL=http://localhost:8000/api/agit
 
 # --- Actor (JWT 연동 전, X-User-Uuid) ---
 DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e
 
-# --- 통합 개발환경 로컬 로그인 ---
+# --- 통합 개발환경용 테스트 계정 로그인 ---
 # 현재 JWT 연동 전 개발용 Bearer + X-User-Uuid 사용
+# 통합 개발환경에 연결 시, 아래 주석을 해제하면 해당 계정으로 API 토큰을 자동 발급합니다.
 # DEV_LOGIN_EMAIL=dev-test@plip.local
 # DEV_LOGIN_PASSWORD=Test1234!

--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,8 @@ API_URL=http://192.168.10.144:8000
 
 # --- Actor (JWT 연동 전, X-User-Uuid) ---
 DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e
+
+# --- 통합 개발환경 로컬 로그인 ---
+# 현재 JWT 연동 전 개발용 Bearer + X-User-Uuid 사용
+# DEV_LOGIN_EMAIL=dev-test@plip.local
+# DEV_LOGIN_PASSWORD=Test1234!

--- a/.env.local.example
+++ b/.env.local.example
@@ -4,9 +4,9 @@
 # --- API_URL ---
 # README.MD 참고해 해당 환경변수를 사용합니다.
 # 통합 테스트용 develop 환경 gateway (기본)
-API_URL=http://192.168.10.144:8080
+API_URL=http://192.168.10.144:8000
 # 로컬
-# API_URL=http://localhost:8080
+# API_URL=http://localhost:8000
 
 # --- Actor (JWT 연동 전, X-User-Uuid) ---
 DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -1,6 +1,15 @@
+/** Gateway `/api/{serviceId}/**` + StripPrefix=2 */
+function gatewayPath(serviceId: string, servicePath: string): string {
+  const normalized = servicePath.startsWith("/") ? servicePath : `/${servicePath}`;
+  return `/api/${serviceId}${normalized}`;
+}
+
 export const API_ENDPOINTS = {
+  auth: {
+    loginLocal: gatewayPath("user", "/api/v1/auth/login/local"),
+  },
   agit: {
-    me: "/api/v1/agits/me",
+    me: gatewayPath("agit", "/api/v1/agits/me"),
   },
   video: {
     uploadUrl: "/api/videos/upload-url",

--- a/docs/video-local.env.example
+++ b/docs/video-local.env.example
@@ -1,5 +1,5 @@
 # Copy to project root as .env.local (gitignored)
 # = 앞뒤 공백 없이 작성
-API_URL=http://localhost:8080
+API_URL=http://localhost:8000
 VIDEO_API_BASE_URL=http://localhost:8085
 DEV_USER_UUID=00000000-0000-4000-8000-000000000001

--- a/lib/api/actorHeaders.ts
+++ b/lib/api/actorHeaders.ts
@@ -1,8 +1,16 @@
+import { getDevAccessToken } from "@/lib/api/devAccessToken";
 import { getDevUserUuid } from "@/lib/api/env";
 
-/** RSC/API 레이어 전용. JWT 연동 시 Gateway 추출 헤더로 교체한다. */
-export function getActorUserHeaders(): Record<string, string> {
-  return {
+/** RSC/API 레이어 전용. JWT 연동 전 개발용 Bearer + X-User-Uuid. */
+export async function getActorUserHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
     "X-User-Uuid": getDevUserUuid(),
   };
+
+  const token = await getDevAccessToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
 }

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -1,13 +1,26 @@
 import { API_ENDPOINTS } from "@/config/api-endpoints";
-import { apiFetch } from "@/lib/api/apiFetch";
 import { getActorUserHeaders } from "@/lib/api/actorHeaders";
+import { ApiError, apiFetch } from "@/lib/api/apiFetch";
+import { clearDevAccessToken } from "@/lib/api/devAccessToken";
 import { getApiUrl } from "@/lib/api/env";
 import type { ApiMyAgitItem } from "@/types/agit/api";
 
 export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
+  try {
+    return await requestMyAgits();
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 401) {
+      throw error;
+    }
+    clearDevAccessToken();
+    return requestMyAgits();
+  }
+}
+
+async function requestMyAgits(): Promise<ApiMyAgitItem[]> {
   return apiFetch<ApiMyAgitItem[]>(API_ENDPOINTS.agit.me, {
     method: "GET",
     baseUrl: getApiUrl(),
-    headers: getActorUserHeaders(),
+    headers: await getActorUserHeaders(),
   });
 }

--- a/lib/api/devAccessToken.ts
+++ b/lib/api/devAccessToken.ts
@@ -1,0 +1,58 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { ApiError, apiFetch } from "@/lib/api/apiFetch";
+import { getApiUrl, getDevLoginEmail, getDevLoginPassword } from "@/lib/api/env";
+
+type LocalLoginResponse = {
+  accessToken?: string;
+};
+
+let cachedAccessToken: string | undefined;
+let pendingLogin: Promise<string | undefined> | undefined;
+
+export function clearDevAccessToken(): void {
+  cachedAccessToken = undefined;
+  pendingLogin = undefined;
+}
+
+export async function getDevAccessToken(): Promise<string | undefined> {
+  if (cachedAccessToken) {
+    return cachedAccessToken;
+  }
+  if (pendingLogin) {
+    return pendingLogin;
+  }
+
+  const email = getDevLoginEmail();
+  const password = getDevLoginPassword();
+  if (!email || !password) {
+    return undefined;
+  }
+
+  pendingLogin = requestDevAccessToken(email, password).finally(() => {
+    pendingLogin = undefined;
+  });
+  return pendingLogin;
+}
+
+async function requestDevAccessToken(email: string, password: string): Promise<string | undefined> {
+  try {
+    const data = await apiFetch<LocalLoginResponse>(API_ENDPOINTS.auth.loginLocal, {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      body: { email, password },
+    });
+    const token = data.accessToken?.trim();
+    cachedAccessToken = token || undefined;
+    return cachedAccessToken;
+  } catch (error) {
+    cachedAccessToken = undefined;
+    if (error instanceof ApiError) {
+      throw new ApiError(
+        `개발용 로그인에 실패했습니다 (${error.status}): ${error.message}`,
+        error.status,
+        error.body,
+      );
+    }
+    throw error;
+  }
+}

--- a/lib/api/env.ts
+++ b/lib/api/env.ts
@@ -13,3 +13,13 @@ export function getVideoApiBaseUrl(): string {
 export function getDevUserUuid(): string {
   return process.env.DEV_USER_UUID?.trim() || DEFAULT_DEV_USER_UUID;
 }
+
+export function getDevLoginEmail(): string | undefined {
+  const email = process.env.DEV_LOGIN_EMAIL?.trim();
+  return email || undefined;
+}
+
+export function getDevLoginPassword(): string | undefined {
+  const password = process.env.DEV_LOGIN_PASSWORD?.trim();
+  return password || undefined;
+}

--- a/lib/api/env.ts
+++ b/lib/api/env.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = "http://localhost:8080";
+const DEFAULT_API_URL = "http://localhost:8000";
 const DEFAULT_VIDEO_API_BASE_URL = "http://localhost:8085";
 const DEFAULT_DEV_USER_UUID = "00000000-0000-4000-8000-000000000001";
 


### PR DESCRIPTION
## 작업 내용

Gateway 기본 포트를 `8080`에서 `8000`으로 맞춰 잘못된 API 호스트를 수정했습니다. JWT 연동 전 개발 환경에서는 `DEV_LOGIN_EMAIL` / `DEV_LOGIN_PASSWORD`로 로컬 로그인 후 Bearer 토큰을 캐시하고, 아지트 목록 요청에 `Authorization`과 `X-User-Uuid`를 함께 붙입니다. Gateway `StripPrefix=2`에 맞춰 서비스 경로를 `/api/{serviceId}/...`로 구성합니다.

## 관련 이슈

Close #23

## 변경 사항

### 1. Gateway 기본 포트 수정 (8080 → 8000)

- **파일:** `.env.local.example`, `docs/video-local.env.example`, `lib/api/env.ts`
- **설명:** 통합 Gateway 기본 포트를 `8000`으로 통일했습니다. 환경변수가 없을 때 쓰는 `DEFAULT_API_URL`도 동일하게 맞췄습니다.

```typescript
// lib/api/env.ts
const DEFAULT_API_URL = "http://localhost:8000";
```

### 2. Gateway StripPrefix 경로 헬퍼 및 로컬 로그인 엔드포인트

- **파일:** `config/api-endpoints.ts`
- **설명:** `/api/{serviceId}{servicePath}` 형태로 Gateway 경로를 만들고, 아지트 목록·로컬 로그인 경로에 적용했습니다.

```typescript
function gatewayPath(serviceId: string, servicePath: string): string {
  const normalized = servicePath.startsWith("/") ? servicePath : `/${servicePath}`;
  return `/api/${serviceId}${normalized}`;
}

export const API_ENDPOINTS = {
  auth: {
    loginLocal: gatewayPath("user", "/api/v1/auth/login/local"),
  },
  agit: {
    me: gatewayPath("agit", "/api/v1/agits/me"),
  },
```

### 3. 개발용 로컬 로그인 토큰 캐시

- **파일:** `lib/api/devAccessToken.ts`, `lib/api/env.ts`, `.env.local.example`
- **설명:** `DEV_LOGIN_EMAIL` / `DEV_LOGIN_PASSWORD`가 있으면 로컬 로그인으로 `accessToken`을 받아 메모리에 캐시합니다. 동시 요청은 하나의 pending Promise로 합칩니다.

```typescript
export async function getDevAccessToken(): Promise<string | undefined> {
  if (cachedAccessToken) {
    return cachedAccessToken;
  }
  if (pendingLogin) {
    return pendingLogin;
  }

  const email = getDevLoginEmail();
  const password = getDevLoginPassword();
  if (!email || !password) {
    return undefined;
  }

  pendingLogin = requestDevAccessToken(email, password).finally(() => {
    pendingLogin = undefined;
  });
  return pendingLogin;
}
```

### 4. Actor 헤더에 Bearer 토큰 추가

- **파일:** `lib/api/actorHeaders.ts`
- **설명:** `getActorUserHeaders`를 async로 바꾸고, 개발용 토큰이 있으면 `Authorization: Bearer`를 붙입니다.

```typescript
export async function getActorUserHeaders(): Promise<Record<string, string>> {
  const headers: Record<string, string> = {
    "X-User-Uuid": getDevUserUuid(),
  };

  const token = await getDevAccessToken();
  if (token) {
    headers.Authorization = `Bearer ${token}`;
  }

  return headers;
}
```

### 5. 아지트 목록 401 시 토큰 갱신 후 재요청

- **파일:** `lib/api/agitApi.ts`
- **설명:** `getMyAgits`가 401이면 캐시 토큰을 지우고 한 번 더 요청합니다.

```typescript
export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
  try {
    return await requestMyAgits();
  } catch (error) {
    if (!(error instanceof ApiError) || error.status !== 401) {
      throw error;
    }
    clearDevAccessToken();
    return requestMyAgits();
  }
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [ ] `.env.local`의 `API_URL`이 Gateway `8000`을 가리키는지 확인
  - [ ] `DEV_LOGIN_EMAIL` / `DEV_LOGIN_PASSWORD` 설정 후 내 아지트 목록이 정상 조회되는지 확인
  - [ ] 자격 증명이 없을 때 기존처럼 `X-User-Uuid`만으로 동작하는지 확인

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
