### PR TITLE
[#40] Feature : 아지트 생성 API 연동

### DIFF
--- a/actions/agitActions.ts
+++ b/actions/agitActions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { ApiError } from "@/lib/api/apiFetch";
+import * as agitService from "@/services/agitService";
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import { parseCreateAgitInput } from "@/types/agit/schema";
+import type { UiAgit, UiCreateAgitInput } from "@/types/agit/ui";
+
+function toActionError(error: unknown): ActionResult<never> {
+  if (error instanceof ApiError) {
+    return actionFailure(`[${error.status}] ${error.message}`);
+  }
+  if (error instanceof Error) {
+    return actionFailure(error.message);
+  }
+  return actionFailure("Unknown error");
+}
+
+export async function createAgitAction(
+  input: UiCreateAgitInput,
+): Promise<ActionResult<UiAgit>> {
+  const parsed = parseCreateAgitInput(input);
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    const agit = await agitService.createAgit(parsed.data);
+    return actionSuccess(agit);
+  } catch (error) {
+    return toActionError(error);
+  }
+}

--- a/app/(agit)/agit/[agitId]/joined/page.tsx
+++ b/app/(agit)/agit/[agitId]/joined/page.tsx
@@ -1,4 +1,7 @@
 import { JoinCompleteTemplate } from "@/components/templates";
