### PR TITLE
[#31] Feature : NextAuth JWT BFF 연동

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,11 +3,14 @@
 
 # --- API_URL ---
 # README.MD 참고해 해당 환경변수를 사용합니다.
-# 통합 테스트용 develop 환경 gateway (기본/권장)
-API_URL=http://192.168.10.144:8000
-
-# 로컬 테스트용 (no gateway에서 임시 테스트용으로 사용하는 경우, 포트 번호와 서비스명은 변경해 사용하세요.)
-# API_URL=http://localhost:8000/api/agit
+# baseUrl 끝에 /api/user 등 서비스 prefix를 붙이지 않습니다. 경로는 config/api-endpoints.ts에서 정의합니다.
+#
+# Gateway 경유 (develop 등, 기본/권장)
+# API_URL=http://192.168.10.144:8000
+#
+# 로컬 user-service 직접 호출 (Gateway 미사용)
+# 최종 URL 예: http://localhost:8080/api/v1/auth/login/social/naver
+API_URL=http://localhost:8080
 
 # --- Actor (JWT 연동 전, X-User-Uuid) ---
 DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e
@@ -16,3 +19,13 @@ DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e
 # 현재 JWT 연동 전 개발용 Bearer + X-User-Uuid 사용
 # DEV_LOGIN_EMAIL=dev-test@plip.local
 # DEV_LOGIN_PASSWORD=Test1234!
+
+# --- NextAuth ---
+AUTH_SECRET=
+AUTH_URL=http://localhost:3000
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+AUTH_KAKAO_ID=
+AUTH_KAKAO_SECRET=
+AUTH_NAVER_ID=
+AUTH_NAVER_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pnpm-workspace.yaml
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 /build

--- a/actions/authActions.ts
+++ b/actions/authActions.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { signOut } from "@/auth";
+import { ApiError } from "@/lib/api/apiFetch";
+import * as authService from "@/services/authService";
+import { getServerRefreshToken } from "@/lib/auth/server-token";
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import type { UiRestorePayload } from "@/types/auth/ui";
+
+function toActionError(error: unknown): ActionResult<never> {
+  if (error instanceof ApiError) {
+    return actionFailure(`[${error.status}] ${error.message}`);
+  }
+  if (error instanceof Error) {
+    return actionFailure(error.message);
+  }
+  return actionFailure("Unknown error");
+}
+
+export async function logoutAction(): Promise<ActionResult<void>> {
+  try {
+    const refreshToken = await getServerRefreshToken();
+    if (refreshToken) {
+      await authService.logout(refreshToken);
+    }
+    await signOut({ redirect: false });
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function restoreAccountAction(
+  payload: UiRestorePayload,
+): Promise<ActionResult<{ userUuid: string }>> {
+  try {
+    const tokens = await authService.restoreAccount(payload);
+    return actionSuccess({ userUuid: tokens.userUuid });
+  } catch (error) {
+    return toActionError(error);
+  }
+}

--- a/app/(auth)/signup/social-terms/page.tsx
+++ b/app/(auth)/signup/social-terms/page.tsx
@@ -1,0 +1,5 @@
+import { SocialSignupTermsTemplate } from "@/components/templates/SocialSignupTermsTemplate";
+
+export default function SocialSignupTermsPage() {
+  return <SocialSignupTermsTemplate />;
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Geist_Mono, Gothic_A1, Inter, Manrope, Montserrat, Poppins, Geist } from "next/font/google";
+import { AuthSessionProvider } from "@/components/providers/AuthSessionProvider";
 import { AppRouteShell } from "@/components/templates/AppRouteShell";
 import "./globals.css";
 import { cn } from "@/lib/utils";
@@ -57,7 +58,9 @@ export default function RootLayout({
       className={cn("h-full", "antialiased", poppins.variable, gothicA1.variable, montserrat.variable, manrope.variable, geistMono.variable, inter.variable, "font-sans", geist.variable)}
     >
       <body className="flex min-h-dvh flex-col">
-        <AppRouteShell>{children}</AppRouteShell>
+        <AuthSessionProvider>
+          <AppRouteShell>{children}</AppRouteShell>
+        </AuthSessionProvider>
       </body>
     </html>
   );

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,13 @@
+import type { NextAuthConfig } from "next-auth";
+
+export default {
+  providers: [],
+  pages: {
+    signIn: "/login",
+    error: "/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  trustHost: true,
+} satisfies NextAuthConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,215 @@
+import NextAuth, { CredentialsSignin } from "next-auth";
+import type { Provider } from "next-auth/providers";
+import Credentials from "next-auth/providers/credentials";
+import Google from "next-auth/providers/google";
+import Kakao from "next-auth/providers/kakao";
+import authConfig from "@/auth.config";
+import { ApiError } from "@/lib/api/apiFetch";
+import { AUTH_ERROR_CODES, getApiErrorCode } from "@/lib/auth/auth-errors";
+import * as authService from "@/services/authService";
+import type { JWT } from "next-auth/jwt";
+
+class PendingRestoreError extends CredentialsSignin {
+  code = AUTH_ERROR_CODES.PENDING_RESTORE;
+}
+
+const KakaoProvider = Kakao({
+  clientId: process.env.AUTH_KAKAO_ID,
+  clientSecret: process.env.AUTH_KAKAO_SECRET,
+  authorization: {
+    url: "https://kauth.kakao.com/oauth/authorize",
+    params: {
+      // account_email은 사업자 등록·동의항목 설정 필요 — 미설정 시 KOE205
+      scope: "profile_nickname",
+    },
+  },
+});
+
+const NaverProvider: Provider = {
+  id: "naver",
+  name: "Naver",
+  type: "oauth",
+  clientId: process.env.AUTH_NAVER_ID,
+  clientSecret: process.env.AUTH_NAVER_SECRET,
+  authorization: {
+    url: "https://nid.naver.com/oauth2.0/authorize",
+    params: { response_type: "code", auth_type: "reprompt" },
+  },
+  token: {
+    url: "https://nid.naver.com/oauth2.0/token",
+    params: { grant_type: "authorization_code" },
+  },
+  userinfo: {
+    url: "https://openapi.naver.com/v1/nid/me",
+    params: { response_type: "json" },
+  },
+  profile(profile) {
+    const record = profile as {
+      response?: { id?: string; email?: string; nickname?: string; name?: string };
+    };
+    return {
+      id: record.response?.id ?? "",
+      email: record.response?.email ?? null,
+      name: record.response?.nickname ?? record.response?.name ?? null,
+    };
+  },
+};
+
+const GUEST_ONLY_PREFIXES = ["/login", "/signup", "/forgot-password", "/reset-password"];
+const PROTECTED_PREFIXES = ["/home", "/diary", "/agit", "/mypage", "/shop", "/create", "/viewer"];
+
+function matchesPrefix(pathname: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+async function refreshAccessToken(token: JWT): Promise<JWT> {
+  if (!token.refreshToken) {
+    return { ...token, accessToken: undefined, refreshToken: undefined };
+  }
+
+  try {
+    const refreshed = await authService.reissueToken(String(token.refreshToken));
+    return {
+      ...token,
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      accessTokenExpiresAt: refreshed.accessTokenExpiresAt,
+    };
+  } catch {
+    return { ...token, accessToken: undefined, refreshToken: undefined };
+  }
+}
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  ...authConfig,
+  providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+    KakaoProvider,
+    NaverProvider,
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const email = credentials?.email;
+        const password = credentials?.password;
+        if (typeof email !== "string" || typeof password !== "string") {
+          return null;
+        }
+
+        try {
+          const result = await authService.loginLocal({ email, password });
+          return {
+            id: result.userUuid,
+            userUuid: result.userUuid,
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken,
+            accessTokenExpiresAt: result.accessTokenExpiresAt,
+          };
+        } catch (error) {
+          if (
+            error instanceof ApiError &&
+            getApiErrorCode(error.body) === AUTH_ERROR_CODES.PENDING_RESTORE
+          ) {
+            throw new PendingRestoreError();
+          }
+          return null;
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    authorized({ auth: session, request }) {
+      const pathname = request.nextUrl.pathname;
+      const isLoggedIn = !!session?.user;
+
+      if (matchesPrefix(pathname, GUEST_ONLY_PREFIXES) && isLoggedIn) {
+        return Response.redirect(new URL("/home", request.nextUrl));
+      }
+
+      if (matchesPrefix(pathname, PROTECTED_PREFIXES) && !isLoggedIn) {
+        return false;
+      }
+
+      return true;
+    },
+    async signIn({ account, user }) {
+      if (account?.provider === "credentials") {
+        return !!user?.accessToken;
+      }
+
+      const providerAccessToken = account?.access_token;
+      const provider = account?.provider;
+      if (!providerAccessToken || !provider) {
+        return `/login?error=OAuthCallback&provider=${provider ?? "unknown"}`;
+      }
+
+      try {
+        const result = await authService.loginSocial(provider, providerAccessToken);
+        user.id = result.userUuid;
+        user.userUuid = result.userUuid;
+        user.accessToken = result.accessToken;
+        user.refreshToken = result.refreshToken;
+        user.accessTokenExpiresAt = result.accessTokenExpiresAt;
+        return true;
+      } catch (error) {
+        if (error instanceof ApiError) {
+          const code = getApiErrorCode(error.body);
+          if (code === AUTH_ERROR_CODES.PENDING_RESTORE) {
+            return `/login?restore=pending&provider=${provider}`;
+          }
+          if (error.status === 422) {
+            return `/signup/social-terms?provider=${provider}`;
+          }
+          const message =
+            typeof error.body === "object" &&
+            error.body !== null &&
+            "message" in error.body &&
+            typeof error.body.message === "string"
+              ? encodeURIComponent(error.body.message)
+              : encodeURIComponent(error.message);
+          return `/login?error=social_backend&provider=${provider}&status=${error.status}&message=${message}`;
+        }
+        return `/login?error=social_backend&provider=${provider}`;
+      }
+    },
+    async jwt({ token, user, trigger, session }) {
+      if (user) {
+        token.accessToken = user.accessToken;
+        token.refreshToken = user.refreshToken;
+        token.accessTokenExpiresAt = user.accessTokenExpiresAt;
+        token.userUuid = user.userUuid ?? user.id;
+      }
+
+      if (trigger === "update" && session && typeof session === "object") {
+        const patch = session as {
+          accessToken?: string;
+          refreshToken?: string;
+          accessTokenExpiresAt?: number;
+          userUuid?: string;
+        };
+        if (patch.accessToken) token.accessToken = patch.accessToken;
+        if (patch.refreshToken) token.refreshToken = patch.refreshToken;
+        if (patch.accessTokenExpiresAt) token.accessTokenExpiresAt = patch.accessTokenExpiresAt;
+        if (patch.userUuid) token.userUuid = patch.userUuid;
+      }
+
+      const expiresAt = token.accessTokenExpiresAt;
+      if (typeof expiresAt === "number" && Date.now() < expiresAt - 60_000) {
+        return token;
+      }
+
+      return refreshAccessToken(token);
+    },
+    session({ session, token }) {
+      if (typeof token.userUuid === "string") {
+        session.user.id = token.userUuid;
+      }
+      return session;
+    },
+  },
+});

--- a/components/organisms/LoginForm.tsx
+++ b/components/organisms/LoginForm.tsx
@@ -1,42 +1,157 @@
+"use client";
+
 import { SubmitButton, TextLink } from "@/components/atoms";
 import { AuthDivider, AuthField } from "@/components/molecules";
+import { RestoreAccountDialog } from "@/components/organisms/RestoreAccountDialog";
 import { ROUTES } from "@/config/routes";
+import { AUTH_ERROR_CODES } from "@/lib/auth/auth-errors";
+import type { SocialProvider, UiRestorePayload } from "@/types/auth/ui";
+import { signIn } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+const SOCIAL_PROVIDERS: { id: SocialProvider; label: string }[] = [
+  { id: "kakao", label: "카카오로 계속" },
+  { id: "naver", label: "네이버로 계속" },
+  { id: "google", label: "Google로 계속" },
+];
+
+function resolveOAuthErrorMessage(searchParams: URLSearchParams): string | null {
+  const error = searchParams.get("error");
+  if (!error) return null;
+
+  if (error === "social_backend") {
+    const provider = searchParams.get("provider") ?? "소셜";
+    const status = searchParams.get("status");
+    const backendMessage = searchParams.get("message");
+    const decoded = backendMessage ? decodeURIComponent(backendMessage) : null;
+    const statusLabel = status ? ` (${status})` : "";
+    return (
+      decoded ??
+      `${provider} 로그인 API 연동 실패${statusLabel}. API_URL과 user-service 기동을 확인해 주세요.`
+    );
+  }
+
+  const messages: Record<string, string> = {
+    AccessDenied: "소셜 로그인이 거부되었습니다. OAuth 설정 또는 백엔드 연동을 확인해 주세요.",
+    Configuration: "OAuth Client ID/Secret 설정을 확인해 주세요.",
+    OAuthCallback: "OAuth 인증 중 오류가 발생했습니다. Redirect URI를 확인해 주세요.",
+    OAuthSignin: "OAuth 로그인을 시작하지 못했습니다. Client ID/Secret을 확인해 주세요.",
+    CallbackRouteError: "OAuth callback 처리 중 오류가 발생했습니다.",
+  };
+
+  return messages[error] ?? "로그인 중 오류가 발생했습니다.";
+}
 
 export function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlError = resolveOAuthErrorMessage(searchParams);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const error = submitError ?? urlError;
+  const [pending, setPending] = useState(false);
+  const [restoreOpen, setRestoreOpen] = useState(false);
+  const [restorePayload, setRestorePayload] = useState<UiRestorePayload | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitError(null);
+    setPending(true);
+
+    const form = new FormData(event.currentTarget);
+    const email = String(form.get("email") ?? "");
+    const password = String(form.get("password") ?? "");
+
+    const result = await signIn("credentials", {
+      email,
+      password,
+      redirect: false,
+    });
+
+    setPending(false);
+
+    if (result?.code === AUTH_ERROR_CODES.PENDING_RESTORE) {
+      setRestorePayload({ type: "local", email, password });
+      setRestoreOpen(true);
+      return;
+    }
+
+    if (result?.error) {
+      setSubmitError("이메일 또는 비밀번호를 확인해 주세요.");
+      return;
+    }
+
+    router.push(ROUTES.home);
+    router.refresh();
+  }
+
+  function handleSocial(provider: SocialProvider) {
+    setSubmitError(null);
+    void signIn(provider, { callbackUrl: ROUTES.home });
+  }
+
+  function handleRestoreCompleted() {
+    router.push(ROUTES.home);
+    router.refresh();
+  }
+
   return (
-    <form className="flex w-full flex-col gap-4" action={ROUTES.home} method="get">
-      <AuthField
-        id="login-email"
-        name="email"
-        type="email"
-        label="이메일"
-        placeholder="name@example.com"
-        autoComplete="email"
-        required
-      />
-      <AuthField
-        id="login-password"
-        name="password"
-        type="password"
-        label="비밀번호"
-        placeholder="••••••••"
-        autoComplete="current-password"
-        required
-      />
-      <TextLink href={ROUTES.forgotPassword} className="dl-link self-end text-right text-[12px] leading-[15px]">
-        비밀번호를 잊으셨나요?
-      </TextLink>
-      <SubmitButton variant="brand">로그인</SubmitButton>
-      <AuthDivider />
-      <SubmitButton type="button" variant="outline">
-        Google로 계속
-      </SubmitButton>
-      <p className="text-center text-[13px] font-medium leading-4 text-[var(--dl-color-text-brand)]">
-        계정이 없나요?{" "}
-        <TextLink href={ROUTES.signup} className="dl-link text-[13px]">
-          회원가입
+    <>
+      <form className="flex w-full flex-col gap-4" onSubmit={handleSubmit}>
+        <AuthField
+          id="login-email"
+          name="email"
+          type="email"
+          label="이메일"
+          placeholder="name@example.com"
+          autoComplete="email"
+          required
+        />
+        <AuthField
+          id="login-password"
+          name="password"
+          type="password"
+          label="비밀번호"
+          placeholder="••••••••"
+          autoComplete="current-password"
+          required
+        />
+        {error ? <p className="text-[12px] text-red-600">{error}</p> : null}
+        <TextLink
+          href={ROUTES.forgotPassword}
+          className="dl-link self-end text-right text-[12px] leading-[15px]"
+        >
+          비밀번호를 잊으셨나요?
         </TextLink>
-      </p>
-    </form>
+        <SubmitButton variant="brand" disabled={pending}>
+          로그인
+        </SubmitButton>
+        <AuthDivider />
+        {SOCIAL_PROVIDERS.map((provider) => (
+          <SubmitButton
+            key={provider.id}
+            type="button"
+            variant="outline"
+            disabled={pending}
+            onClick={() => handleSocial(provider.id)}
+          >
+            {provider.label}
+          </SubmitButton>
+        ))}
+        <p className="text-center text-[13px] font-medium leading-4 text-[var(--dl-color-text-brand)]">
+          계정이 없나요?{" "}
+          <TextLink href={ROUTES.signup} className="dl-link text-[13px]">
+            회원가입
+          </TextLink>
+        </p>
+      </form>
+
+      <RestoreAccountDialog
+        open={restoreOpen}
+        onOpenChange={setRestoreOpen}
+        payload={restorePayload}
+        onCompleted={handleRestoreCompleted}
+      />
+    </>
   );
 }

--- a/components/organisms/ProfileHubSection.tsx
+++ b/components/organisms/ProfileHubSection.tsx
@@ -1,14 +1,27 @@
 "use client";
 
+import { logoutAction } from "@/actions/authActions";
 import { SubmitButton, TextLink } from "@/components/atoms";
 import { DailyToggle } from "@/components/molecules/DailyToggle";
 import { SettingsRow } from "@/components/molecules/SettingsRow";
 import { ROUTES } from "@/config/routes";
+import { signOut } from "next-auth/react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 export function ProfileHubSection() {
+  const router = useRouter();
   const [notify, setNotify] = useState(true);
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  async function handleLogout() {
+    setLoggingOut(true);
+    await logoutAction();
+    await signOut({ redirect: false });
+    router.push(ROUTES.login);
+    router.refresh();
+  }
 
   return (
     <section className="flex w-full flex-col gap-3.5">
@@ -35,7 +48,9 @@ export function ProfileHubSection() {
       <SettingsRow href={ROUTES.shop.myItems} title="내 다운로드" description="저장한 내 영상 관리" />
       <SettingsRow href={ROUTES.mypage.settings} title="도움말·약관" description="신고·개인정보·서비스 정책" />
 
-      <SubmitButton variant="outline">로그아웃</SubmitButton>
+      <SubmitButton type="button" variant="outline" disabled={loggingOut} onClick={handleLogout}>
+        로그아웃
+      </SubmitButton>
       <TextLink href={ROUTES.mypage.settings} className="text-center text-[12px] text-[var(--dl-color-text-tertiary)]">
         계정 삭제
       </TextLink>

--- a/components/organisms/RestoreAccountDialog.tsx
+++ b/components/organisms/RestoreAccountDialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { restoreAccountAction } from "@/actions/authActions";
+import { SubmitButton } from "@/components/atoms";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { UiRestorePayload } from "@/types/auth/ui";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+
+type RestoreAccountDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  payload: UiRestorePayload | null;
+  onCompleted: () => void;
+};
+
+export function RestoreAccountDialog({
+  open,
+  onOpenChange,
+  payload,
+  onCompleted,
+}: RestoreAccountDialogProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function handleRestore() {
+    if (!payload) return;
+
+    setPending(true);
+    setError(null);
+
+    const result = await restoreAccountAction(payload);
+    if (!result.ok) {
+      setError(result.error);
+      setPending(false);
+      return;
+    }
+
+    if (payload.type === "local") {
+      const signInResult = await signIn("credentials", {
+        email: payload.email,
+        password: payload.password,
+        redirect: false,
+      });
+      if (signInResult?.error) {
+        setError("복구 후 로그인에 실패했습니다.");
+        setPending(false);
+        return;
+      }
+    }
+
+    setPending(false);
+    onOpenChange(false);
+    onCompleted();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={!pending} className="dl-panel border-[var(--dl-color-border-default)] bg-white">
+        <DialogHeader>
+          <DialogTitle className="dl-title text-base">탈퇴 유예 중인 계정</DialogTitle>
+          <DialogDescription className="dl-subtitle text-[13px]">
+            30일 유예 기간 중입니다. 계정을 복구하시겠습니까?
+          </DialogDescription>
+        </DialogHeader>
+        {error ? <p className="text-[12px] text-red-600">{error}</p> : null}
+        <DialogFooter className="border-0 bg-transparent p-0">
+          <SubmitButton
+            type="button"
+            variant="outline"
+            disabled={pending}
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </SubmitButton>
+          <SubmitButton type="button" variant="brand" disabled={pending || !payload} onClick={handleRestore}>
+            복구
+          </SubmitButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/providers/AuthSessionProvider.tsx
+++ b/components/providers/AuthSessionProvider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import type { ReactNode } from "react";
+
+type AuthSessionProviderProps = {
+  children: ReactNode;
+};
+
+export function AuthSessionProvider({ children }: AuthSessionProviderProps) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/components/templates/LoginTemplate.tsx
+++ b/components/templates/LoginTemplate.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { LoginForm } from "@/components/organisms";
 import { AuthTopBar } from "@/components/molecules/AuthTopBar";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
@@ -9,7 +10,9 @@ export function LoginTemplate() {
       <AuthTopBar title="" backHref={ROUTES.intro} />
       <h2 className="dl-title">다시 만나 반가워요</h2>
       <p className="dl-subtitle">PLIP에서 오늘의 5초를 이어가세요.</p>
-      <LoginForm />
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
     </DailyLoopAuthTemplate>
   );
 }

--- a/components/templates/SocialSignupTermsTemplate.tsx
+++ b/components/templates/SocialSignupTermsTemplate.tsx
@@ -1,0 +1,13 @@
+import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
+import { ROUTES } from "@/config/routes";
+import { AuthTopBar } from "@/components/molecules/AuthTopBar";
+
+export function SocialSignupTermsTemplate() {
+  return (
+    <DailyLoopAuthTemplate>
+      <AuthTopBar title="" backHref={ROUTES.login} />
+      <h2 className="dl-title">약관 동의</h2>
+      <p className="dl-subtitle">소셜 계정 가입을 위해 약관 동의가 필요합니다.</p>
+    </DailyLoopAuthTemplate>
+  );
+}

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -1,4 +1,4 @@
-/** Gateway `/api/{serviceId}/**` + StripPrefix=2 */
+/** Gateway `/api/{serviceId}/**` + StripPrefix=2 — Gateway 경유 시 auth/users에 적용 */
 function gatewayPath(serviceId: string, servicePath: string): string {
   const normalized = servicePath.startsWith("/") ? servicePath : `/${servicePath}`;
   return `/api/${serviceId}${normalized}`;
@@ -6,7 +6,21 @@ function gatewayPath(serviceId: string, servicePath: string): string {
 
 export const API_ENDPOINTS = {
   auth: {
-    loginLocal: gatewayPath("user", "/api/v1/auth/login/local"),
+    otpRequest: "/api/v1/auth/email/otp-request",
+    otpVerify: "/api/v1/auth/email/otp-verify",
+    signupLocal: "/api/v1/auth/signup/local",
+    loginLocal: "/api/v1/auth/login/local",
+    loginSocial: (provider: string) => `/api/v1/auth/login/social/${provider}` as const,
+    reissue: "/api/v1/auth/reissue",
+    logout: "/api/v1/auth/logout",
+    passwordReset: "/api/v1/auth/password-reset",
+  },
+  users: {
+    me: "/api/v1/users/me",
+    profile: "/api/v1/users/me/profile",
+    password: "/api/v1/users/me/password",
+    notificationSettings: "/api/v1/users/me/notification-settings",
+    restore: "/api/v1/users/me/restore",
   },
   agit: {
     me: gatewayPath("agit", "/api/v1/agits/me"),

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   login: "/login",
   signup: "/signup",
   signupProfile: "/signup/profile",
+  signupSocialTerms: "/signup/social-terms",
   forgotPassword: "/forgot-password",
   resetPassword: "/reset-password",
   create: "/create",

--- a/lib/api/actorHeaders.ts
+++ b/lib/api/actorHeaders.ts
@@ -1,15 +1,36 @@
 import { getDevAccessToken } from "@/lib/api/devAccessToken";
 import { getDevUserUuid } from "@/lib/api/env";
+import { getRequestAccessTokenOverride } from "@/lib/auth/request-token-cache";
+import { getServerAccessToken, getServerAuthJwt } from "@/lib/auth/server-token";
 
-/** RSC/API 레이어 전용. JWT 연동 전 개발용 Bearer + X-User-Uuid. */
+/** RSC/API 레이어 전용. NextAuth JWT 우선, 미로그인 dev 환경 fallback. */
 export async function getActorUserHeaders(): Promise<Record<string, string>> {
+  const override = getRequestAccessTokenOverride();
+  if (override) {
+    return {
+      Authorization: `Bearer ${override}`,
+    };
+  }
+
+  const accessToken = await getServerAccessToken();
+  if (accessToken) {
+    const jwt = await getServerAuthJwt();
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+    };
+    if (typeof jwt?.userUuid === "string" && jwt.userUuid) {
+      headers["X-User-Uuid"] = jwt.userUuid;
+    }
+    return headers;
+  }
+
   const headers: Record<string, string> = {
     "X-User-Uuid": getDevUserUuid(),
   };
 
-  const token = await getDevAccessToken();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+  const devToken = await getDevAccessToken();
+  if (devToken) {
+    headers.Authorization = `Bearer ${devToken}`;
   }
 
   return headers;

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -1,8 +1,8 @@
 import { API_ENDPOINTS } from "@/config/api-endpoints";
 import { getActorUserHeaders } from "@/lib/api/actorHeaders";
-import { ApiError, apiFetch } from "@/lib/api/apiFetch";
-import { clearDevAccessToken } from "@/lib/api/devAccessToken";
+import { apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl } from "@/lib/api/env";
+import { withAuthRetry } from "@/lib/api/withAuthRetry";
 import type { ApiAgitDetail, ApiMyAgitItem } from "@/types/agit/api";
 
 export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
@@ -23,16 +23,4 @@ export async function getAgit(agitUuid: string): Promise<ApiAgitDetail> {
       headers: await getActorUserHeaders(),
     }),
   );
-}
-
-async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
-  try {
-    return await request();
-  } catch (error) {
-    if (!(error instanceof ApiError) || error.status !== 401) {
-      throw error;
-    }
-    clearDevAccessToken();
-    return request();
-  }
 }

--- a/lib/api/authApi.ts
+++ b/lib/api/authApi.ts
@@ -1,0 +1,73 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { apiFetch } from "@/lib/api/apiFetch";
+import { getApiUrl } from "@/lib/api/env";
+import type {
+  ApiAccountRestoreRequest,
+  ApiAccountRestoreResponse,
+  ApiLocalLoginRequest,
+  ApiLocalLoginResponse,
+  ApiLogoutRequest,
+  ApiLogoutResponse,
+  ApiSocialLoginRequest,
+  ApiSocialLoginResponse,
+  ApiTokenReissueRequest,
+  ApiTokenReissueResponse,
+} from "@/types/auth/api";
+
+type AuthFetchOptions = {
+  bearerToken?: string;
+};
+
+function buildAuthHeaders(bearerToken?: string): Record<string, string> | undefined {
+  if (!bearerToken) {
+    return undefined;
+  }
+  return { Authorization: `Bearer ${bearerToken}` };
+}
+
+export async function postLoginLocal(body: ApiLocalLoginRequest): Promise<ApiLocalLoginResponse> {
+  return apiFetch<ApiLocalLoginResponse>(API_ENDPOINTS.auth.loginLocal, {
+    method: "POST",
+    baseUrl: getApiUrl(),
+    body,
+  });
+}
+
+export async function postLoginSocial(
+  provider: string,
+  body: ApiSocialLoginRequest,
+): Promise<ApiSocialLoginResponse> {
+  return apiFetch<ApiSocialLoginResponse>(API_ENDPOINTS.auth.loginSocial(provider), {
+    method: "POST",
+    baseUrl: getApiUrl(),
+    body,
+  });
+}
+
+export async function postReissue(body: ApiTokenReissueRequest): Promise<ApiTokenReissueResponse> {
+  return apiFetch<ApiTokenReissueResponse>(API_ENDPOINTS.auth.reissue, {
+    method: "POST",
+    baseUrl: getApiUrl(),
+    body,
+  });
+}
+
+export async function postLogout(body: ApiLogoutRequest): Promise<ApiLogoutResponse> {
+  return apiFetch<ApiLogoutResponse>(API_ENDPOINTS.auth.logout, {
+    method: "POST",
+    baseUrl: getApiUrl(),
+    body,
+  });
+}
+
+export async function postRestoreAccount(
+  body: ApiAccountRestoreRequest,
+  options: AuthFetchOptions = {},
+): Promise<ApiAccountRestoreResponse> {
+  return apiFetch<ApiAccountRestoreResponse>(API_ENDPOINTS.users.restore, {
+    method: "POST",
+    baseUrl: getApiUrl(),
+    body,
+    headers: buildAuthHeaders(options.bearerToken),
+  });
+}

--- a/lib/api/withAuthRetry.ts
+++ b/lib/api/withAuthRetry.ts
@@ -1,0 +1,41 @@
+import { ApiError } from "@/lib/api/apiFetch";
+import { clearDevAccessToken } from "@/lib/api/devAccessToken";
+import {
+  clearRequestAccessTokenOverride,
+  getRequestAccessTokenOverride,
+  setRequestAccessTokenOverride,
+} from "@/lib/auth/request-token-cache";
+import { getServerAuthJwt } from "@/lib/auth/server-token";
+import * as authService from "@/services/authService";
+
+export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 401) {
+      throw error;
+    }
+
+    clearDevAccessToken();
+
+    const override = getRequestAccessTokenOverride();
+    if (override) {
+      clearRequestAccessTokenOverride();
+      throw error;
+    }
+
+    const jwt = await getServerAuthJwt();
+    const refreshToken = jwt?.refreshToken;
+    if (typeof refreshToken !== "string" || !refreshToken) {
+      throw error;
+    }
+
+    try {
+      const refreshed = await authService.reissueToken(refreshToken);
+      setRequestAccessTokenOverride(refreshed.accessToken);
+      return await request();
+    } finally {
+      clearRequestAccessTokenOverride();
+    }
+  }
+}

--- a/lib/auth/auth-errors.ts
+++ b/lib/auth/auth-errors.ts
@@ -1,0 +1,11 @@
+export const AUTH_ERROR_CODES = {
+  PENDING_RESTORE: "AUTH_010",
+} as const;
+
+export function getApiErrorCode(body: unknown): string | undefined {
+  if (typeof body === "object" && body !== null && "code" in body) {
+    const code = (body as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}

--- a/lib/auth/request-token-cache.ts
+++ b/lib/auth/request-token-cache.ts
@@ -1,0 +1,14 @@
+/** 401 reissue 후 동일 요청 체인에서 Bearer 재시도용 (세션 쿠키 갱신 전) */
+let requestAccessTokenOverride: string | undefined;
+
+export function setRequestAccessTokenOverride(token: string | undefined): void {
+  requestAccessTokenOverride = token;
+}
+
+export function getRequestAccessTokenOverride(): string | undefined {
+  return requestAccessTokenOverride;
+}
+
+export function clearRequestAccessTokenOverride(): void {
+  requestAccessTokenOverride = undefined;
+}

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -1,0 +1,25 @@
+import { headers } from "next/headers";
+import { getToken } from "next-auth/jwt";
+
+export async function getServerAuthJwt() {
+  const headerStore = await headers();
+  const cookie = headerStore.get("cookie") ?? "";
+
+  return getToken({
+    req: { headers: { cookie } },
+    secret: process.env.AUTH_SECRET,
+    secureCookie: process.env.NODE_ENV === "production",
+  });
+}
+
+export async function getServerAccessToken(): Promise<string | undefined> {
+  const jwt = await getServerAuthJwt();
+  const token = jwt?.accessToken;
+  return typeof token === "string" && token.length > 0 ? token : undefined;
+}
+
+export async function getServerRefreshToken(): Promise<string | undefined> {
+  const jwt = await getServerAuthJwt();
+  const token = jwt?.refreshToken;
+  return typeof token === "string" && token.length > 0 ? token : undefined;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,5 @@
+export { auth as middleware } from "@/auth";
+
+export const config = {
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|plip|video|video-api).*)"],
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.31.0",
         "next": "16.3.0",
+        "next-auth": "^5.0.0-beta.32",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "shadcn": "^4.17.0",
@@ -43,6 +44,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
+      "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7 || ^8.0.5"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1956,6 +1986,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -7243,6 +7282,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.32.tgz",
+      "integrity": "sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7 || ^8.0.5",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
@@ -7325,6 +7391,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.7.tgz",
+      "integrity": "sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -7916,6 +7991,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.31.0",
     "next": "16.3.0",
+    "next-auth": "^5.0.0-beta.32",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "shadcn": "^4.17.0",

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -1,0 +1,60 @@
+import * as authApi from "@/lib/api/authApi";
+import type {
+  ApiLocalLoginRequest,
+  ApiTokenReissueResponse,
+  ApiTokenResponse,
+} from "@/types/auth/api";
+import type { UiAuthTokens, UiRestorePayload } from "@/types/auth/ui";
+
+function mapTokenResponse(data: ApiTokenResponse): UiAuthTokens {
+  return {
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+    accessTokenExpiresAt: Date.now() + data.accessTokenExpiresIn * 1000,
+    userUuid: data.userUuid,
+  };
+}
+
+function mapReissueResponse(data: ApiTokenReissueResponse): UiAuthTokens {
+  return {
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+    accessTokenExpiresAt: Date.now() + data.accessTokenExpiresIn * 1000,
+    userUuid: "",
+  };
+}
+
+export async function loginLocal(payload: ApiLocalLoginRequest): Promise<UiAuthTokens> {
+  const data = await authApi.postLoginLocal(payload);
+  return mapTokenResponse(data);
+}
+
+export async function loginSocial(provider: string, accessToken: string): Promise<UiAuthTokens> {
+  const data = await authApi.postLoginSocial(provider, { accessToken });
+  return mapTokenResponse(data);
+}
+
+export async function reissueToken(refreshToken: string): Promise<UiAuthTokens> {
+  const data = await authApi.postReissue({ refreshToken });
+  const mapped = mapReissueResponse(data);
+  return mapped;
+}
+
+export async function logout(refreshToken: string): Promise<void> {
+  await authApi.postLogout({ refreshToken });
+}
+
+export async function restoreAccount(payload: UiRestorePayload): Promise<UiAuthTokens> {
+  if (payload.type === "local") {
+    const data = await authApi.postRestoreAccount({
+      email: payload.email,
+      password: payload.password,
+    });
+    return mapTokenResponse(data);
+  }
+
+  const data = await authApi.postRestoreAccount({
+    accessToken: payload.accessToken,
+  });
+  return mapTokenResponse(data);
+}

--- a/types/auth/api.ts
+++ b/types/auth/api.ts
@@ -1,0 +1,62 @@
+export type ApiErrorBody = {
+  code?: string;
+  message?: string;
+};
+
+export type ApiLocalLoginRequest = {
+  email: string;
+  password: string;
+};
+
+export type ApiTokenResponse = {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+  userUuid: string;
+};
+
+export type ApiLocalLoginResponse = ApiTokenResponse;
+
+export type ApiSocialLoginRequest = {
+  accessToken: string;
+  termsAgreements?: ApiTermAgreement[];
+};
+
+export type ApiTermAgreement = {
+  termId: number;
+  agreed: boolean;
+};
+
+export type ApiSocialLoginResponse = ApiTokenResponse & {
+  newUser?: boolean;
+};
+
+export type ApiTokenReissueRequest = {
+  refreshToken: string;
+};
+
+export type ApiTokenReissueResponse = {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+};
+
+export type ApiLogoutRequest = {
+  refreshToken: string;
+};
+
+export type ApiLogoutResponse = {
+  code?: string;
+  message?: string;
+};
+
+export type ApiAccountRestoreRequest = {
+  email?: string;
+  password?: string;
+  accessToken?: string;
+};
+
+export type ApiAccountRestoreResponse = ApiTokenResponse & {
+  code?: string;
+  message?: string;
+};

--- a/types/auth/next-auth.d.ts
+++ b/types/auth/next-auth.d.ts
@@ -1,0 +1,25 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: DefaultSession["user"] & {
+      id: string;
+    };
+  }
+
+  interface User {
+    accessToken?: string;
+    refreshToken?: string;
+    accessTokenExpiresAt?: number;
+    userUuid?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string;
+    refreshToken?: string;
+    accessTokenExpiresAt?: number;
+    userUuid?: string;
+  }
+}

--- a/types/auth/ui.ts
+++ b/types/auth/ui.ts
@@ -1,0 +1,27 @@
+export type SocialProvider = "google" | "kakao" | "naver";
+
+export type UiAuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: number;
+  userUuid: string;
+};
+
+export type UiLoginCredentials = {
+  email: string;
+  password: string;
+};
+
+export type UiRestoreLocalPayload = {
+  type: "local";
+  email: string;
+  password: string;
+};
+
+export type UiRestoreSocialPayload = {
+  type: "social";
+  provider: SocialProvider;
+  accessToken: string;
+};
+
+export type UiRestorePayload = UiRestoreLocalPayload | UiRestoreSocialPayload;


