### PR TITLE
Feature: 로그인 세션을 boolean으로 분리하고 API에 액세스 토큰을 붙인다

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Geist_Mono, Gothic_A1, Inter, Manrope, Montserrat, Poppins, Geist } from "next/font/google";
+import { auth } from "@/auth";
 import { AuthSessionProvider } from "@/components/providers/AuthSessionProvider";
 import { AppRouteShell } from "@/components/templates/AppRouteShell";
 import "./globals.css";
@@ -47,18 +48,20 @@ export const metadata: Metadata = {
   description: "PLIP — Personal Clip",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
+  const session = await auth();
+
   return (
     <html
       lang="ko"
       className={cn("h-full", "antialiased", poppins.variable, gothicA1.variable, montserrat.variable, manrope.variable, geistMono.variable, inter.variable, "font-sans", geist.variable)}
     >
       <body className="flex min-h-dvh flex-col">
-        <AuthSessionProvider>
+        <AuthSessionProvider isLoggedIn={session?.isLoggedIn === true}>
           <AppRouteShell>{children}</AppRouteShell>
         </AuthSessionProvider>
       </body>

--- a/auth.ts
+++ b/auth.ts
@@ -1,16 +1,22 @@
 import NextAuth, { CredentialsSignin } from "next-auth";
+import type { Account, Session, User } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 import type { Provider } from "next-auth/providers";
 import Credentials from "next-auth/providers/credentials";
 import Google from "next-auth/providers/google";
 import Kakao from "next-auth/providers/kakao";
+import type { NextRequest } from "next/server";
 import authConfig from "@/auth.config";
 import { ApiError } from "@/lib/api/apiFetch";
 import { AUTH_ERROR_CODES, getApiErrorCode } from "@/lib/auth/auth-errors";
 import * as authService from "@/services/authService";
-import type { JWT } from "next-auth/jwt";
 
 class PendingRestoreError extends CredentialsSignin {
   code = AUTH_ERROR_CODES.PENDING_RESTORE;
+}
+
+function logLoginAccessToken(source: string, accessToken: string | undefined) {
+  console.log(`[auth] ${source} accessToken`, accessToken);
 }
 
 const KakaoProvider = Kakao({
@@ -103,6 +109,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         try {
           const result = await authService.loginLocal({ email, password });
+          logLoginAccessToken("local", result.accessToken);
           return {
             id: result.userUuid,
             userUuid: result.userUuid,
@@ -123,9 +130,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
   callbacks: {
-    authorized({ auth: session, request }) {
+    authorized({ auth: session, request }: { auth: Session | null; request: NextRequest }) {
       const pathname = request.nextUrl.pathname;
-      const isLoggedIn = !!session?.user;
+      const isLoggedIn = session?.isLoggedIn === true;
 
       if (matchesPrefix(pathname, GUEST_ONLY_PREFIXES) && isLoggedIn) {
         return Response.redirect(new URL("/home", request.nextUrl));
@@ -137,7 +144,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
       return true;
     },
-    async signIn({ account, user }) {
+    async signIn({ account, user }: { account?: Account | null; user: User }) {
       if (account?.provider === "credentials") {
         return !!user?.accessToken;
       }
@@ -150,6 +157,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
       try {
         const result = await authService.loginSocial(provider, providerAccessToken);
+        logLoginAccessToken(provider, result.accessToken);
         user.id = result.userUuid;
         user.userUuid = result.userUuid;
         user.accessToken = result.accessToken;
@@ -177,7 +185,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         return `/login?error=social_backend&provider=${provider}`;
       }
     },
-    async jwt({ token, user, trigger, session }) {
+    async jwt({
+      token,
+      user,
+      trigger,
+      session,
+    }: {
+      token: JWT;
+      user?: User;
+      trigger?: "signIn" | "signUp" | "update";
+      session?: Session;
+    }) {
       if (user) {
         token.accessToken = user.accessToken;
         token.refreshToken = user.refreshToken;
@@ -205,11 +223,22 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
       return refreshAccessToken(token);
     },
-    session({ session, token }) {
-      if (typeof token.userUuid === "string") {
-        session.user.id = token.userUuid;
-      }
-      return session;
+    session({ session, token }: { session: Session; token: JWT }): Session {
+      const accessToken =
+        typeof token.accessToken === "string" && token.accessToken.length > 0
+          ? token.accessToken
+          : undefined;
+      const refreshToken =
+        typeof token.refreshToken === "string" && token.refreshToken.length > 0
+          ? token.refreshToken
+          : undefined;
+
+      return {
+        expires: session.expires,
+        isLoggedIn: Boolean(accessToken),
+        accessToken,
+        refreshToken,
+      };
     },
   },
 });

--- a/components/providers/AuthSessionProvider.tsx
+++ b/components/providers/AuthSessionProvider.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { SessionProvider } from "next-auth/react";
-import type { ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
+
+type AuthStatus = {
+  isLoggedIn: boolean;
+};
+
+const AuthStatusContext = createContext<AuthStatus>({ isLoggedIn: false });
 
 type AuthSessionProviderProps = {
+  isLoggedIn: boolean;
   children: ReactNode;
 };
 
-export function AuthSessionProvider({ children }: AuthSessionProviderProps) {
-  return <SessionProvider>{children}</SessionProvider>;
+export function AuthSessionProvider({ isLoggedIn, children }: AuthSessionProviderProps) {
+  return <AuthStatusContext.Provider value={{ isLoggedIn }}>{children}</AuthStatusContext.Provider>;
+}
+
+export function useAuthStatus(): AuthStatus {
+  return useContext(AuthStatusContext);
 }

--- a/docs/auth-login-signup-flow.html
+++ b/docs/auth-login-signup-flow.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>로그인 · 회원가입 프로세스 — plip-user-app</title>
+  <style>
+    :root {
+      --bg: #f6f6f4;
+      --surface: #fff;
+      --text: #1b1b18;
+      --muted: #5c5c56;
+      --stroke: #d8d6cf;
+      --accent: #1f6feb;
+      --accent-bg: #e8f1fc;
+      --ok: #0f6b3a;
+      --ok-bg: #e5f6ec;
+      --warn: #8a5a00;
+      --warn-bg: #fff4d6;
+      --danger: #b42318;
+      --danger-bg: #fdecea;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.5 system-ui, sans-serif;
+      color: var(--text);
+      background: var(--bg);
+    }
+    main { max-width: 980px; margin: 0 auto; padding: 32px 20px 64px; }
+    h1 { font-size: 24px; font-weight: 650; margin: 0 0 8px; }
+    h2 { font-size: 18px; margin: 0 0 8px; }
+    h3 { font-size: 15px; margin: 20px 0 8px; }
+    p { margin: 0 0 12px; }
+    .muted { color: var(--muted); }
+    .tabs { display: flex; flex-wrap: wrap; gap: 8px; margin: 20px 0; }
+    .tabs button {
+      border: 1px solid var(--stroke);
+      background: var(--surface);
+      color: var(--text);
+      padding: 6px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    .tabs button[aria-selected="true"] {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .panel { display: none; }
+    .panel.active { display: block; }
+    .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+    .stat, .card, .callout {
+      background: var(--surface);
+      border: 1px solid var(--stroke);
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .stat strong { display: block; font-size: 16px; margin-bottom: 4px; }
+    .stat span, .stat-label { color: var(--muted); font-size: 12px; }
+    .stat.warn { background: var(--warn-bg); }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin: 16px 0; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid var(--stroke); vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; }
+    .callout { margin: 16px 0; }
+    .callout.warn { background: var(--warn-bg); border-color: #e6d08a; }
+    .callout.danger { background: var(--danger-bg); border-color: #f0b8b3; }
+    .callout strong { display: block; margin-bottom: 6px; }
+    .flow { display: flex; flex-direction: column; align-items: center; gap: 0; margin: 20px 0; }
+    .node {
+      width: 220px;
+      min-height: 52px;
+      border: 1px solid var(--stroke);
+      border-radius: 6px;
+      background: var(--surface);
+      padding: 8px 10px;
+      text-align: center;
+    }
+    .node small { display: block; color: var(--muted); font-size: 11px; }
+    .node.accent { background: var(--accent-bg); border-color: var(--accent); }
+    .node.ok { background: var(--ok-bg); border-color: var(--ok); }
+    .node.warn { background: var(--warn-bg); border-color: #c9a227; }
+    .node.danger { background: var(--danger-bg); border-color: var(--danger); }
+    .arrow { color: var(--muted); height: 20px; line-height: 20px; }
+    .branch { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; margin-top: 8px; }
+    code {
+      font: 12px/1.4 ui-monospace, monospace;
+      background: var(--surface);
+      border: 1px solid var(--stroke);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .paths { margin-top: 24px; }
+    .path-row { display: flex; gap: 10px; align-items: center; margin: 8px 0; flex-wrap: wrap; }
+    @media (max-width: 800px) {
+      .stats, .grid-2, .grid-3 { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>로그인 · 회원가입 프로세스</h1>
+    <p class="muted">plip-user-app 코드와 user-service OpenAPI 기준. Source: auth.ts, LoginForm, SignUpForm, api-endpoints.ts, plip-user docs/openapi.yaml</p>
+
+    <div class="tabs" role="tablist">
+      <button type="button" role="tab" aria-selected="true" data-tab="overview">한눈에</button>
+      <button type="button" role="tab" aria-selected="false" data-tab="local-login">로컬 로그인</button>
+      <button type="button" role="tab" aria-selected="false" data-tab="local-signup">로컬 가입</button>
+      <button type="button" role="tab" aria-selected="false" data-tab="social">소셜 로그인</button>
+    </div>
+
+    <section id="overview" class="panel active">
+      <div class="stats">
+        <div class="stat"><strong>NextAuth v5</strong><span>프론트 세션</span></div>
+        <div class="stat"><strong>/api/user + /api/v1</strong><span>Gateway 경로</span></div>
+        <div class="stat"><strong>8000</strong><span>Develop PC Gateway</span></div>
+        <div class="stat warn"><strong>K3s Ingress</strong><span>운영 예정</span></div>
+      </div>
+      <div class="callout warn">
+        <strong>지금 쓰는 게이트웨이</strong>
+        API_URL은 Develop PC Spring Cloud Gateway (192.168.10.144:8000)입니다.
+        운영 K3s에서는 Ingress가 Gateway를 대체할 예정이며, 경로 규칙은 인프라 매니페스트가 공개되면 다시 맞춰야 합니다.
+      </div>
+      <div class="grid-2">
+        <div class="card">
+          <h3>액터</h3>
+          <table>
+            <thead><tr><th>구분</th><th>역할</th></tr></thead>
+            <tbody>
+              <tr><td>브라우저 /login · /signup</td><td>폼 · OAuth 시작</td></tr>
+              <tr><td>NextAuth /api/auth/*</td><td>Google/Kakao/Naver 토큰 교환</td></tr>
+              <tr><td>Gateway :8000</td><td>/api/{service} 라우팅</td></tr>
+              <tr><td>plip-user</td><td>로컬/소셜 로그인 · JWT 발급</td></tr>
+              <tr><td>JWT 세션</td><td>access/refresh를 NextAuth JWT에 저장</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="card">
+          <h3>백엔드 계약</h3>
+          <table>
+            <thead><tr><th>상태</th><th>의미</th><th>앱 동작</th></tr></thead>
+            <tbody>
+              <tr><td>200</td><td>기존 회원 JWT</td><td>/home</td></tr>
+              <tr><td>401 SOCIAL_002</td><td>소셜 토큰 검증 실패</td><td>로그인 에러</td></tr>
+              <tr><td>401 (빈 본문)</td><td>Gateway 경로 불일치</td><td>social_backend</td></tr>
+              <tr><td>422 SOCIAL_003</td><td>신규 소셜 · 약관 필요</td><td>/signup/social-terms</td></tr>
+              <tr><td>AUTH_010</td><td>탈퇴 복구 대기</td><td>복구 다이얼로그</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section id="local-login" class="panel">
+      <h2>로컬 로그인</h2>
+      <p class="muted">LoginForm이 NextAuth credentials를 호출하고, authorize()가 user-service POST /api/v1/auth/login/local 을 Gateway 경유(/api/user/...)로 칩니다.</p>
+      <div class="flow">
+        <div class="node">로그인 폼<small>email + password</small></div>
+        <div class="arrow">↓</div>
+        <div class="node">signIn(credentials)<small>redirect: false</small></div>
+        <div class="arrow">↓</div>
+        <div class="node">authorize()<small>auth.ts</small></div>
+        <div class="arrow">↓</div>
+        <div class="node accent">login/local<small>/api/user/api/v1/...</small></div>
+        <div class="arrow">↓</div>
+        <div class="branch">
+          <div class="node ok">JWT 세션<small>access · refresh → /home</small></div>
+          <div class="node danger">이메일/비밀번호 오류</div>
+          <div class="node warn">복구 다이얼로그<small>AUTH_010</small></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="local-signup" class="panel">
+      <h2>로컬 회원가입</h2>
+      <p class="muted">SignUpForm은 3단계 UI입니다. 1·2단계는 화면만 있고, 약관 후 /signup/profile 로 이동합니다. OTP·signup/local API 호출은 아직 폼에 연결되지 않았습니다.</p>
+      <div class="grid-3">
+        <div class="card"><h3>1 이메일 · 비밀번호</h3><p>이메일, 비밀번호, 비밀번호 확인 후 다음.</p></div>
+        <div class="card"><h3>2 OTP 화면</h3><p>6자리 코드 입력 UI. otp-request / otp-verify는 미연결.</p></div>
+        <div class="card"><h3>3 약관 → 프로필</h3><p>필수 약관 동의 후 /signup/profile. signup/local 미연결.</p></div>
+      </div>
+      <div class="flow">
+        <div class="node">1. 이메일·비밀번호</div>
+        <div class="arrow">↓</div>
+        <div class="node">2. OTP 입력<small>UI only</small></div>
+        <div class="arrow">↓</div>
+        <div class="node">3. 약관 동의</div>
+        <div class="arrow">↓</div>
+        <div class="branch">
+          <div class="node accent">/signup/profile</div>
+          <div class="node warn">signup/local<small>엔드포인트만 정의</small></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="social" class="panel">
+      <h2>소셜 로그인 (NextAuth)</h2>
+      <p class="muted">OAuth는 NextAuth가 처리합니다. 콜백의 signIn에서 provider access_token을 user-service 소셜 로그인으로 넘깁니다.</p>
+      <div class="flow">
+        <div class="node">소셜 버튼<small>google / kakao / naver</small></div>
+        <div class="arrow">↓</div>
+        <div class="node">제공자 동의<small>NextAuth OAuth</small></div>
+        <div class="arrow">↓</div>
+        <div class="node accent">/api/auth/callback</div>
+        <div class="arrow">↓</div>
+        <div class="node">account.access_token</div>
+        <div class="arrow">↓</div>
+        <div class="node">Gateway<small>/api/user/api/v1/auth/login/social/{p}</small></div>
+        <div class="arrow">↓</div>
+        <div class="branch">
+          <div class="node ok">기존 회원 200<small>JWT → /home</small></div>
+          <div class="node warn">신규 422<small>SOCIAL_003 → /signup/social-terms</small></div>
+          <div class="node danger">401<small>경로 오류 또는 SOCIAL_002</small></div>
+        </div>
+      </div>
+      <div class="callout danger">
+        <strong>최근 401의 실제 원인</strong>
+        Google/Kakao 콜백(302)은 성공했습니다. 앱이 Gateway 없이 /api/v1/auth/login/social/google 을 쳐 빈 401이 났습니다.
+        올바른 전체 경로는 /api/user/api/v1/auth/login/social/{provider} 입니다.
+      </div>
+      <h3>소셜 신규 가입 갭</h3>
+      <p>422 시 provider만 쿼리로 넘기고 accessToken은 버려집니다. SocialSignupTermsTemplate는 안내 문구만 있고 termsAgreements를 다시 보내지 않습니다.</p>
+    </section>
+
+    <div class="card paths">
+      <h3>호출 경로</h3>
+      <div class="path-row"><strong>로컬 로그인</strong><code>POST /api/user/api/v1/auth/login/local</code></div>
+      <div class="path-row"><strong>소셜 로그인</strong><code>POST /api/user/api/v1/auth/login/social/{provider}</code></div>
+      <div class="path-row"><strong>로컬 가입</strong><code>POST /api/user/api/v1/auth/signup/local</code></div>
+    </div>
+  </main>
+  <script>
+    const tabs = document.querySelectorAll("[data-tab]");
+    const panels = document.querySelectorAll(".panel");
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        const id = tab.getAttribute("data-tab");
+        tabs.forEach((t) => t.setAttribute("aria-selected", String(t === tab)));
+        panels.forEach((p) => p.classList.toggle("active", p.id === id));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/lib/api/actorHeaders.ts
+++ b/lib/api/actorHeaders.ts
@@ -1,27 +1,12 @@
 import { getDevAccessToken } from "@/lib/api/devAccessToken";
 import { getDevUserUuid } from "@/lib/api/env";
-import { getRequestAccessTokenOverride } from "@/lib/auth/request-token-cache";
-import { getServerAccessToken, getServerAuthJwt } from "@/lib/auth/server-token";
+import { getSessionAuthHeaders } from "@/lib/auth/server-token";
 
 /** RSC/API 레이어 전용. NextAuth JWT 우선, 미로그인 dev 환경 fallback. */
 export async function getActorUserHeaders(): Promise<Record<string, string>> {
-  const override = getRequestAccessTokenOverride();
-  if (override) {
-    return {
-      Authorization: `Bearer ${override}`,
-    };
-  }
-
-  const accessToken = await getServerAccessToken();
-  if (accessToken) {
-    const jwt = await getServerAuthJwt();
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${accessToken}`,
-    };
-    if (typeof jwt?.userUuid === "string" && jwt.userUuid) {
-      headers["X-User-Uuid"] = jwt.userUuid;
-    }
-    return headers;
+  const sessionHeaders = await getSessionAuthHeaders();
+  if (sessionHeaders.Authorization) {
+    return sessionHeaders;
   }
 
   const headers: Record<string, string> = {

--- a/lib/api/apiFetch.ts
+++ b/lib/api/apiFetch.ts
@@ -1,4 +1,5 @@
 import { getVideoApiBaseUrl } from "@/lib/api/env";
+import { getSessionAuthHeaders } from "@/lib/auth/server-token";
 
 export class ApiError extends Error {
   constructor(
@@ -16,6 +17,8 @@ type ApiFetchOptions = Omit<RequestInit, "body"> & {
   searchParams?: Record<string, string | undefined>;
   /** 생략 시 기존처럼 VIDEO_API_BASE_URL */
   baseUrl?: string;
+  /** false면 세션 토큰을 붙이지 않음. 로그인/재발급 등 공개 API용. 기본 true */
+  auth?: boolean;
 };
 
 function buildUrl(
@@ -38,35 +41,48 @@ function buildUrl(
   return url.toString();
 }
 
-export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
-  const { body, searchParams, headers, baseUrl, ...rest } = options;
+async function requestApi(path: string, options: ApiFetchOptions = {}): Promise<Response> {
+  const { body, searchParams, headers, baseUrl, auth = true, ...rest } = options;
   const hasJsonBody = body !== undefined;
+  const sessionHeaders = auth ? await getSessionAuthHeaders() : {};
 
-  const response = await fetch(buildUrl(path, searchParams, baseUrl), {
+  return fetch(buildUrl(path, searchParams, baseUrl), {
     ...rest,
     headers: {
+      ...sessionHeaders,
       ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
       ...headers,
     },
     body: hasJsonBody ? JSON.stringify(body) : undefined,
     cache: "no-store",
   });
+}
 
+async function parseBody(response: Response): Promise<unknown> {
   const contentType = response.headers.get("content-type") ?? "";
-  const parsedBody = contentType.includes("application/json")
+  return contentType.includes("application/json")
     ? await response.json().catch(() => undefined)
     : await response.text().catch(() => undefined);
+}
+
+function toApiError(status: number, parsedBody: unknown): ApiError {
+  const message =
+    typeof parsedBody === "object" &&
+    parsedBody !== null &&
+    "message" in parsedBody &&
+    typeof parsedBody.message === "string"
+      ? parsedBody.message
+      : `API request failed (${status})`;
+
+  return new ApiError(message, status, parsedBody);
+}
+
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const response = await requestApi(path, options);
+  const parsedBody = await parseBody(response);
 
   if (!response.ok) {
-    const message =
-      typeof parsedBody === "object" &&
-      parsedBody !== null &&
-      "message" in parsedBody &&
-      typeof parsedBody.message === "string"
-        ? parsedBody.message
-        : `API request failed (${response.status})`;
-
-    throw new ApiError(message, response.status, parsedBody);
+    throw toApiError(response.status, parsedBody);
   }
 
   return parsedBody as T;
@@ -76,34 +92,11 @@ export async function apiFetchWithStatus<T>(
   path: string,
   options: ApiFetchOptions = {},
 ): Promise<{ status: number; data: T }> {
-  const { body, searchParams, headers, baseUrl, ...rest } = options;
-  const hasJsonBody = body !== undefined;
-
-  const response = await fetch(buildUrl(path, searchParams, baseUrl), {
-    ...rest,
-    headers: {
-      ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
-      ...headers,
-    },
-    body: hasJsonBody ? JSON.stringify(body) : undefined,
-    cache: "no-store",
-  });
-
-  const contentType = response.headers.get("content-type") ?? "";
-  const parsedBody = contentType.includes("application/json")
-    ? await response.json().catch(() => undefined)
-    : await response.text().catch(() => undefined);
+  const response = await requestApi(path, options);
+  const parsedBody = await parseBody(response);
 
   if (!response.ok) {
-    const message =
-      typeof parsedBody === "object" &&
-      parsedBody !== null &&
-      "message" in parsedBody &&
-      typeof parsedBody.message === "string"
-        ? parsedBody.message
-        : `API request failed (${response.status})`;
-
-    throw new ApiError(message, response.status, parsedBody);
+    throw toApiError(response.status, parsedBody);
   }
 
   return { status: response.status, data: parsedBody as T };

--- a/lib/api/authApi.ts
+++ b/lib/api/authApi.ts
@@ -30,6 +30,7 @@ export async function postLoginLocal(body: ApiLocalLoginRequest): Promise<ApiLoc
     method: "POST",
     baseUrl: getApiUrl(),
     body,
+    auth: false,
   });
 }
 
@@ -41,6 +42,7 @@ export async function postLoginSocial(
     method: "POST",
     baseUrl: getApiUrl(),
     body,
+    auth: false,
   });
 }
 
@@ -49,6 +51,7 @@ export async function postReissue(body: ApiTokenReissueRequest): Promise<ApiToke
     method: "POST",
     baseUrl: getApiUrl(),
     body,
+    auth: false,
   });
 }
 

--- a/lib/api/devAccessToken.ts
+++ b/lib/api/devAccessToken.ts
@@ -40,6 +40,7 @@ async function requestDevAccessToken(email: string, password: string): Promise<s
       method: "POST",
       baseUrl: getApiUrl(),
       body: { email, password },
+      auth: false,
     });
     const token = data.accessToken?.trim();
     cachedAccessToken = token || undefined;

--- a/lib/api/videoApi.ts
+++ b/lib/api/videoApi.ts
@@ -1,5 +1,6 @@
 import { API_ENDPOINTS } from "@/config/api-endpoints";
 import { apiFetch, apiFetchWithStatus } from "@/lib/api/apiFetch";
+import { withAuthRetry } from "@/lib/api/withAuthRetry";
 import type {
   VideoCompleteRequest,
   VideoCompleteResponse,
@@ -14,13 +15,15 @@ export async function postUploadUrl(
   userUuid: string,
   contentType?: string,
 ): Promise<VideoUploadUrlResponse> {
-  return apiFetch<VideoUploadUrlResponse>(API_ENDPOINTS.video.uploadUrl, {
-    method: "POST",
-    searchParams: {
-      userUuid,
-      contentType,
-    },
-  });
+  return withAuthRetry(() =>
+    apiFetch<VideoUploadUrlResponse>(API_ENDPOINTS.video.uploadUrl, {
+      method: "POST",
+      searchParams: {
+        userUuid,
+        contentType,
+      },
+    }),
+  );
 }
 
 export async function postComplete(
@@ -28,25 +31,32 @@ export async function postComplete(
   userUuid: string,
   request?: VideoCompleteRequest,
 ): Promise<VideoCompleteResponse> {
-  return apiFetch<VideoCompleteResponse>(API_ENDPOINTS.video.complete(videoUuid), {
-    method: "POST",
-    searchParams: { userUuid },
-    body: request ?? {},
-  });
+  return withAuthRetry(() =>
+    apiFetch<VideoCompleteResponse>(API_ENDPOINTS.video.complete(videoUuid), {
+      method: "POST",
+      searchParams: { userUuid },
+      body: request ?? {},
+    }),
+  );
 }
 
 export async function getVideoDetail(videoUuid: string): Promise<VideoDetailResponse> {
-  return apiFetch<VideoDetailResponse>(API_ENDPOINTS.video.detail(videoUuid), {
-    method: "GET",
-  });
+  return withAuthRetry(() =>
+    apiFetch<VideoDetailResponse>(API_ENDPOINTS.video.detail(videoUuid), {
+      method: "GET",
+    }),
+  );
 }
 
 export async function getDownloadUrl(videoUuid: string): Promise<VideoDownloadUrlResult> {
-  const { status, data } = await apiFetchWithStatus<
-    VideoDownloadUrlResponse | VideoDownloadUrlProcessingResponse
-  >(API_ENDPOINTS.video.downloadUrl(videoUuid), {
-    method: "GET",
-  });
+  const { status, data } = await withAuthRetry(() =>
+    apiFetchWithStatus<VideoDownloadUrlResponse | VideoDownloadUrlProcessingResponse>(
+      API_ENDPOINTS.video.downloadUrl(videoUuid),
+      {
+        method: "GET",
+      },
+    ),
+  );
 
   if (status === 202) {
     return {

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -1,3 +1,4 @@
+import { getRequestAccessTokenOverride } from "@/lib/auth/request-token-cache";
 import { headers } from "next/headers";
 import { getToken } from "next-auth/jwt";
 
@@ -12,14 +13,48 @@ export async function getServerAuthJwt() {
   });
 }
 
+async function getServerAuthJwtSafe() {
+  try {
+    return await getServerAuthJwt();
+  } catch {
+    return null;
+  }
+}
+
 export async function getServerAccessToken(): Promise<string | undefined> {
-  const jwt = await getServerAuthJwt();
+  const override = getRequestAccessTokenOverride();
+  if (override) {
+    return override;
+  }
+
+  const jwt = await getServerAuthJwtSafe();
   const token = jwt?.accessToken;
   return typeof token === "string" && token.length > 0 ? token : undefined;
 }
 
 export async function getServerRefreshToken(): Promise<string | undefined> {
-  const jwt = await getServerAuthJwt();
+  const jwt = await getServerAuthJwtSafe();
   const token = jwt?.refreshToken;
   return typeof token === "string" && token.length > 0 ? token : undefined;
+}
+
+export async function getSessionAuthHeaders(): Promise<Record<string, string>> {
+  const override = getRequestAccessTokenOverride();
+  if (override) {
+    return { Authorization: `Bearer ${override}` };
+  }
+
+  const jwt = await getServerAuthJwtSafe();
+  if (!jwt) {
+    return {};
+  }
+
+  const sessionHeaders: Record<string, string> = {};
+  if (typeof jwt.accessToken === "string" && jwt.accessToken) {
+    sessionHeaders.Authorization = `Bearer ${jwt.accessToken}`;
+  }
+  if (typeof jwt.userUuid === "string" && jwt.userUuid) {
+    sessionHeaders["X-User-Uuid"] = jwt.userUuid;
+  }
+  return sessionHeaders;
 }

--- a/types/auth/authjs.d.ts
+++ b/types/auth/authjs.d.ts
@@ -1,10 +1,12 @@
 import type { DefaultSession } from "next-auth";
+import "next-auth/jwt";
 
 declare module "next-auth" {
   interface Session {
-    user: DefaultSession["user"] & {
-      id: string;
-    };
+    isLoggedIn: boolean;
+    accessToken?: string;
+    refreshToken?: string;
+    user?: DefaultSession["user"];
   }
 
   interface User {


### PR DESCRIPTION
## Summary
- 로그인 응답에 `accessToken`, `refreshToken`이 있으면 JWT와 **서버 세션**에 저장합니다.
- 클라이언트 `SessionProvider`/`useSession`은 제거했습니다. UI·proxy 가드는 `isLoggedIn` boolean만 사용합니다.
- 로그인된 API 호출은 세션의 액세스 토큰을 `Authorization: Bearer`로 자동 첨부합니다.

## 세션에 토큰 저장

로그인(로컬/소셜) 성공 시 백엔드 토큰을 JWT에 넣고, `session` 콜백에서 세션으로 노출합니다.

### `types/auth/authjs.d.ts`
`Session`에 토큰 필드를 추가했습니다.

```ts
interface Session {
  isLoggedIn: boolean;
  accessToken?: string;
  refreshToken?: string;
  user?: DefaultSession["user"];
}
```

### `auth.ts` — jwt
로그인 `user`에 토큰이 있으면 JWT에 복사합니다.

```ts
if (user) {
  token.accessToken = user.accessToken;
  token.refreshToken = user.refreshToken;
  token.accessTokenExpiresAt = user.accessTokenExpiresAt;
  token.userUuid = user.userUuid ?? user.id;
}
```

### `auth.ts` — session
세션 객체에 액세스/리프레시 토큰을 담습니다. 프로필(`name`/`email`/`image`/`id`)은 넣지 않습니다.

```ts
session({ session, token }: { session: Session; token: JWT }): Session {
  const accessToken =
    typeof token.accessToken === "string" && token.accessToken.length > 0
      ? token.accessToken
      : undefined;
  const refreshToken =
    typeof token.refreshToken === "string" && token.refreshToken.length > 0
      ? token.refreshToken
      : undefined;

  return {
    expires: session.expires,
    isLoggedIn: Boolean(accessToken),
    accessToken,
    refreshToken,
  };
}
```

서버의 `auth()` 결과는 아래 형태입니다.

```ts
{
  expires: string;
  isLoggedIn: boolean;
  accessToken?: string;
  refreshToken?: string;
}
```

## 그 외 변경

### `components/providers/AuthSessionProvider.tsx`
NextAuth `SessionProvider` 대신 `isLoggedIn`만 전달합니다. 클라이언트에는 토큰을 주지 않습니다.

### `app/layout.tsx`
`auth()`로 `isLoggedIn`만 읽어 프로바이더에 넘깁니다.

### `lib/auth/server-token.ts` / `lib/api/apiFetch.ts`
세션 JWT의 `accessToken`으로 `Authorization`, `X-User-Uuid`를 만들고 `apiFetch`가 기본 첨부합니다. 로그인/재발급은 `auth: false`입니다.

### `lib/api/videoApi.ts` / `lib/api/actorHeaders.ts`
영상 API에도 세션 토큰과 401 재시도를 적용했습니다.

## Test plan
- [ ] 로그인 후 서버 `auth()`에 `accessToken`, `refreshToken`, `isLoggedIn: true`가 있는지 확인
- [ ] 클라이언트 프로바이더/`useAuthStatus()`에는 `isLoggedIn`만 있는지 확인
- [ ] 로그인 후 아지트/영상 API가 `Authorization: Bearer <accessToken>`으로 호출되는지 확인
- [ ] 비로그인에서 `/home`, `/agit`, `/mypage`가 `/login`으로 리다이렉트되는지 확인