+import { ApiError } from "@/lib/api/apiFetch";
+import { getAgit } from "@/services/agitService";
+import type { UiAgit } from "@/types/agit/ui";
 
 type PageProps = {
   params: Promise<{ agitId: string }>;
@@ -6,5 +9,18 @@ type PageProps = {
 
 export default async function AgitJoinedPage({ params }: PageProps) {
   const { agitId } = await params;
-  return <JoinCompleteTemplate agitId={agitId} />;
+  let agit: UiAgit | null = null;
+  let error: string | undefined;
+
+  try {
+    agit = await getAgit(agitId);
+  } catch (caught) {
+    if (caught instanceof ApiError && (caught.status === 403 || caught.status === 404)) {
+      agit = null;
+    } else {
+      error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
+    }
+  }
+
+  return <JoinCompleteTemplate agit={agit} error={error} />;
 }

--- a/components/molecules/AuthField.tsx
+++ b/components/molecules/AuthField.tsx
@@ -12,6 +12,8 @@ type AuthFieldProps = {
   required?: boolean;
   defaultValue?: string;
   maxLength?: number;
+  pattern?: string;
+  title?: string;
 };
 
 export function AuthField({
@@ -25,6 +27,8 @@ export function AuthField({
   required,
   defaultValue,
   maxLength,
+  pattern,
+  title,
 }: AuthFieldProps) {
   return (
     <div className="dl-field">
@@ -40,6 +44,8 @@ export function AuthField({
         required={required}
         defaultValue={defaultValue}
         maxLength={maxLength}
+        pattern={pattern}
+        title={title}
         variant="daily"
       />
       {hint ? <p className="dl-hint">{hint}</p> : null}

--- a/components/organisms/CreateRoomAccessForm.tsx
+++ b/components/organisms/CreateRoomAccessForm.tsx
@@ -1,19 +1,63 @@
 "use client";
 
+import { createAgitAction } from "@/actions/agitActions";
 import { SubmitButton } from "@/components/atoms";
+import { AuthField } from "@/components/molecules";
 import { AgreementRow } from "@/components/molecules/AgreementRow";
+import { CREATE_ROOM_DRAFT_KEY, readCreateRoomDraft } from "@/lib/agit/createRoomDraft";
 import { ROUTES } from "@/config/routes";
+import {
+  AGIT_NICKNAME_MAX_LENGTH,
+  AGIT_NICKNAME_MIN_LENGTH,
+} from "@/types/agit/schema";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function CreateRoomAccessForm() {
   const router = useRouter();
   const [agreed, setAgreed] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  function handleSubmit() {
-    if (!agreed) return;
-    router.push(ROUTES.agit.joined("azit-walk"));
+  useEffect(() => {
+    if (!readCreateRoomDraft()) {
+      router.replace(ROUTES.agit.create);
+    }
+  }, [router]);
+
+  async function handleSubmit(formData: FormData) {
+    if (!agreed || pending) {
+      return;
+    }
+
+    const draft = readCreateRoomDraft();
+    if (!draft) {
+      router.replace(ROUTES.agit.create);
+      return;
+    }
+
+    setError(null);
+    setPending(true);
+
+    const result = await createAgitAction({
+      agitName: draft.title,
+      description: draft.intro,
+      maximumCapacity: draft.capacity,
+      nickname: String(formData.get("nickname") ?? ""),
+      thumbnailPath: draft.thumbnailPath,
+    });
+
+    setPending(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    sessionStorage.removeItem(CREATE_ROOM_DRAFT_KEY);
+    router.push(ROUTES.agit.joined(result.data.id));
+    router.refresh();
   }
 
   return (
@@ -26,12 +70,24 @@ export function CreateRoomAccessForm() {
         </div>
         <div className="min-w-0 flex-1">
           <p className="dl-notice-card__title">프로필 사진</p>
-          <p className="dl-notice-card__body">안지민</p>
+          <p className="dl-notice-card__body">아지트에서 사용할 프로필</p>
         </div>
         <button type="button" className="dl-profile-card__action">
           사진 변경
         </button>
       </div>
+
+      <AuthField
+        id="room-nickname"
+        name="nickname"
+        label="닉네임"
+        hint={`영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자`}
+        placeholder="보드왕"
+        maxLength={AGIT_NICKNAME_MAX_LENGTH}
+        pattern="[0-9A-Za-z가-힣]{2,12}"
+        title="영문·숫자·한글 2~12자, 특수문자와 공백 불가"
+        required
+      />
 
       <AgreementRow
         id="create-guide"
@@ -42,9 +98,11 @@ export function CreateRoomAccessForm() {
         onChange={setAgreed}
       />
 
+      {error ? <p className="m-0 text-[12px] text-red-600">{error}</p> : null}
+
       <div className="dl-actions">
-        <SubmitButton variant="brand" disabled={!agreed}>
-          아지트 만들기
+        <SubmitButton variant="brand" disabled={!agreed || pending}>
+          {pending ? "만드는 중..." : "아지트 만들기"}
         </SubmitButton>
       </div>
     </form>

--- a/components/organisms/CreateRoomBasicForm.tsx
+++ b/components/organisms/CreateRoomBasicForm.tsx
@@ -3,28 +3,25 @@
 import { SubmitButton } from "@/components/atoms";
 import { AuthField, CapacityStepper } from "@/components/molecules";
 import { ThumbnailUpload } from "@/components/molecules/ThumbnailUpload";
+import { CREATE_ROOM_DRAFT_KEY } from "@/lib/agit/createRoomDraft";
 import { ROUTES } from "@/config/routes";
+import {
+  AGIT_DEFAULT_MAX_CAPACITY,
+  AGIT_DESCRIPTION_MAX_LENGTH,
+  AGIT_NAME_MAX_LENGTH,
+} from "@/types/agit/schema";
+import type { UiCreateAgitDraft } from "@/types/agit/ui";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-export const CREATE_ROOM_DRAFT_KEY = "plip-create-room";
-
-export type CreateRoomDraft = {
-  title: string;
-  intro: string;
-  category: string;
-  capacity: number;
-};
-
 export function CreateRoomBasicForm() {
   const router = useRouter();
-  const [capacity, setCapacity] = useState(5);
+  const [capacity, setCapacity] = useState(AGIT_DEFAULT_MAX_CAPACITY);
 
   function handleSubmit(formData: FormData) {
-    const draft: CreateRoomDraft = {
+    const draft: UiCreateAgitDraft = {
       title: String(formData.get("title") ?? ""),
       intro: String(formData.get("intro") ?? ""),
-      category: "루틴",
       capacity,
     };
     sessionStorage.setItem(CREATE_ROOM_DRAFT_KEY, JSON.stringify(draft));
@@ -39,33 +36,36 @@ export function CreateRoomBasicForm() {
         id="room-title"
         name="title"
         label="아지트 제목"
-        hint="최대 24자"
+        hint={`최대 ${AGIT_NAME_MAX_LENGTH}자`}
         placeholder="새벽 기상 인증"
-        defaultValue="새벽 기상 인증"
-        maxLength={24}
+        maxLength={AGIT_NAME_MAX_LENGTH}
         required
       />
       <AuthField
         id="room-intro"
         name="intro"
         label="소개글"
-        hint="최대 120자"
+        hint={`최대 ${AGIT_DESCRIPTION_MAX_LENGTH}자`}
         placeholder="함께 아침 루틴을 기록해요"
-        defaultValue="함께 아침 루틴을 기록해요"
-        maxLength={120}
-        required
+        maxLength={AGIT_DESCRIPTION_MAX_LENGTH}
       />
 
       <p className="m-0 text-[14px] font-medium text-[var(--dl-color-text-primary)]">최대 인원</p>
       <div className="dl-capacity-card">
         <div className="dl-capacity-card__body">
           <p className="dl-capacity-card__value">{capacity}명</p>
-          <p className="dl-capacity-card__hint">기본 5명 · 최대 20명</p>
+          <p className="dl-capacity-card__hint">기본 {AGIT_DEFAULT_MAX_CAPACITY}명</p>
         </div>
-        <CapacityStepper value={capacity} min={2} max={20} onChange={setCapacity} compact />
+        <CapacityStepper
+          value={capacity}
+          min={2}
+          max={AGIT_DEFAULT_MAX_CAPACITY}
+          onChange={setCapacity}
+          compact
+        />
       </div>
       <p className="m-0 text-[11px] text-[var(--dl-color-text-tertiary)]">
-        기본 정원 5명 · 최대 20명까지 설정할 수 있어요.
+        기본 정원 {AGIT_DEFAULT_MAX_CAPACITY}명까지 설정할 수 있어요.
       </p>
 
       <div className="dl-actions">

--- a/components/templates/RoomFlowTemplates.tsx
+++ b/components/templates/RoomFlowTemplates.tsx
@@ -9,6 +9,7 @@ import { RoomProfileSelect } from "@/components/organisms/RoomProfileSelect";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiAgit } from "@/types/agit/ui";
 
 function RoomMissing({ backHref = ROUTES.agit.root }: { backHref?: string }) {
   return (
@@ -81,15 +82,33 @@ export function RoomProfileTemplate({ agitId }: { agitId: string }) {
   );
 }
 
-export function JoinCompleteTemplate({ agitId }: { agitId: string }) {
-  const agit = getAgitById(agitId);
-  if (!agit) return <RoomMissing />;
+export function JoinCompleteTemplate({
+  agit,
+  error,
+}: {
+  agit: UiAgit | null;
+  error?: string;
+}) {
+  if (error) {
+    return (
+      <DailyLoopAuthTemplate>
+        <p className="dl-subtitle">{error}</p>
+        <TextLink href={ROUTES.agit.root} className="dl-link">
+          목록으로
+        </TextLink>
+      </DailyLoopAuthTemplate>
+    );
+  }
+
+  if (!agit) {
+    return <RoomMissing />;
+  }
 
   return (
     <DailyLoopAuthTemplate>
       <p className="dl-eyebrow">R06 · JOIN COMPLETE</p>
       <div className="h-[42px]" />
-      <JoinCompleteSection agit={agit} />
+      <JoinCompleteSection agit={agit} profileName={agit.ownerName} />
     </DailyLoopAuthTemplate>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -24,6 +24,7 @@ export const API_ENDPOINTS = {
     restore: gatewayPath("user", "/api/v1/users/me/restore"),
   },
   agit: {
+    create: gatewayPath("agit", "/api/v1/agits"),
     me: gatewayPath("agit", "/api/v1/agits/me"),
     detail: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}`),
   },

--- a/lib/agit/createRoomDraft.ts
+++ b/lib/agit/createRoomDraft.ts
@@ -1,0 +1,29 @@
+import type { UiCreateAgitDraft } from "@/types/agit/ui";
+
+export const CREATE_ROOM_DRAFT_KEY = "plip-create-room";
+
+export function readCreateRoomDraft(): UiCreateAgitDraft | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw = sessionStorage.getItem(CREATE_ROOM_DRAFT_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<UiCreateAgitDraft>;
+    if (typeof parsed.title !== "string" || typeof parsed.capacity !== "number") {
+      return null;
+    }
+    return {
+      title: parsed.title,
+      intro: typeof parsed.intro === "string" ? parsed.intro : "",
+      capacity: parsed.capacity,
+      thumbnailPath: parsed.thumbnailPath,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -3,7 +3,7 @@ import { getActorUserHeaders } from "@/lib/api/actorHeaders";
 import { apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl } from "@/lib/api/env";
 import { withAuthRetry } from "@/lib/api/withAuthRetry";
-import type { ApiAgitDetail, ApiMyAgitItem } from "@/types/agit/api";
+import type { ApiAgitDetail, ApiCreateAgitRequest, ApiCreateAgitResponse, ApiMyAgitItem } from "@/types/agit/api";
 
 export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
   return withAuthRetry(async () =>
@@ -21,6 +21,17 @@ export async function getAgit(agitUuid: string): Promise<ApiAgitDetail> {
       method: "GET",
       baseUrl: getApiUrl(),
       headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function createAgit(body: ApiCreateAgitRequest): Promise<ApiCreateAgitResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiCreateAgitResponse>(API_ENDPOINTS.agit.create, {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      body,
     }),
   );
 }

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -1,6 +1,6 @@
 import * as agitApi from "@/lib/api/agitApi";
-import type { ApiAgitDetail, ApiMyAgitItem } from "@/types/agit/api";
-import type { UiAgit } from "@/types/agit/ui";
+import type { ApiAgitDetail, ApiCreateAgitRequest, ApiCreateAgitResponse, ApiMyAgitItem } from "@/types/agit/api";
+import type { UiAgit, UiCreateAgitInput } from "@/types/agit/ui";
 
 const DEFAULT_COVER_GRADIENT = "linear-gradient(104deg, #2e1f52 0%, #7a5cfa 100%)";
 
@@ -39,4 +39,32 @@ export async function listMyAgits(): Promise<UiAgit[]> {
 export async function getAgit(agitId: string): Promise<UiAgit> {
   const item = await agitApi.getAgit(agitId);
   return mapAgitDetail(item);
+}
+
+function mapCreatedAgit(item: ApiCreateAgitResponse): UiAgit {
+  return {
+    id: item.agitUuid,
+    name: item.agitName,
+    memberCount: 1,
+    description: item.description ?? "",
+    coverGradient: DEFAULT_COVER_GRADIENT,
+    topicCount: 0,
+    maxMembers: item.maximumCapacity,
+    ownerName: item.nickname,
+    thumbnailSrc: item.thumbnailPath ?? undefined,
+    joined: true,
+  };
+}
+
+export async function createAgit(input: UiCreateAgitInput): Promise<UiAgit> {
+  const body: ApiCreateAgitRequest = {
+    agitName: input.agitName,
+    maximumCapacity: input.maximumCapacity,
+    nickname: input.nickname,
+    ...(input.description ? { description: input.description } : {}),
+    ...(input.thumbnailPath ? { thumbnailPath: input.thumbnailPath } : {}),
+    ...(input.profileImagePath ? { profileImagePath: input.profileImagePath } : {}),
+  };
+  const created = await agitApi.createAgit(body);
+  return mapCreatedAgit(created);
 }

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -32,3 +32,25 @@ export type ApiAgitDetail = {
   members: ApiAgitDetailMember[];
   topics: ApiAgitDetailTopic[];
 };
+
+export type ApiCreateAgitRequest = {
+  agitName: string;
+  description?: string;
+  maximumCapacity: number;
+  thumbnailPath?: string;
+  nickname: string;
+  profileImagePath?: string;
+};
+
+export type ApiCreateAgitResponse = {
+  agitUuid: string;
+  agitName: string;
+  description: string | null;
+  maximumCapacity: number;
+  code: string;
+  thumbnailPath: string | null;
+  ampId: number;
+  nickname: string;
+  profileImagePath: string | null;
+  role: ApiAgitMemberRole;
+};

--- a/types/agit/schema.ts
+++ b/types/agit/schema.ts
@@ -1,0 +1,84 @@
+import type { ApiCreateAgitRequest } from "@/types/agit/api";
+
+export const AGIT_NAME_MAX_LENGTH = 20;
+export const AGIT_DESCRIPTION_MAX_LENGTH = 100;
+export const AGIT_DEFAULT_MAX_CAPACITY = 5;
+export const AGIT_CAPACITY_MIN = 1;
+export const AGIT_NICKNAME_MIN_LENGTH = 2;
+export const AGIT_NICKNAME_MAX_LENGTH = 12;
+export const AGIT_NICKNAME_PATTERN = /^[0-9A-Za-z가-힣]{2,12}$/;
+
+export type CreateAgitParseResult =
+  | { ok: true; data: ApiCreateAgitRequest }
+  | { ok: false; error: string };
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asOptionalPath(value: unknown): string | undefined {
+  const trimmed = asTrimmedString(value);
+  return trimmed || undefined;
+}
+
+export function parseCreateAgitInput(input: {
+  agitName: unknown;
+  description?: unknown;
+  maximumCapacity: unknown;
+  nickname: unknown;
+  thumbnailPath?: unknown;
+  profileImagePath?: unknown;
+}): CreateAgitParseResult {
+  const agitName = asTrimmedString(input.agitName);
+  if (!agitName) {
+    return { ok: false, error: "아지트 제목은 필수입니다." };
+  }
+  if (agitName.length > AGIT_NAME_MAX_LENGTH) {
+    return { ok: false, error: `아지트 제목은 ${AGIT_NAME_MAX_LENGTH}자 이하여야 합니다.` };
+  }
+
+  const description = asTrimmedString(input.description);
+  if (description.length > AGIT_DESCRIPTION_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `소개글은 ${AGIT_DESCRIPTION_MAX_LENGTH}자 이하여야 합니다.`,
+    };
+  }
+
+  const maximumCapacity =
+    typeof input.maximumCapacity === "number"
+      ? input.maximumCapacity
+      : Number(input.maximumCapacity);
+  if (!Number.isInteger(maximumCapacity)) {
+    return { ok: false, error: "인원수는 필수입니다." };
+  }
+  if (maximumCapacity < AGIT_CAPACITY_MIN || maximumCapacity > AGIT_DEFAULT_MAX_CAPACITY) {
+    return {
+      ok: false,
+      error: `인원수는 ${AGIT_CAPACITY_MIN} 이상 ${AGIT_DEFAULT_MAX_CAPACITY} 이하여야 합니다.`,
+    };
+  }
+
+  const nickname = asTrimmedString(input.nickname);
+  if (!AGIT_NICKNAME_PATTERN.test(nickname)) {
+    return {
+      ok: false,
+      error: `닉네임은 영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자이며, 특수문자와 공백을 사용할 수 없습니다.`,
+    };
+  }
+
+  const thumbnailPath = asOptionalPath(input.thumbnailPath);
+  const profileImagePath = asOptionalPath(input.profileImagePath);
+
+  return {
+    ok: true,
+    data: {
+      agitName,
+      ...(description ? { description } : {}),
+      maximumCapacity,
+      nickname,
+      ...(thumbnailPath ? { thumbnailPath } : {}),
+      ...(profileImagePath ? { profileImagePath } : {}),
+    },
+  };
+}

--- a/types/agit/ui.ts
+++ b/types/agit/ui.ts
@@ -5,6 +5,22 @@ export type UiMyAgit = {
   name: string;
 };
 
+export type UiCreateAgitDraft = {
+  title: string;
+  intro: string;
+  capacity: number;
+  thumbnailPath?: string;
+};
+
+export type UiCreateAgitInput = {
+  agitName: string;
+  description?: string;
+  maximumCapacity: number;
+  nickname: string;
+  thumbnailPath?: string;
+  profileImagePath?: string;
+};
+
 export type UiAgit = {
   id: string;
   name: string;


### PR DESCRIPTION
## 작업 내용

아지트 만들기 플로우를 mock 이동에서 `POST /api/v1/agits` 연동으로 바꿨습니다.
Gateway + JWT 액터로 생성하고, 성공 시 실제 `agitUuid`의 참여 완료 화면으로 이동합니다.
입력 검증(제목 20자, 소개 100자, 정원 기본 상한 5, 닉네임 규칙)은 아지트 API 스펙에 맞췄습니다.

## 관련 이슈

Close #40

## 변경 사항

### 1. 아지트 생성 API 클라이언트·타입·검증

- **파일:** `config/api-endpoints.ts`, `types/agit/api.ts`, `types/agit/schema.ts`, `types/agit/ui.ts`, `lib/api/agitApi.ts`
- **설명:** 생성 엔드포인트와 요청/응답 DTO를 추가하고, 제목·소개·정원·닉네임 규칙을 파싱합니다.

```typescript
export async function createAgit(body: ApiCreateAgitRequest): Promise<ApiCreateAgitResponse> {
  return withAuthRetry(async () =>
    apiFetch<ApiCreateAgitResponse>(API_ENDPOINTS.agit.create, {
      method: "POST",
      baseUrl: getApiUrl(),
      headers: await getActorUserHeaders(),
      body,
    }),
  );
}
```

### 2. Server Action 및 Service 매핑

- **파일:** `actions/agitActions.ts`, `services/agitService.ts`
- **설명:** 클라이언트는 Action만 호출하고, Service에서 API DTO를 UI 모델로 변환합니다.

```typescript
export async function createAgitAction(
  input: UiCreateAgitInput,
): Promise<ActionResult<UiAgit>> {
  const parsed = parseCreateAgitInput(input);
  if (!parsed.ok) {
    return actionFailure(parsed.error);
  }
  try {
    const agit = await agitService.createAgit(parsed.data);
    return actionSuccess(agit);
  } catch (error) {
    return toActionError(error);
  }
}
```

### 3. 만들기 플로우 UI 연동

- **파일:** `components/organisms/CreateRoomBasicForm.tsx`, `components/organisms/CreateRoomAccessForm.tsx`, `lib/agit/createRoomDraft.ts`, `components/molecules/AuthField.tsx`
- **설명:** 1단계 초안을 sessionStorage에 저장하고, 2단계에서 닉네임과 함께 생성 API를 호출합니다. 성공 시 mock `azit-walk` 대신 실제 UUID로 이동합니다.

```tsx
const result = await createAgitAction({
  agitName: draft.title,
  description: draft.intro,
  maximumCapacity: draft.capacity,
  nickname: String(formData.get("nickname") ?? ""),
  thumbnailPath: draft.thumbnailPath,
});
if (!result.ok) {
  setError(result.error);
  return;
}
sessionStorage.removeItem(CREATE_ROOM_DRAFT_KEY);
router.push(ROUTES.agit.joined(result.data.id));
```

### 4. 참여 완료 화면을 상세 API로 조회

- **파일:** `app/(agit)/agit/[agitId]/joined/page.tsx`, `components/templates/RoomFlowTemplates.tsx`
- **설명:** mock 목록 대신 `getAgit` 결과를 보여 주고, 생성한 방장 닉네임을 완료 화면에 넘깁니다.

```tsx
try {
  agit = await getAgit(agitId);
} catch (caught) {
  if (caught instanceof ApiError && (caught.status === 403 || caught.status === 404)) {
    agit = null;
  } else {
    error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
  }
}
return <JoinCompleteTemplate agit={agit} error={error} />;
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] `/agit/create` → 설정에서 아지트 생성
  - [x] 성공 시 `/agit/{uuid}/joined` 이동 후 목록에 노출

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인