### PR DESCRIPTION
## 작업 내용

NextAuth v5 BFF와 user-service JWT를 연동했습니다. Google/Kakao/Naver OAuth 및 로컬 로그인, 토큰 재발급(RTR), 로그아웃, Next.js route guard를 구현했고, API 호출 시 Bearer를 부착합니다.

Gateway JWT filter 전제 하에 NextAuth는 OAuth UX와 토큰 보관(BFF)만 담당하며, 소셜 신규 약관 flow는 placeholder로 두었습니다.

## 변경 사항

### 1. NextAuth 설정 및 OAuth Provider

- **파일:** `auth.ts`, `auth.config.ts`, `app/api/auth/[...nextauth]/route.ts`, `middleware.ts`
- **설명:** Google/Kakao/Naver/Credentials provider, JWT 세션에 access/refresh token 보관, 소셜 `signIn` 콜백에서 `login/social` BFF 연동, 백엔드/ OAuth 오류 시 `/login` redirect

```typescript
// auth.ts
async signIn({ account, user }) {
  const result = await authService.loginSocial(provider, providerAccessToken);
  user.accessToken = result.accessToken;
  user.refreshToken = result.refreshToken;
  user.userUuid = result.userUuid;
  return true;
}
```

### 2. Auth 3-Layer

