### PR TITLE
[#42] Feature : 아지트 목록·세부메뉴 UI 다듬기

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5638,11 +5638,6 @@ button.plip-bottom-nav__item {
   box-shadow: 0 8px 24px rgba(23, 23, 28, 0.04);
 }
 
-.dl-azit-card--active {
-  border-color: rgba(123, 92, 250, 0.28);
-  background: linear-gradient(180deg, rgba(247, 244, 255, 0.72), rgba(255, 255, 255, 1));
-}
-
 .dl-azit-card__main {
   display: flex;
   min-width: 0;
@@ -5668,30 +5663,9 @@ button.plip-bottom-nav__item {
   object-fit: cover;
 }
 
-.dl-azit-card__cover-badge {
-  position: absolute;
-  right: 4px;
-  bottom: 4px;
-  min-width: 18px;
-  padding: 2px 5px;
-  border-radius: 999px;
-  background: rgba(23, 23, 28, 0.72);
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1.2;
-  color: #fff;
-  text-align: center;
-}
-
 .dl-azit-card__body {
   min-width: 0;
   flex: 1;
-}
-
-.dl-azit-card__title-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .dl-azit-card__name {
@@ -5705,16 +5679,6 @@ button.plip-bottom-nav__item {
   white-space: nowrap;
 }
 
-.dl-azit-card__visibility {
-  flex-shrink: 0;
-  padding: 3px 7px;
-  border-radius: 999px;
-  background: var(--dl-color-bg-surface);
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--dl-color-text-secondary);
-}
-
 .dl-azit-card__topic {
   margin: 4px 0 0;
   overflow: hidden;
@@ -5725,26 +5689,10 @@ button.plip-bottom-nav__item {
   white-space: nowrap;
 }
 
-.dl-azit-card__meta-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  margin-top: 6px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--dl-color-text-secondary);
-}
-
-.dl-azit-card__meta--hot {
-  color: var(--dl-color-text-brand);
-  font-weight: 600;
-}
-
 .dl-azit-card__actions {
   display: flex;
   flex-shrink: 0;
-  flex-direction: column;
+  flex-direction: row;
   gap: 8px;
 }
 
@@ -6867,6 +6815,36 @@ button.plip-bottom-nav__item {
   font-size: 14px;
   font-weight: 600;
   text-decoration: none !important;
+}
+
+.dl-drawer__invite-row {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid #e3e0ed;
+  border-radius: 14px;
+  background: #fff;
+}
+
+.dl-drawer__invite-body {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 14px;
+}
+
+.dl-drawer__invite-code {
+  margin: 0;
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #262433;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* v1.4 · Compact Calendar */

--- a/components/molecules/AgitListRow.tsx
+++ b/components/molecules/AgitListRow.tsx
@@ -7,33 +7,18 @@ type AgitListRowProps = {
   agit: UiAgit;
 };
 
-function visibilityLabel(visibility?: UiAgit["visibility"]) {
-  return visibility === "private" ? "비공개" : "공개";
-}
-
 export function AgitListRow({ agit }: AgitListRowProps) {
-  const videoCount = agit.todayVideoCount ?? 0;
-  const memberLabel = agit.maxMembers ? `${agit.memberCount}/${agit.maxMembers}명` : `${agit.memberCount}명`;
-
   return (
-    <article className={`dl-azit-card${videoCount > 0 ? " dl-azit-card--active" : ""}`}>
+    <article className="dl-azit-card">
       <TextLink href={ROUTES.agit.detail(agit.id)} className="dl-azit-card__main no-underline">
         <div className="dl-azit-card__cover" style={{ background: agit.coverGradient }}>
           {agit.thumbnailSrc ? (
             <Image src={agit.thumbnailSrc} alt="" width={56} height={56} className="dl-azit-card__cover-img" />
           ) : null}
-          {videoCount > 0 ? (
-            <span className="dl-azit-card__cover-badge" aria-hidden>
-              {videoCount}
-            </span>
-          ) : null}
         </div>
 
         <div className="dl-azit-card__body">
-          <div className="dl-azit-card__title-row">
-            <p className="dl-azit-card__name">{agit.name}</p>
-            <span className="dl-azit-card__visibility">{visibilityLabel(agit.visibility)}</span>
-          </div>
+          <p className="dl-azit-card__name">{agit.name}</p>
           {agit.topicSummary ? (
             <p className="dl-azit-card__topic">
               {agit.topicSummary.startsWith("#")
@@ -41,13 +26,6 @@ export function AgitListRow({ agit }: AgitListRowProps) {
                 : `#${agit.topicSummary.replace(/\s+/g, "_")}`}
             </p>
           ) : null}
-          <div className="dl-azit-card__meta-row">
-            <span>{memberLabel}</span>
-            <span aria-hidden>·</span>
-            <span className={videoCount > 0 ? "dl-azit-card__meta--hot" : ""}>
-              오늘 {videoCount}개 영상
-            </span>
-          </div>
         </div>
       </TextLink>
 

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -4,6 +4,7 @@ import { DailyIcon, SubmitButton, TextLink } from "@/components/atoms";
 import { useOverlayTransition } from "@/hooks/useOverlayTransition";
 import { ROUTES } from "@/config/routes";
 import type { UiAgit } from "@/types/agit/ui";
+import { useState } from "react";
 
 type AgitMenuDrawerProps = {
   agit: UiAgit;
@@ -15,12 +16,22 @@ const MENU = [
   { id: "chat", label: "채팅", icon: "message" as const, href: (id: string) => ROUTES.agit.chat(id) },
   { id: "calendar", label: "캘린더", icon: "calendar" as const, href: (id: string) => ROUTES.agit.calendar(id) },
   { id: "members", label: "멤버 관리", icon: "users" as const, href: (id: string) => ROUTES.agit.members(id) },
-  { id: "invite", label: "초대 링크 복사", icon: "link" as const, href: (id: string) => ROUTES.agit.invite(id) },
   { id: "settings", label: "방 설정", icon: "usersBrand" as const, href: (id: string) => ROUTES.agit.manage(id) },
 ];
 
 export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
   const { mounted, visible } = useOverlayTransition(open);
+  const [copied, setCopied] = useState(false);
+
+  async function copyInviteCode() {
+    if (!agit.inviteCode) return;
+    try {
+      await navigator.clipboard.writeText(agit.inviteCode);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }
 
   if (!mounted) return null;
 
@@ -38,7 +49,7 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
         aria-hidden={!visible}
       >
         <div className="dl-drawer__header">
-          <h2 className="dl-drawer__title">아지트 메뉴</h2>
+          <h2 className="dl-drawer__title">{agit.name}</h2>
           <button type="button" className="dl-icon-sq" aria-label="닫기" onClick={onClose}>
             <DailyIcon name="x" size={20} />
           </button>
@@ -51,6 +62,18 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
             {agit.maxMembers ? `/${agit.maxMembers}` : ""}명 · 방장 {agit.ownerName ?? "안지민"}
           </p>
         </div>
+
+        {agit.inviteCode ? (
+          <div className="dl-drawer__invite-row">
+            <div className="dl-drawer__invite-body">
+              <DailyIcon name="link" size={24} />
+              <p className="dl-drawer__invite-code">{agit.inviteCode}</p>
+            </div>
+            <button type="button" className="dl-badge" onClick={copyInviteCode}>
+              {copied ? "복사됨" : "복사"}
+            </button>
+          </div>
+        ) : null}
 
         {MENU.map((item) => (
           <TextLink key={item.id} href={item.href(agit.id)} className="dl-drawer__menu-row" onClick={onClose}>

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -27,6 +27,7 @@ function mapAgitDetail(item: ApiAgitDetail): UiAgit {
     maxMembers: item.maximumCapacity,
     ownerName: item.hostNickname,
     thumbnailSrc: item.thumbnailPath ?? undefined,
+    inviteCode: item.code,
     joined: true,
   };
 }
@@ -52,6 +53,7 @@ function mapCreatedAgit(item: ApiCreateAgitResponse): UiAgit {
     maxMembers: item.maximumCapacity,
     ownerName: item.nickname,
     thumbnailSrc: item.thumbnailPath ?? undefined,
+    inviteCode: item.code,
     joined: true,
   };
 }

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -29,6 +29,7 @@ export type ApiAgitDetail = {
   currentMemberCount: number;
   hostNickname: string;
   myRole: ApiAgitMemberRole;
+  code?: string;
   members: ApiAgitDetailMember[];
   topics: ApiAgitDetailTopic[];
 };

--- a/types/agit/ui.ts
+++ b/types/agit/ui.ts
@@ -36,6 +36,7 @@ export type UiAgit = {
   videoCount?: number;
   topicSummary?: string;
   thumbnailSrc?: string;
+  inviteCode?: string;
   joined?: boolean;
   hasNewChat?: boolean;
   hasTodayTopic?: boolean;


### PR DESCRIPTION
## 작업 내용

아지트 목록 카드를 얇게 다듬고, 세부 메뉴에 아지트 제목과 초대코드를 보여 바로 복사할 수 있게 했습니다. 초대코드는 별도 재발급 API가 아니라 아지트 진입 시 조회하는 상세 응답의 `code`를 사용합니다. 상세 GET에 `code`가 없으면 초대코드 행은 숨깁니다.

## 관련 이슈

Close #42

## 변경 사항

### 1. 아지트 상세 초대코드를 UI 모델에 연결

- **파일:** `types/agit/api.ts`, `types/agit/ui.ts`, `services/agitService.ts`
- **설명:** 상세·생성 응답의 `code`를 `UiAgit.inviteCode`로 매핑한다.

```typescript
function mapAgitDetail(item: ApiAgitDetail): UiAgit {
  return {
    id: item.agitUuid,
    name: item.agitName,
    // ...
    inviteCode: item.code,
    joined: true,
  };
}
```

### 2. 아지트 목록 카드 UI 정리

- **파일:** `components/molecules/AgitListRow.tsx`, `app/globals.css`
- **설명:** 메시지·카메라 아이콘을 한 줄로 두고, 공개 뱃지·인원·오늘 영상 수 표시를 제거한다.

```tsx
<article className="dl-azit-card">
  <TextLink href={ROUTES.agit.detail(agit.id)} className="dl-azit-card__main no-underline">
    <div className="dl-azit-card__cover" style={{ background: agit.coverGradient }}>
      {agit.thumbnailSrc ? (
        <Image src={agit.thumbnailSrc} alt="" width={56} height={56} className="dl-azit-card__cover-img" />
      ) : null}
    </div>
    <div className="dl-azit-card__body">
      <p className="dl-azit-card__name">{agit.name}</p>
```

### 3. 세부 메뉴에 제목과 초대코드 복사

- **파일:** `components/organisms/AgitMenuDrawer.tsx`, `app/globals.css`
- **설명:** 드로어 제목을 아지트 이름으로 바꾸고, 초대 링크 이동 행 대신 코드를 표시하고 클립보드에 복사한다.

```tsx
<h2 className="dl-drawer__title">{agit.name}</h2>
{agit.inviteCode ? (
  <div className="dl-drawer__invite-row">
    <div className="dl-drawer__invite-body">
      <DailyIcon name="link" size={24} />
      <p className="dl-drawer__invite-code">{agit.inviteCode}</p>
    </div>
    <button type="button" className="dl-badge" onClick={copyInviteCode}>
      {copied ? "복사됨" : "복사"}
    </button>
  </div>
) : null}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인
