### PR TITLE
[#50] Docs : 로컬 Caddy 프록시 실행 가이드 추가

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,15 +2,17 @@
 # 이 값을 .env.local 파일에 복사해 사용합니다.
 
 # --- API_URL ---
-# README.MD 참고해 해당 환경변수를 사용합니다.
+# README.MD 참고해 사용할 환경변수의 주석을 해제하세요.
 # baseUrl 끝에 /api/user 등 서비스 prefix를 붙이지 않습니다. 경로는 config/api-endpoints.ts에서 정의합니다.
 #
 # Gateway 경유 (develop 등, 기본/권장)
 # API_URL=http://192.168.10.144:8000
 #
 # 로컬 user-service 직접 호출 (Gateway 미사용)
-# 최종 URL 예: http://localhost:8080/api/v1/auth/login/social/naver
-API_URL=http://localhost:8080
+# 예: http://localhost:8080/api/user
+# API_URL=http://localhost:8080/api/{service}
+# 혹은 프록시를 사용할 경우 (LOCAL_CADDY.md 참고)
+# API_URL=http://localhost:8000
 
 # --- Actor (JWT 연동 전, X-User-Uuid) ---
 DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,54 @@
+# 로컬 개발 전용. 배포(Vercel)에서는 사용하지 않습니다.
+# 게이트웨이 path /api/{serviceId}/** → 서비스에서 /api/{serviceId} 제거 (StripPrefix=2)
+
+:8000 {
+	# user
+	handle_path /api/user/* {
+		reverse_proxy localhost:8080
+	}
+
+	# diary 다이어리
+	handle_path /api/diary/* {
+		reverse_proxy localhost:8081
+	}
+
+	# chat 채팅
+	handle_path /api/chat/* {
+		reverse_proxy localhost:8082
+	}
+
+	# agit 아지트
+	handle_path /api/agit/* {
+		reverse_proxy localhost:8083
+	}
+
+	# topic 토픽
+	handle_path /api/topic/* {
+		reverse_proxy localhost:8084
+	}
+
+	# video — 현재 프론트는 prefix 없이 /api/videos 로 직행
+	handle /api/videos/* {
+		reverse_proxy localhost:8085
+	}
+
+	# video — 게이트웨이형 /api/video/**
+	handle_path /api/video/* {
+		reverse_proxy localhost:8085
+	}
+
+	# point 포인트
+	handle_path /api/point/* {
+		reverse_proxy localhost:8086
+	}
+
+	# shop 가게
+	handle_path /api/shop/* {
+		reverse_proxy localhost:8087
+	}
+
+	# backoffice 백오피스
+	handle_path /api/backoffice/* {
+		reverse_proxy localhost:8088
+	}
+}

--- a/LOCAL_CADDY.md
+++ b/LOCAL_CADDY.md
@@ -1,0 +1,68 @@
+# 로컬 Caddy 프록시 (개발 전용)
+
+배포(Vercel)에서는 쓰지 않습니다. 팀 게이트웨이(`API_URL`)를 쓸 때도 필요 없습니다.
+
+## 1. 문제와 적용 시점
+
+프론트는 게이트웨이용 path를 씁니다. (`/api/agit/api/v1/...`)  
+`API_URL`은 호스트 하나라서, 로컬에서 user·agit를 **다른 포트**로 띄우면 요청이 한곳으로만 갑니다.  
+게이트웨이 없이 치면 path에서 `/api/agit`가 안 떨어져 서비스의 `/api/v1/...`과 안 맞습니다.
+
+이 프록시는 `:8000`에서 경로만 나눠 주고, `/api/{serviceId}`를 뗍니다. Next의 `API_URL=http://localhost:8000`은 그대로입니다.
+
+
+| 서비스        | 포트   | 게이트웨이 prefix                                 |
+| ---------- | ---- | -------------------------------------------- |
+| user       | 8080 | `/api/user`                                  |
+| diary      | 8081 | `/api/diary`                                 |
+| chat       | 8082 | `/api/chat`                                  |
+| agit       | 8083 | `/api/agit`                                  |
+| topic      | 8084 | `/api/topic`                                 |
+| video      | 8085 | `/api/video` (현재 앱 `/api/videos`는 prefix 유지) |
+| point      | 8086 | `/api/point`                                 |
+| shop       | 8087 | `/api/shop`                                  |
+| backoffice | 8088 | `/api/backoffice`                            |
+
+
+**이럴 때만 사용**
+
+- 로컬에서 게이트웨이 없이 **여러 서비스**를 직접 띄울 때
+- 프론트 path는 지금처럼 게이트웨이 형태를 유지하고 싶을 때
+
+팀 공유 게이트웨이에 붙으면 Caddy는 켜지 않습니다.
+
+## 2. 설치 (도커 없이)
+
+macOS:
+
+```bash
+brew install caddy
+```
+
+Windows:
+
+```bash
+winget install Caddy
+```
+
+또는 [Caddy 설치 문서](https://caddyserver.com/docs/install).
+
+도커로도 가능합니다. `Caddyfile`의 `localhost`는 컨테이너 기준이라, 호스트 서비스는 `host.docker.internal`로 바꿉니다. 기본은 도커 없이 `caddy run`입니다.
+
+## 3. 실행 순서
+
+필요한 로컬 서비스만 켜도 됩니다. 포트는 `Caddyfile`과 같아야 합니다.
+
+1. 사용할 서비스 실행 (예: user `:8080`, agit `:8083`)
+2. 프로젝트 루트에서 프록시 실행
+
+```bash
+caddy run
+```
+
+1. `.env.local`에 `API_URL=http://localhost:8000`
+2. `npm run dev` (Next `:3000`)
+
+끄기: 프록시 터미널에서 `Ctrl+C`.
+
+확인: `http://localhost:8000/api/agit/api/v1/agits/me` 로 요청이 agit의 `/api/v1/agits/me`로 전달되면 됩니다.


### PR DESCRIPTION
## 작업 내용

로컬에서 게이트웨이 없이 user·agit 등 여러 서비스를 띄우면 `API_URL`이 호스트 하나라 포트 분기가 안 되고, 게이트웨이 path(`/api/agit/...`)가 서비스 path와 맞지 않습니다. 개발 전용 Caddy 프록시로 `/api/{serviceId}`를 떼고 각 로컬 포트로 넘기도록 설정과 실행 가이드를 추가합니다. 배포(Vercel)와 팀 게이트웨이 사용 시에는 쓰지 않습니다.

## 관련 이슈

Close #50

## 변경 사항

### 1. 로컬 멀티 서비스 Caddy 프록시 설정

- **파일:** `Caddyfile`
- **설명:** `:8000`에서 서비스별 prefix를 제거하고 로컬 포트로 전달합니다. 비디오는 현재 앱 path(`/api/videos`)를 유지하는 핸들과 게이트웨이형(`/api/video`)을 함께 둡니다.

```caddyfile
:8000 {
	handle_path /api/user/* {
		reverse_proxy localhost:8080
	}

	handle_path /api/agit/* {
		reverse_proxy localhost:8083
	}

	handle /api/videos/* {
		reverse_proxy localhost:8085
	}

	handle_path /api/video/* {
		reverse_proxy localhost:8085
	}
}
```

### 2. 실행 가이드와 API_URL 예시

- **파일:** `LOCAL_CADDY.md`, `.env.local.example`
- **설명:** 문제·적용 시점, Caddy 설치(도커 없이 `caddy run`, 도커는 짧게 안내), 실행 순서를 적습니다. env 예시에서 직접 호출 기본값을 주석 처리하고 프록시 사용 시 `API_URL=http://localhost:8000`을 안내합니다.

```markdown
1. 사용할 서비스 실행 (예: user `:8080`, agit `:8083`)
2. 프로젝트 루트에서 `caddy run`
3. `.env.local`에 `API_URL=http://localhost:8000`
4. `npm run dev`
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`) — `caddy run` 후 로그인·아지트 목록이 로컬 서비스로 전달되는지

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