- **파일:** `types/auth/*`, `config/api-endpoints.ts`, `lib/api/authApi.ts`, `services/authService.ts`, `actions/authActions.ts`, `lib/auth/*`
- **설명:** user-service auth API(`/api/v1/...`) 경로 정의, login/reissue/logout/restore 호출 계층

```typescript
// config/api-endpoints.ts
loginSocial: (provider) => `/api/v1/auth/login/social/${provider}`,
reissue: "/api/v1/auth/reissue",
logout: "/api/v1/auth/logout",
```

### 3. Route Guard 및 API Bearer 부착

- **파일:** `middleware.ts`, `lib/api/actorHeaders.ts`, `lib/api/withAuthRetry.ts`, `lib/api/agitApi.ts`
- **설명:** Next.js middleware로 게스트/보호 라우트 가드, 세션 JWT에서 Bearer 추출, agit API 401 시 reissue 후 1회 재시도

```typescript
// lib/api/actorHeaders.ts
const accessToken = await getServerAccessToken();
if (accessToken) {
  return { Authorization: `Bearer ${accessToken}` };
}
```

### 4. 로그인 UI 및 SessionProvider

- **파일:** `components/organisms/LoginForm.tsx`, `components/organisms/ProfileHubSection.tsx`, `components/organisms/RestoreAccountDialog.tsx`, `components/providers/AuthSessionProvider.tsx`, `app/layout.tsx`
- **설명:** 로컬/소셜 로그인, OAuth·백엔드 오류 메시지, 마이페이지 로그아웃, AUTH_010 복구 다이얼로그 shell

### 5. 환경 변수 예시

- **파일:** `.env.local.example`
- **설명:** `AUTH_SECRET`, `AUTH_URL`, OAuth Client ID/Secret, `API_URL` 가이드 추가

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] 로컬 로그인 → `/home`
  - [x] 미로그인 `/home`·`/mypage` 차단
  - [x] 로그인 상태 `/login` → `/home` redirect
  - [x] 로그아웃 → `/login`
  - [x] 소셜 로그인 1종 → `/home`

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인