### PR TITLE
[#27] Feature : 아지트 상세 페이지 API 연동

### DIFF
--- a/app/(agit)/agit/[agitId]/page.tsx
+++ b/app/(agit)/agit/[agitId]/page.tsx
@@ -1,4 +1,7 @@
 import { AgitDetailTemplate } from "@/components/templates";
+import { ApiError } from "@/lib/api/apiFetch";
+import { getAgit } from "@/services/agitService";
+import type { UiAgit } from "@/types/agit/ui";
 
 type AgitDetailPageProps = {
   params: Promise<{ agitId: string }>;
@@ -6,5 +9,18 @@ type AgitDetailPageProps = {
 
 export default async function AgitDetailPage({ params }: AgitDetailPageProps) {
   const { agitId } = await params;
-  return <AgitDetailTemplate agitId={agitId} />;
+  let agit: UiAgit | null = null;
+  let error: string | undefined;
+
+  try {
+    agit = await getAgit(agitId);
+  } catch (caught) {
+    if (caught instanceof ApiError && (caught.status === 403 || caught.status === 404)) {
+      agit = null;
+    } else {
+      error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
+    }
+  }
+
+  return <AgitDetailTemplate agit={agit} error={error} />;
 }

--- a/components/organisms/AgitDetailSection.tsx
+++ b/components/organisms/AgitDetailSection.tsx
@@ -3,17 +3,28 @@
 import { DailyIcon, TextLink } from "@/components/atoms";
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { TopicViewerSection } from "@/components/organisms/TopicViewerSection";
-import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiAgit } from "@/types/agit/ui";
 import { useState } from "react";
 
 type AgitDetailSectionProps = {
-  agitId: string;
+  agit: UiAgit | null;
+  error?: string;
 };
 
-export function AgitDetailSection({ agitId }: AgitDetailSectionProps) {
-  const agit = getAgitById(agitId);
+export function AgitDetailSection({ agit, error }: AgitDetailSectionProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+
+  if (error) {
+    return (
+      <section className="px-6 py-8">
+        <p className="dl-subtitle">{error}</p>
+        <TextLink href={ROUTES.agit.root} className="dl-link">
+          목록으로
+        </TextLink>
+      </section>
+    );
+  }
 
   if (!agit) {
     return (
@@ -26,6 +37,14 @@ export function AgitDetailSection({ agitId }: AgitDetailSectionProps) {
     );
   }
 
+  const coverStyle = agit.thumbnailSrc
+    ? {
+        backgroundImage: `url(${agit.thumbnailSrc})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }
+    : { background: agit.coverGradient };
+
   return (
     <section aria-label="아지트 메인" className="relative flex flex-col gap-4 px-6 pb-8 pt-3">
       <header className="flex items-start justify-between gap-3">
@@ -37,8 +56,11 @@ export function AgitDetailSection({ agitId }: AgitDetailSectionProps) {
             {agit.name}
           </h1>
           <p className="mt-1 text-[12px] text-[var(--dl-color-text-secondary)]">
-            루틴 · {agit.memberCount}
-            {agit.maxMembers ? `/${agit.maxMembers}` : ""}명 · {agit.visibility === "private" ? "비공개" : "공개"}
+            {agit.memberCount}
+            {agit.maxMembers ? `/${agit.maxMembers}` : ""}명
+            {agit.visibility
+              ? ` · ${agit.visibility === "private" ? "비공개" : "공개"}`
+              : ""}
           </p>
         </div>
         <button type="button" className="dl-icon-sq" aria-label="아지트 메뉴" onClick={() => setMenuOpen(true)}>
@@ -46,11 +68,7 @@ export function AgitDetailSection({ agitId }: AgitDetailSectionProps) {
         </button>
       </header>
 
-      <div
-        className="h-[110px] overflow-hidden rounded-2xl"
-        style={{ background: agit.coverGradient }}
-        aria-hidden
-      />
+      <div className="h-[110px] overflow-hidden rounded-2xl" style={coverStyle} aria-hidden />
 
       <nav className="flex gap-2" aria-label="아지트 로컬 메뉴">
         {(

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -9,7 +9,7 @@ import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
-import type { UiMyAgit } from "@/types/agit/ui";
+import type { UiAgit, UiMyAgit } from "@/types/agit/ui";
 
 export function AgitListTemplate({
   items,
@@ -25,10 +25,16 @@ export function AgitListTemplate({
   );
 }
 
-export function AgitDetailTemplate({ agitId }: { agitId: string }) {
+export function AgitDetailTemplate({
+  agit,
+  error,
+}: {
+  agit: UiAgit | null;
+  error?: string;
+}) {
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
-      <AgitDetailSection agitId={agitId} />
+      <AgitDetailSection agit={agit} error={error} />
     </AppChromeTemplate>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -10,6 +10,7 @@ export const API_ENDPOINTS = {
   },
   agit: {
     me: gatewayPath("agit", "/api/v1/agits/me"),
+    detail: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}`),
   },
   video: {
     uploadUrl: "/api/videos/upload-url",

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -3,24 +3,36 @@ import { getActorUserHeaders } from "@/lib/api/actorHeaders";
 import { ApiError, apiFetch } from "@/lib/api/apiFetch";
 import { clearDevAccessToken } from "@/lib/api/devAccessToken";
 import { getApiUrl } from "@/lib/api/env";
-import type { ApiMyAgitItem } from "@/types/agit/api";
+import type { ApiAgitDetail, ApiMyAgitItem } from "@/types/agit/api";
 
 export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiMyAgitItem[]>(API_ENDPOINTS.agit.me, {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function getAgit(agitUuid: string): Promise<ApiAgitDetail> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiAgitDetail>(API_ENDPOINTS.agit.detail(agitUuid), {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
   try {
-    return await requestMyAgits();
+    return await request();
   } catch (error) {
     if (!(error instanceof ApiError) || error.status !== 401) {
       throw error;
     }
     clearDevAccessToken();
-    return requestMyAgits();
+    return request();
   }
-}
-
-async function requestMyAgits(): Promise<ApiMyAgitItem[]> {
-  return apiFetch<ApiMyAgitItem[]>(API_ENDPOINTS.agit.me, {
-    method: "GET",
-    baseUrl: getApiUrl(),
-    headers: await getActorUserHeaders(),
-  });
 }

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -1,6 +1,8 @@
 import * as agitApi from "@/lib/api/agitApi";
-import type { ApiMyAgitItem } from "@/types/agit/api";
-import type { UiMyAgit } from "@/types/agit/ui";
+import type { ApiAgitDetail, ApiMyAgitItem } from "@/types/agit/api";
+import type { UiAgit, UiMyAgit } from "@/types/agit/ui";
+
+const DEFAULT_COVER_GRADIENT = "linear-gradient(104deg, #2e1f52 0%, #7a5cfa 100%)";
 
 function mapMyAgit(item: ApiMyAgitItem): UiMyAgit {
   return {
@@ -9,7 +11,27 @@ function mapMyAgit(item: ApiMyAgitItem): UiMyAgit {
   };
 }
 
+function mapAgitDetail(item: ApiAgitDetail): UiAgit {
+  return {
+    id: item.agitUuid,
+    name: item.agitName,
+    memberCount: item.currentMemberCount,
+    description: item.description ?? "",
+    coverGradient: DEFAULT_COVER_GRADIENT,
+    topicCount: item.topics.length,
+    maxMembers: item.maximumCapacity,
+    ownerName: item.hostNickname,
+    thumbnailSrc: item.thumbnailPath ?? undefined,
+    joined: true,
+  };
+}
+
 export async function listMyAgits(): Promise<UiMyAgit[]> {
   const items = await agitApi.getMyAgits();
   return items.map(mapMyAgit);
+}
+
+export async function getAgit(agitId: string): Promise<UiAgit> {
+  const item = await agitApi.getAgit(agitId);
+  return mapAgitDetail(item);
 }

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -2,3 +2,33 @@ export type ApiMyAgitItem = {
   agitUuid: string;
   agitName: string;
 };
+
+export type ApiAgitMemberRole = "HOST" | "GUEST";
+
+export type ApiAgitStatus = "ACTIVE" | "DELETED";
+
+export type ApiAgitDetailMember = {
+  userUuid: string;
+  nickname: string;
+  profileImagePath: string | null;
+  role: ApiAgitMemberRole;
+};
+
+export type ApiAgitDetailTopic = {
+  topicId: string;
+  startedAt: string | null;
+};
+
+export type ApiAgitDetail = {
+  agitUuid: string;
+  agitName: string;
+  description: string | null;
+  thumbnailPath: string | null;
+  status: ApiAgitStatus;
+  maximumCapacity: number;
+  currentMemberCount: number;
+  hostNickname: string;
+  myRole: ApiAgitMemberRole;
+  members: ApiAgitDetailMember[];
+  topics: ApiAgitDetailTopic[];
+};


### PR DESCRIPTION
## 작업 내용

개별 아지트 허브 진입 시 `GET /api/v1/agits/{agitUuid}`를 한 번 호출해 방 이름·인원·방장·썸네일을 표시한다. Next 캐시는 쓰지 않고 기존 `apiFetch`의 `no-store`를 유지한다. 채팅·멤버·토픽 뷰어 등 하위 화면 mock은 이번 범위에 넣지 않았다.

## 관련 이슈

Close #27

## 변경 사항

### 1. 상세 조회 API 클라이언트

- **파일:** `config/api-endpoints.ts`, `types/agit/api.ts`, `lib/api/agitApi.ts`, `services/agitService.ts`
- **설명:** Gateway 경로와 DTO를 추가하고, 목록과 같은 401 재시도로 상세 GET을 호출한 뒤 `UiAgit`으로 매핑한다.

```typescript
export async function getAgit(agitUuid: string): Promise<ApiAgitDetail> {
  return withAuthRetry(async () =>
    apiFetch<ApiAgitDetail>(API_ENDPOINTS.agit.detail(agitUuid), {
      method: "GET",
      baseUrl: getApiUrl(),
      headers: await getActorUserHeaders(),
    }),
  );
}
```

### 2. 상세 허브 RSC 연동

- **파일:** `app/(agit)/agit/[agitId]/page.tsx`, `components/templates/AgitTemplates.tsx`, `components/organisms/AgitDetailSection.tsx`
- **설명:** 페이지에서 service를 호출해 props로 전달한다. 403/404는 없음 안내, 그 외는 오류 문구. 허브에서 mock `getAgitById`를 제거한다.

```typescript
try {
  agit = await getAgit(agitId);
} catch (caught) {
  if (caught instanceof ApiError && (caught.status === 403 || caught.status === 404)) {
    agit = null;
  } else {
    error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
  }
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — 목록에서 실 UUID로 상세 진입

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과