### PR TITLE
[#33] Fix : 게이트웨이 user-service auth/users API 경로 수정

### DIFF
--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -6,21 +6,22 @@ function gatewayPath(serviceId: string, servicePath: string): string {
 
 export const API_ENDPOINTS = {
   auth: {
-    otpRequest: "/api/v1/auth/email/otp-request",
-    otpVerify: "/api/v1/auth/email/otp-verify",
-    signupLocal: "/api/v1/auth/signup/local",
-    loginLocal: "/api/v1/auth/login/local",
-    loginSocial: (provider: string) => `/api/v1/auth/login/social/${provider}` as const,
-    reissue: "/api/v1/auth/reissue",
-    logout: "/api/v1/auth/logout",
-    passwordReset: "/api/v1/auth/password-reset",
+    otpRequest: gatewayPath("user", "/api/v1/auth/email/otp-request"),
+    otpVerify: gatewayPath("user", "/api/v1/auth/email/otp-verify"),
+    signupLocal: gatewayPath("user", "/api/v1/auth/signup/local"),
+    loginLocal: gatewayPath("user", "/api/v1/auth/login/local"),
+    loginSocial: (provider: string) =>
+      gatewayPath("user", `/api/v1/auth/login/social/${provider}`),
+    reissue: gatewayPath("user", "/api/v1/auth/reissue"),
+    logout: gatewayPath("user", "/api/v1/auth/logout"),
+    passwordReset: gatewayPath("user", "/api/v1/auth/password-reset"),
   },
   users: {
-    me: "/api/v1/users/me",
-    profile: "/api/v1/users/me/profile",
-    password: "/api/v1/users/me/password",
-    notificationSettings: "/api/v1/users/me/notification-settings",
-    restore: "/api/v1/users/me/restore",
+    me: gatewayPath("user", "/api/v1/users/me"),
+    profile: gatewayPath("user", "/api/v1/users/me/profile"),
+    password: gatewayPath("user", "/api/v1/users/me/password"),
+    notificationSettings: gatewayPath("user", "/api/v1/users/me/notification-settings"),
+    restore: gatewayPath("user", "/api/v1/users/me/restore"),
   },
   agit: {
     me: gatewayPath("agit", "/api/v1/agits/me"),


### PR DESCRIPTION
## 작업 내용

게이트웨이 환경에서 일반·소셜 로그인이 `/api/v1/auth/...`로 나가 401이 났습니다. agit와 같이 `gatewayPath("user", ...)`를 붙여 `/api/user/api/v1/...`로 호출하도록 바꿨습니다. `API_URL`에는 서비스 prefix를 넣지 않습니다.

## 관련 이슈

Close #33

## 변경 사항

### 1. auth/users 엔드포인트에 게이트웨이 user prefix 적용

- **파일:** `config/api-endpoints.ts`
- **설명:** auth·users 경로를 `gatewayPath("user", ...)`로 통일해 게이트웨이 `/api/user/**` 라우트로 보냅니다. 로그인, 소셜 로그인, 재발급, 로그아웃, 계정 복구가 포함됩니다.

```typescript
export const API_ENDPOINTS = {
  auth: {
    otpRequest: gatewayPath("user", "/api/v1/auth/email/otp-request"),
    otpVerify: gatewayPath("user", "/api/v1/auth/email/otp-verify"),
    signupLocal: gatewayPath("user", "/api/v1/auth/signup/local"),
    loginLocal: gatewayPath("user", "/api/v1/auth/login/local"),
    loginSocial: (provider: string) =>
      gatewayPath("user", `/api/v1/auth/login/social/${provider}`),
    reissue: gatewayPath("user", "/api/v1/auth/reissue"),
    logout: gatewayPath("user", "/api/v1/auth/logout"),
    passwordReset: gatewayPath("user", "/api/v1/auth/password-reset"),
  },
  users: {
    me: gatewayPath("user", "/api/v1/users/me"),
    restore: gatewayPath("user", "/api/v1/users/me/restore"),
    // ...
  },
};
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — 게이트웨이 `API_URL`에서 로그인 경로 `/api/user/api/v1/auth/login/local` 확인

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인