### PR TITLE
[#49] Feature : 다이어리 테마 CRUD UI API 연동

### DIFF
--- a/actions/diaryActions.ts
+++ b/actions/diaryActions.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { ApiError } from "@/lib/api/apiFetch";
+import * as diaryService from "@/services/diaryService";
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import { parseThemeId, parseThemeName } from "@/types/diary/schema";
+import type { UiDiaryTheme } from "@/types/diary/ui";
+
+function toActionError(error: unknown): ActionResult<never> {
+  if (error instanceof ApiError) {
+    return actionFailure(`[${error.status}] ${error.message}`);
+  }
+  if (error instanceof Error) {
+    return actionFailure(error.message);
+  }
+  return actionFailure("Unknown error");
+}
+
+export async function createThemeAction(themeName: unknown): Promise<ActionResult<UiDiaryTheme>> {
+  const parsed = parseThemeName(themeName);
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    const theme = await diaryService.createDiaryTheme(parsed.data);
+    return actionSuccess(theme);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function updateThemeNameAction(
+  themeId: unknown,
+  themeName: unknown,
+): Promise<ActionResult<UiDiaryTheme>> {
+  const parsedId = parseThemeId(themeId);
+  if (!parsedId.ok) {
+    return actionFailure(parsedId.error);
+  }
+
+  const parsedName = parseThemeName(themeName);
+  if (!parsedName.ok) {
+    return actionFailure(parsedName.error);
+  }
+
+  try {
+    const theme = await diaryService.updateDiaryThemeName(parsedId.data, parsedName.data);
+    return actionSuccess(theme);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function deleteThemeAction(themeId: unknown): Promise<ActionResult<void>> {
+  const parsedId = parseThemeId(themeId);
+  if (!parsedId.ok) {
+    return actionFailure(parsedId.error);
+  }
+
+  try {
+    await diaryService.deleteDiaryTheme(parsedId.data);
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}

--- a/app/(diary)/diary/themes/page.tsx
+++ b/app/(diary)/diary/themes/page.tsx
@@ -1,5 +1,17 @@
 import { DiaryThemesTemplate } from "@/components/templates";
+import { listDiaryThemes } from "@/services/diaryService";
+import type { UiDiaryTheme } from "@/types/diary/ui";
 
-export default function DiaryThemesPage() {
-  return <DiaryThemesTemplate />;
+export default async function DiaryThemesPage() {
+  let themes: UiDiaryTheme[] = [];
+  let error: string | undefined;
+
+  try {
+    themes = await listDiaryThemes();
+  } catch (caught) {
+    themes = [];
+    error = caught instanceof Error ? caught.message : "테마 목록을 불러오지 못했습니다.";
+  }
+
+  return <DiaryThemesTemplate themes={themes} error={error} />;
 }

--- a/components/organisms/CreateThemeDialog.tsx
+++ b/components/organisms/CreateThemeDialog.tsx
@@ -1,43 +1,101 @@
 "use client";
 
+import { createThemeAction, updateThemeNameAction } from "@/actions/diaryActions";
 import { Input, Label, SubmitButton } from "@/components/atoms";
 import { AnimatedDialog } from "@/components/molecules/AnimatedOverlays";
+import type { UiDiaryTheme } from "@/types/diary/ui";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 type CreateThemeDialogProps = {
   open: boolean;
   onClose: () => void;
+  theme?: UiDiaryTheme | null;
 };
 
-export function CreateThemeDialog({ open, onClose }: CreateThemeDialogProps) {
+const dialogActionClassName =
+  "inline-flex items-center justify-center gap-[0.5rem] border border-[var(--dc-glass-border)] rounded-[var(--dc-btn-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px] p-[0.4rem_1rem] text-[0.8125rem] font-medium leading-[1.25rem] !text-[var(--dc-fg-primary)] !no-underline w-auto";
+
+export function CreateThemeDialog({ open, onClose, theme = null }: CreateThemeDialogProps) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isEdit = theme !== null;
+  const titleId = isEdit ? "edit-theme-title" : "create-theme-title";
+
+  function handleClose() {
+    if (pending) {
+      return;
+    }
+    setError(null);
+    onClose();
+  }
+
+  async function handleSubmit(formData: FormData) {
+    if (pending) {
+      return;
+    }
+
+    setError(null);
+    setPending(true);
+
+    const result = isEdit
+      ? await updateThemeNameAction(theme.id, formData.get("themeName"))
+      : await createThemeAction(formData.get("themeName"));
+
+    setPending(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    router.refresh();
+    handleClose();
+  }
+
   return (
-    <AnimatedDialog open={open} onClose={onClose} labelledBy="create-theme-title" className="w-[min(420px,_calc(100vw_-_2rem))] p-[1.25rem] border border-[var(--dc-glass-border)] rounded-[var(--dc-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow-card)] backdrop-blur-[20px]">
+    <AnimatedDialog
+      open={open}
+      onClose={handleClose}
+      labelledBy={titleId}
+      className="w-[min(420px,_calc(100vw_-_2rem))] p-[1.25rem] border border-[var(--dc-glass-border)] rounded-[var(--dc-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow-card)] backdrop-blur-[20px]"
+    >
       <div className="mb-4 flex items-start justify-between gap-3">
-        <h2 id="create-theme-title" className="text-base font-extrabold text-[#111]">
-          테마 생성
+        <h2 id={titleId} className="text-base font-extrabold text-[#111]">
+          {isEdit ? "테마 수정" : "테마 생성"}
         </h2>
-        <button type="button" aria-label="닫기" className="text-sm font-bold text-black/45" onClick={onClose}>
+        <button type="button" aria-label="닫기" className="text-sm font-bold text-black/45" onClick={handleClose}>
           ✕
         </button>
       </div>
 
-      <form
-        className="flex flex-col gap-4"
-        onSubmit={(event) => {
-          event.preventDefault();
-          onClose();
-        }}
-      >
+      <form key={theme?.id ?? "create"} className="flex flex-col gap-4" action={handleSubmit}>
         <div className="flex flex-col gap-2">
           <Label htmlFor="theme-name">이름</Label>
-          <Input id="theme-name" name="themeName" placeholder="테마 이름" required />
+          <Input
+            id="theme-name"
+            name="themeName"
+            placeholder="테마 이름"
+            defaultValue={theme?.name ?? ""}
+            required
+            disabled={pending}
+          />
         </div>
 
+        {error ? <p className="m-0 text-sm text-red-600">{error}</p> : null}
+
         <div className="flex justify-end gap-2">
-          <SubmitButton type="button" className="inline-flex items-center justify-center gap-[0.5rem] border border-[var(--dc-glass-border)] rounded-[var(--dc-btn-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px] p-[0.4rem_1rem] text-[0.8125rem] font-medium leading-[1.25rem] !text-[var(--dc-fg-primary)] !no-underline w-auto" onClick={onClose}>
+          <SubmitButton
+            type="button"
+            className={dialogActionClassName}
+            onClick={handleClose}
+            disabled={pending}
+          >
             취소
           </SubmitButton>
-          <SubmitButton type="submit" className="inline-flex items-center justify-center gap-[0.5rem] border border-[var(--dc-glass-border)] rounded-[var(--dc-btn-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px] p-[0.4rem_1rem] text-[0.8125rem] font-medium leading-[1.25rem] !text-[var(--dc-fg-primary)] !no-underline w-auto">
-            생성
+          <SubmitButton type="submit" className={dialogActionClassName} disabled={pending}>
+            {isEdit ? "수정" : "생성"}
           </SubmitButton>
         </div>
       </form>

--- a/components/organisms/DiarySideMenu.tsx
+++ b/components/organisms/DiarySideMenu.tsx
@@ -3,12 +3,13 @@
 import { Separator, TextLink } from "@/components/atoms";
 import { AnimatedSideSheet } from "@/components/molecules/AnimatedOverlays";
 import { DiaryMenuLink } from "@/components/organisms/DiaryHeader";
-import { DIARY_THEMES } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiDiaryTheme } from "@/types/diary/ui";
 
 type DiarySideMenuProps = {
   open: boolean;
   onClose: () => void;
+  themes: UiDiaryTheme[];
 };
 
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] as const;
@@ -32,7 +33,7 @@ function buildAugust2026Days() {
   return cells;
 }
 
-export function DiarySideMenu({ open, onClose }: DiarySideMenuProps) {
+export function DiarySideMenu({ open, onClose, themes }: DiarySideMenuProps) {
   const cells = buildAugust2026Days();
 
   return (
@@ -49,7 +50,7 @@ export function DiarySideMenu({ open, onClose }: DiarySideMenuProps) {
 
       <p className="m-[0.15rem_0_0] text-[rgba(0,_0,_0,_0.4)] text-[0.72rem] font-extrabold tracking-[0.06em] uppercase">Themes</p>
       <div className="flex flex-col">
-        {DIARY_THEMES.map((theme) => (
+        {themes.map((theme) => (
           <DiaryMenuLink key={theme.id} href={ROUTES.diary.themes.detail(theme.id)}>
             {theme.name}
           </DiaryMenuLink>

--- a/components/organisms/DiaryThemesListSection.tsx
+++ b/components/organisms/DiaryThemesListSection.tsx
@@ -1,14 +1,155 @@
 "use client";
 import leftoverStyles from "@/components/styles/leftover.module.css";
 
+import { deleteThemeAction } from "@/actions/diaryActions";
 import { TextLink } from "@/components/atoms";
+import { AnimatedDropdown } from "@/components/molecules/AnimatedOverlays";
 import { CreateThemeDialog } from "@/components/organisms/CreateThemeDialog";
-import { DIARY_THEMES } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
-import { useState } from "react";
+import type { UiDiaryTheme } from "@/types/diary/ui";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 
-export function DiaryThemesListSection() {
+type DiaryThemesListSectionProps = {
+  themes: UiDiaryTheme[];
+  error?: string;
+};
+
+type ThemeCardMenuProps = {
+  theme: UiDiaryTheme;
+  open: boolean;
+  pending: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+function ThemeCardMenu({
+  theme,
+  open,
+  pending,
+  onToggle,
+  onClose,
+  onEdit,
+  onDelete,
+}: ThemeCardMenuProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onPointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("mousedown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("mousedown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div ref={rootRef} className="absolute top-[0.35rem] right-[0.35rem] z-20">
+      <button
+        type="button"
+        className="grid place-items-center w-[1.5rem] h-[1.5rem] border-0 rounded-[999px] bg-[rgba(0,_0,_0,_0.45)] text-[#fff] text-[0.85rem] font-extrabold leading-none cursor-pointer disabled:opacity-50"
+        aria-label={`${theme.name} 테마 메뉴`}
+        aria-expanded={open}
+        disabled={pending}
+        onClick={onToggle}
+      >
+        ···
+      </button>
+
+      <AnimatedDropdown
+        open={open}
+        role="menu"
+        aria-label={`${theme.name} 테마 옵션`}
+        className="absolute top-[calc(100%+0.25rem)] right-0 min-w-[5.5rem] rounded-md border border-black/10 bg-white p-1 shadow-md"
+      >
+        <button
+          type="button"
+          role="menuitem"
+          className="block w-full rounded px-3 py-2 text-left text-sm font-semibold text-[#111]"
+          onClick={onEdit}
+        >
+          수정
+        </button>
+        <button
+          type="button"
+          role="menuitem"
+          className="block w-full rounded px-3 py-2 text-left text-sm font-semibold text-red-600"
+          onClick={onDelete}
+        >
+          삭제
+        </button>
+      </AnimatedDropdown>
+    </div>
+  );
+}
+
+export function DiaryThemesListSection({ themes, error: fetchError }: DiaryThemesListSectionProps) {
+  const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTheme, setEditingTheme] = useState<UiDiaryTheme | null>(null);
+  const [openMenuThemeId, setOpenMenuThemeId] = useState<string | null>(null);
+  const [pendingThemeId, setPendingThemeId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function openCreateDialog() {
+    setEditingTheme(null);
+    setDialogOpen(true);
+  }
+
+  function openEditDialog(theme: UiDiaryTheme) {
+    setOpenMenuThemeId(null);
+    setEditingTheme(theme);
+    setDialogOpen(true);
+  }
+
+  function closeDialog() {
+    setDialogOpen(false);
+    setEditingTheme(null);
+  }
+
+  async function handleDelete(theme: UiDiaryTheme) {
+    if (pendingThemeId) {
+      return;
+    }
+
+    setOpenMenuThemeId(null);
+
+    if (!window.confirm(`"${theme.name}" 테마를 삭제할까요?`)) {
+      return;
+    }
+
+    setError(null);
+    setPendingThemeId(theme.id);
+
+    const result = await deleteThemeAction(theme.id);
+    setPendingThemeId(null);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    router.refresh();
+  }
 
   return (
     <>
@@ -18,14 +159,18 @@ export function DiaryThemesListSection() {
           <button
             type="button"
             className="border border-[var(--dc-glass-border)] rounded-[var(--dc-btn-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px] p-[0.4rem_0.85rem] text-[var(--dc-fg-primary)] text-[0.8rem] font-medium cursor-pointer"
-            onClick={() => setDialogOpen(true)}
+            onClick={openCreateDialog}
           >
             생성
           </button>
         </div>
 
+        {fetchError || error ? (
+          <p className="m-0 px-1 text-sm text-red-600">{fetchError ?? error}</p>
+        ) : null}
+
         <div className="grid grid-cols-[repeat(3,_minmax(0,_1fr))] gap-[0.85rem_0.35rem] bg-[transparent]">
-          {DIARY_THEMES.map((theme, index) => (
+          {themes.map((theme, index) => (
             <div key={theme.id} className="relative m-0">
               <TextLink
                 href={ROUTES.diary.themes.detail(theme.id)}
@@ -37,21 +182,23 @@ export function DiaryThemesListSection() {
                 />
                 <span className="text-[0.78rem] font-bold">{theme.name}</span>
               </TextLink>
-              {index === 0 ? (
-                <button
-                  type="button"
-                  className="absolute top-[0.35rem] right-[0.35rem] z-20 grid place-items-center w-[1.5rem] h-[1.5rem] border-0 rounded-[999px] bg-[rgba(0,_0,_0,_0.45)] text-[#fff] text-[0.85rem] font-extrabold leading-none cursor-pointer"
-                  aria-label={`${theme.name} 테마 삭제`}
-                >
-                  ···
-                </button>
-              ) : null}
+              <ThemeCardMenu
+                theme={theme}
+                open={openMenuThemeId === theme.id}
+                pending={pendingThemeId === theme.id}
+                onToggle={() =>
+                  setOpenMenuThemeId((current) => (current === theme.id ? null : theme.id))
+                }
+                onClose={() => setOpenMenuThemeId(null)}
+                onEdit={() => openEditDialog(theme)}
+                onDelete={() => handleDelete(theme)}
+              />
             </div>
           ))}
         </div>
       </div>
 
-      <CreateThemeDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+      <CreateThemeDialog open={dialogOpen} onClose={closeDialog} theme={editingTheme} />
     </>
   );
 }

--- a/components/templates/DiaryThemesTemplate.tsx
+++ b/components/templates/DiaryThemesTemplate.tsx
@@ -1,10 +1,16 @@
 import { DiaryThemesListSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
+import type { UiDiaryTheme } from "@/types/diary/ui";
 
-export function DiaryThemesTemplate() {
+type DiaryThemesTemplateProps = {
+  themes: UiDiaryTheme[];
+  error?: string;
+};
+
+export function DiaryThemesTemplate({ themes, error }: DiaryThemesTemplateProps) {
   return (
     <DiaryTemplate>
-      <DiaryThemesListSection />
+      <DiaryThemesListSection themes={themes} error={error} />
     </DiaryTemplate>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -29,6 +29,19 @@ export const API_ENDPOINTS = {
     me: gatewayPath("agit", "/api/v1/agits/me"),
     detail: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}`),
   },
+  diary: {
+    themes: gatewayPath("diary", "/api/v1/diaries/themes"),
+    themeDetail: (themeId: string) => gatewayPath("diary", `/api/v1/diaries/themes/${themeId}`),
+    home: gatewayPath("diary", "/api/v1/diaries/home"),
+    calendar: gatewayPath("diary", "/api/v1/diaries/calendar"),
+    dateDetail: (date: string) => gatewayPath("diary", `/api/v1/diaries/dates/${date}`),
+    themeTimeline: (themeId: string) =>
+      gatewayPath("diary", `/api/v1/diaries/themes/${themeId}/timeline`),
+    videoTopicTransfer: (diaryVideoId: string) =>
+      gatewayPath("diary", `/api/v1/diaries/videos/${diaryVideoId}/topic-transfer`),
+    videoUnbind: (diaryVideoId: string) =>
+      gatewayPath("diary", `/api/v1/diaries/videos/${diaryVideoId}`),
+  },
   video: {
     uploadUrl: "/api/videos/upload-url",
     complete: (videoUuid: string) => `/api/videos/${videoUuid}/complete` as const,

--- a/lib/api/diaryApi.ts
+++ b/lib/api/diaryApi.ts
@@ -9,6 +9,7 @@ import type {
   ApiDiaryDateResponse,
   ApiDiaryHomeResponse,
   ApiDiaryTheme,
+  ApiDiaryThemesResponse,
   ApiDiaryTimelineResponse,
   ApiDiaryTopicTransferRequest,
   ApiUpdateDiaryThemeNameRequest,
@@ -24,8 +25,8 @@ function diaryFetch<T>(path: string, options: Parameters<typeof apiFetch>[1] = {
   );
 }
 
-export async function getDiaryThemes(): Promise<ApiDiaryTheme[]> {
-  return diaryFetch<ApiDiaryTheme[]>(API_ENDPOINTS.diary.themes, { method: "GET" });
+export async function getDiaryThemes(): Promise<ApiDiaryThemesResponse> {
+  return diaryFetch<ApiDiaryThemesResponse>(API_ENDPOINTS.diary.themes, { method: "GET" });
 }
 
 export async function getDiaryTheme(themeId: string): Promise<ApiDiaryTheme> {

--- a/lib/api/diaryApi.ts
+++ b/lib/api/diaryApi.ts
@@ -1,0 +1,95 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { getActorUserHeaders } from "@/lib/api/actorHeaders";
+import { apiFetch } from "@/lib/api/apiFetch";
+import { getApiUrl } from "@/lib/api/env";
+import { withAuthRetry } from "@/lib/api/withAuthRetry";
+import type {
+  ApiCreateDiaryThemeRequest,
+  ApiDiaryCalendarResponse,
+  ApiDiaryDateResponse,
+  ApiDiaryHomeResponse,
+  ApiDiaryTheme,
+  ApiDiaryTimelineResponse,
+  ApiDiaryTopicTransferRequest,
+  ApiUpdateDiaryThemeNameRequest,
+} from "@/types/diary/api";
+
+function diaryFetch<T>(path: string, options: Parameters<typeof apiFetch>[1] = {}): Promise<T> {
+  return withAuthRetry(async () =>
+    apiFetch<T>(path, {
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      ...options,
+    }),
+  );
+}
+
+export async function getDiaryThemes(): Promise<ApiDiaryTheme[]> {
+  return diaryFetch<ApiDiaryTheme[]>(API_ENDPOINTS.diary.themes, { method: "GET" });
+}
+
+export async function getDiaryTheme(themeId: string): Promise<ApiDiaryTheme> {
+  return diaryFetch<ApiDiaryTheme>(API_ENDPOINTS.diary.themeDetail(themeId), { method: "GET" });
+}
+
+export async function createDiaryTheme(body: ApiCreateDiaryThemeRequest): Promise<ApiDiaryTheme> {
+  return diaryFetch<ApiDiaryTheme>(API_ENDPOINTS.diary.themes, {
+    method: "POST",
+    body,
+  });
+}
+
+export async function updateDiaryThemeName(
+  themeId: string,
+  body: ApiUpdateDiaryThemeNameRequest,
+): Promise<ApiDiaryTheme> {
+  return diaryFetch<ApiDiaryTheme>(API_ENDPOINTS.diary.themeDetail(themeId), {
+    method: "PATCH",
+    body,
+  });
+}
+
+export async function deleteDiaryTheme(themeId: string): Promise<void> {
+  await diaryFetch<void>(API_ENDPOINTS.diary.themeDetail(themeId), { method: "DELETE" });
+}
+
+export async function getDiaryHome(): Promise<ApiDiaryHomeResponse> {
+  return diaryFetch<ApiDiaryHomeResponse>(API_ENDPOINTS.diary.home, { method: "GET" });
+}
+
+export async function getDiaryCalendar(
+  year: number,
+  month: number,
+): Promise<ApiDiaryCalendarResponse> {
+  return diaryFetch<ApiDiaryCalendarResponse>(API_ENDPOINTS.diary.calendar, {
+    method: "GET",
+    searchParams: {
+      year: String(year),
+      month: String(month),
+    },
+  });
+}
+
+export async function getDiaryByDate(date: string): Promise<ApiDiaryDateResponse> {
+  return diaryFetch<ApiDiaryDateResponse>(API_ENDPOINTS.diary.dateDetail(date), { method: "GET" });
+}
+
+export async function getDiaryThemeTimeline(themeId: string): Promise<ApiDiaryTimelineResponse> {
+  return diaryFetch<ApiDiaryTimelineResponse>(API_ENDPOINTS.diary.themeTimeline(themeId), {
+    method: "GET",
+  });
+}
+
+export async function transferDiaryVideoTopic(
+  diaryVideoId: string,
+  body: ApiDiaryTopicTransferRequest,
+): Promise<void> {
+  await diaryFetch<void>(API_ENDPOINTS.diary.videoTopicTransfer(diaryVideoId), {
+    method: "POST",
+    body,
+  });
+}
+
+export async function unbindDiaryVideo(diaryVideoId: string): Promise<void> {
+  await diaryFetch<void>(API_ENDPOINTS.diary.videoUnbind(diaryVideoId), { method: "DELETE" });
+}

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -1,0 +1,157 @@
+import * as diaryApi from "@/lib/api/diaryApi";
+import type {
+  ApiDiaryDateResponse,
+  ApiDiaryDateThemeGroup,
+  ApiDiaryHomeItem,
+  ApiDiaryTheme,
+  ApiDiaryTimelineDateGroup,
+  ApiDiaryTimelineResponse,
+  ApiDiaryVideoSummary,
+} from "@/types/diary/api";
+import type {
+  UiDiaryClip,
+  UiDiaryDateEntry,
+  UiDiaryDateGroup,
+  UiDiaryDateThemeGroup,
+  UiDiaryTheme,
+  UiDiaryThemeDateGroup,
+} from "@/types/diary/ui";
+
+function mapTheme(theme: ApiDiaryTheme): UiDiaryTheme {
+  return {
+    id: theme.themeId,
+    name: theme.themeName,
+  };
+}
+
+function toOptionalThumbnail(path: string | null): string | undefined {
+  return path?.trim() ? path : undefined;
+}
+
+function mapVideoSummary(video: ApiDiaryVideoSummary, themeId: string, date: string): UiDiaryClip {
+  return {
+    id: video.diaryVideoId,
+    themeId,
+    date,
+    thumbnailSrc: toOptionalThumbnail(video.thumbnailPath),
+  };
+}
+
+function resolveRelativeLabel(date: string, today = new Date()): string | undefined {
+  const target = new Date(`${date}T12:00:00`);
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const targetStart = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  const diffDays = Math.round((todayStart.getTime() - targetStart.getTime()) / 86_400_000);
+
+  if (diffDays === 0) return "오늘";
+  if (diffDays === 1) return "어제";
+  if (diffDays === 2) return "그제";
+  return undefined;
+}
+
+function mapHomeItem(item: ApiDiaryHomeItem): UiDiaryDateEntry {
+  const thumbnailPaths = item.thumbnailPaths
+    .map((path) => toOptionalThumbnail(path))
+    .filter((path): path is string => Boolean(path));
+
+  return {
+    date: item.writtenDate,
+    relativeLabel: resolveRelativeLabel(item.writtenDate),
+    hasClips: item.hasVideos,
+    isEmpty: !item.hasVideos,
+    thumbnailPaths,
+  };
+}
+
+function mapDateThemeGroup(group: ApiDiaryDateThemeGroup, date: string): UiDiaryDateThemeGroup {
+  return {
+    themeId: group.themeId,
+    themeName: group.themeName,
+    clipCount: group.videos.length,
+    clips: group.videos.map((video) => mapVideoSummary(video, group.themeId, date)),
+  };
+}
+
+function mapTimelineDateGroup(group: ApiDiaryTimelineDateGroup, themeId: string): UiDiaryThemeDateGroup {
+  return {
+    date: group.writtenDate,
+    clipCount: group.videoCount,
+    clips: group.videos.map((video) => mapVideoSummary(video, themeId, group.writtenDate)),
+  };
+}
+
+function mapDateResponse(response: ApiDiaryDateResponse): UiDiaryDateGroup {
+  return {
+    date: response.writtenDate,
+    themes: response.themes.map((group) => mapDateThemeGroup(group, response.writtenDate)),
+  };
+}
+
+function mapTimelineResponse(response: ApiDiaryTimelineResponse): UiDiaryThemeDateGroup[] {
+  return response.dates.map((group) => mapTimelineDateGroup(group, response.themeId));
+}
+
+export async function listDiaryThemes(): Promise<UiDiaryTheme[]> {
+  const themes = await diaryApi.getDiaryThemes();
+  return themes.map(mapTheme);
+}
+
+export async function getDiaryTheme(themeId: string): Promise<UiDiaryTheme> {
+  const theme = await diaryApi.getDiaryTheme(themeId);
+  return mapTheme(theme);
+}
+
+export async function createDiaryTheme(themeName: string): Promise<UiDiaryTheme> {
+  const created = await diaryApi.createDiaryTheme({ themeName });
+  return mapTheme(created);
+}
+
+export async function updateDiaryThemeName(themeId: string, themeName: string): Promise<UiDiaryTheme> {
+  const updated = await diaryApi.updateDiaryThemeName(themeId, { themeName });
+  return mapTheme(updated);
+}
+
+export async function deleteDiaryTheme(themeId: string): Promise<void> {
+  await diaryApi.deleteDiaryTheme(themeId);
+}
+
+export async function getDiaryHomeFeed(): Promise<UiDiaryDateEntry[]> {
+  const response = await diaryApi.getDiaryHome();
+  return response.items.map(mapHomeItem);
+}
+
+export async function getDiaryCalendarDates(year: number, month: number): Promise<string[]> {
+  const response = await diaryApi.getDiaryCalendar(year, month);
+  return response.writtenDates;
+}
+
+export async function getDiaryDateGroup(date: string): Promise<UiDiaryDateGroup> {
+  const response = await diaryApi.getDiaryByDate(date);
+  return mapDateResponse(response);
+}
+
+export async function getDiaryThemeTimeline(themeId: string): Promise<{
+  theme: UiDiaryTheme;
+  dateGroups: UiDiaryThemeDateGroup[];
+}> {
+  const response = await diaryApi.getDiaryThemeTimeline(themeId);
+  return {
+    theme: {
+      id: response.themeId,
+      name: response.themeName,
+    },
+    dateGroups: mapTimelineResponse(response),
+  };
+}
+
+export async function transferDiaryVideoToTopic(
+  diaryVideoId: string,
+  topicId: string,
+  transferType: "COPY" | "MOVE",
+): Promise<void> {
+  await diaryApi.transferDiaryVideoTopic(diaryVideoId, { topicId, transferType });
+}
+
+export async function unbindDiaryVideo(diaryVideoId: string): Promise<void> {
+  await diaryApi.unbindDiaryVideo(diaryVideoId);
+}

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -19,8 +19,9 @@ import type {
 
 function mapTheme(theme: ApiDiaryTheme): UiDiaryTheme {
   return {
-    id: theme.themeId,
-    name: theme.themeName,
+    // 단건 PATCH/DELETE 경로는 numeric id 사용 (themeUuid 아님)
+    id: String(theme.id),
+    name: theme.name,
   };
 }
 
@@ -92,8 +93,8 @@ function mapTimelineResponse(response: ApiDiaryTimelineResponse): UiDiaryThemeDa
 }
 
 export async function listDiaryThemes(): Promise<UiDiaryTheme[]> {
-  const themes = await diaryApi.getDiaryThemes();
-  return themes.map(mapTheme);
+  const response = await diaryApi.getDiaryThemes();
+  return response.themes.map(mapTheme);
 }
 
 export async function getDiaryTheme(themeId: string): Promise<UiDiaryTheme> {
@@ -102,12 +103,12 @@ export async function getDiaryTheme(themeId: string): Promise<UiDiaryTheme> {
 }
 
 export async function createDiaryTheme(themeName: string): Promise<UiDiaryTheme> {
-  const created = await diaryApi.createDiaryTheme({ themeName });
+  const created = await diaryApi.createDiaryTheme({ name: themeName });
   return mapTheme(created);
 }
 
 export async function updateDiaryThemeName(themeId: string, themeName: string): Promise<UiDiaryTheme> {
-  const updated = await diaryApi.updateDiaryThemeName(themeId, { themeName });
+  const updated = await diaryApi.updateDiaryThemeName(themeId, { name: themeName });
   return mapTheme(updated);
 }
 

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -1,0 +1,63 @@
+/** Diary Service REST DTO */
+
+export type ApiDiaryTheme = {
+  themeId: string;
+  themeName: string;
+};
+
+export type ApiCreateDiaryThemeRequest = {
+  themeName: string;
+};
+
+export type ApiUpdateDiaryThemeNameRequest = {
+  themeName: string;
+};
+
+export type ApiDiaryVideoSummary = {
+  diaryVideoId: string;
+  thumbnailPath: string | null;
+};
+
+export type ApiDiaryHomeItem = {
+  writtenDate: string;
+  hasVideos: boolean;
+  thumbnailPaths: string[];
+};
+
+export type ApiDiaryHomeResponse = {
+  items: ApiDiaryHomeItem[];
+};
+
+export type ApiDiaryCalendarResponse = {
+  year: number;
+  month: number;
+  writtenDates: string[];
+};
+
+export type ApiDiaryDateThemeGroup = {
+  themeId: string;
+  themeName: string;
+  videos: ApiDiaryVideoSummary[];
+};
+
+export type ApiDiaryDateResponse = {
+  writtenDate: string;
+  themes: ApiDiaryDateThemeGroup[];
+};
+
+export type ApiDiaryTimelineDateGroup = {
+  writtenDate: string;
+  videoCount: number;
+  videos: ApiDiaryVideoSummary[];
+};
+
+export type ApiDiaryTimelineResponse = {
+  themeId: string;
+  themeName: string;
+  dates: ApiDiaryTimelineDateGroup[];
+};
+
+export type ApiDiaryTopicTransferRequest = {
+  topicId: string;
+  transferType: "COPY" | "MOVE";
+};

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -1,16 +1,23 @@
 /** Diary Service REST DTO */
 
 export type ApiDiaryTheme = {
-  themeId: string;
-  themeName: string;
+  id: number;
+  themeUuid: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ApiDiaryThemesResponse = {
+  themes: ApiDiaryTheme[];
 };
 
 export type ApiCreateDiaryThemeRequest = {
-  themeName: string;
+  name: string;
 };
 
 export type ApiUpdateDiaryThemeNameRequest = {
-  themeName: string;
+  name: string;
 };
 
 export type ApiDiaryVideoSummary = {

--- a/types/diary/schema.ts
+++ b/types/diary/schema.ts
@@ -1,0 +1,31 @@
+export const DIARY_THEME_NAME_MAX_LENGTH = 20;
+
+export type ThemeNameParseResult =
+  | { ok: true; data: string }
+  | { ok: false; error: string };
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function parseThemeName(value: unknown): ThemeNameParseResult {
+  const themeName = asTrimmedString(value);
+  if (!themeName) {
+    return { ok: false, error: "테마 이름은 필수입니다." };
+  }
+  if (themeName.length > DIARY_THEME_NAME_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `테마 이름은 ${DIARY_THEME_NAME_MAX_LENGTH}자 이하여야 합니다.`,
+    };
+  }
+  return { ok: true, data: themeName };
+}
+
+export function parseThemeId(value: unknown): ThemeNameParseResult {
+  const themeId = asTrimmedString(value);
+  if (!themeId) {
+    return { ok: false, error: "테마 ID가 올바르지 않습니다." };
+  }
+  return { ok: true, data: themeId };
+}

--- a/types/diary/ui.ts
+++ b/types/diary/ui.ts
@@ -1,14 +1,13 @@
-export type DiaryThemeId = "daily" | "exercise" | "cooking";
-
 export type UiDiaryTheme = {
-  id: DiaryThemeId;
+  id: string;
   name: string;
 };
 
 export type UiDiaryClip = {
   id: string;
-  themeId: DiaryThemeId;
+  themeId: string;
   date: string;
+  thumbnailSrc?: string;
 };
 
 export type UiDiaryDateEntry = {
@@ -16,12 +15,14 @@ export type UiDiaryDateEntry = {
   relativeLabel?: string;
   hasClips: boolean;
   isEmpty?: boolean;
+  thumbnailPaths?: string[];
 };
 
 export type UiDiaryDateThemeGroup = {
-  themeId: DiaryThemeId;
+  themeId: string;
   themeName: string;
   clipCount: number;
+  clips?: UiDiaryClip[];
 };
 
 export type UiDiaryDateGroup = {
@@ -32,4 +33,5 @@ export type UiDiaryDateGroup = {
 export type UiDiaryThemeDateGroup = {
   date: string;
   clipCount: number;
+  clips?: UiDiaryClip[];
 };


### PR DESCRIPTION
## 작업 내용

다이어리 테마 데이터 계층(endpoints · types · api · service) 구축.
`/diary/themes` 테마 CRUD UI API 연동(목록·생성·수정·삭제). Theme Swagger DTO 반영(`{ themes }` 래퍼, `{ name }` body, numeric id path). develop Tailwind·AnimatedOverlays 구조 유지.

## 관련 이슈

#49

## 변경 사항

### 1. 다이어리 API 데이터 계층

- **파일:** `config/api-endpoints.ts`, `types/diary/api.ts`, `lib/api/diaryApi.ts`, `services/diaryService.ts`
- **설명:** diary 9개 엔드포인트 HTTP·Service 스캐폴딩

### 2. 테마 CRUD UI API 연동

- **파일:** `actions/diaryActions.ts`, `types/diary/schema.ts`, `app/(diary)/diary/themes/page.tsx`, `DiaryThemesListSection`, `CreateThemeDialog`, `DiarySideMenu`
- **설명:** RSC 목록 fetch, Server Action 생성·수정·삭제, ··· 메뉴 연동

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `/diary/themes` 테마 목록·생성·수정·삭제 수동 확인

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인