### PR TITLE
[#55] Feature : 다이어리 홈 GET /home Hybrid Diary API 연동

### DIFF
--- a/app/(diary)/diary/page.tsx
+++ b/app/(diary)/diary/page.tsx
@@ -1,5 +1,19 @@
 import { DiaryMainTemplate } from "@/components/templates";
+import { getDiaryHomeFeed, listDiaryThemes } from "@/services/diaryService";
+import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
 
-export default function DiaryPage() {
-  return <DiaryMainTemplate />;
+export default async function DiaryPage() {
+  let entries: UiDiaryDateEntry[] = [];
+  let themes: UiDiaryTheme[] = [];
+  let error: string | undefined;
+
+  try {
+    [entries, themes] = await Promise.all([getDiaryHomeFeed(), listDiaryThemes()]);
+  } catch (caught) {
+    entries = [];
+    themes = [];
+    error = caught instanceof Error ? caught.message : "다이어리 홈을 불러오지 못했습니다.";
+  }
+
+  return <DiaryMainTemplate entries={entries} themes={themes} error={error} />;
 }

--- a/components/molecules/DiaryDateScrollSection.tsx
+++ b/components/molecules/DiaryDateScrollSection.tsx
@@ -1,53 +1,50 @@
 import { TextLink } from "@/components/atoms";
-import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { formatDiaryDate, formatDiaryWeekday } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
+import { cn } from "@/lib/utils";
 import type { UiDiaryDateEntry } from "@/types/diary/ui";
 import { Plus } from "lucide-react";
 
 type DiaryDateScrollSectionProps = {
   entry: UiDiaryDateEntry;
+  className?: string;
 };
 
 const TILES = ["bg-[#1a2744]", "bg-[#032426]", "bg-[#2a1a3a]"] as const;
 
 /** Figma Hybrid Diary — 일자 + 3열 모자이크 */
-export function DiaryDateScrollSection({ entry }: DiaryDateScrollSectionProps) {
+export function DiaryDateScrollSection({ entry, className }: DiaryDateScrollSectionProps) {
   const dateLabel = formatDiaryDate(entry.date);
   const weekday = formatDiaryWeekday(entry.date);
   const isEmpty = entry.isEmpty || !entry.hasClips;
   const href = isEmpty ? ROUTES.create : ROUTES.diary.date(entry.date);
 
   return (
-    <article className="flex flex-col gap-2" aria-label={`${dateLabel} 다이어리`}>
-      <div className="flex items-center justify-between gap-3 px-0.5">
-        <TextLink
-          href={ROUTES.diary.date(entry.date)}
-          className="text-[13px] font-bold text-[#161823] no-underline"
-        >
-          {dateLabel} · {weekday}
-        </TextLink>
-        {entry.relativeLabel ? (
-          <Badge variant="secondary" className="rounded-full text-[10px] font-semibold">
-            {entry.relativeLabel}
-          </Badge>
-        ) : null}
-      </div>
+    <article
+      className={cn("flex min-h-0 flex-1 flex-col gap-2", className)}
+      aria-label={`${dateLabel} 다이어리`}
+    >
+      <TextLink
+        href={ROUTES.diary.date(entry.date)}
+        className="shrink-0 px-0.5 text-[13px] font-bold text-[#161823] no-underline"
+      >
+        {dateLabel} · {weekday}
+      </TextLink>
 
-      <TextLink href={href} className="block no-underline">
-        <Card className="overflow-hidden border-0 p-0 shadow-none ring-1 ring-black/5">
+      <TextLink href={href} className="block min-h-0 flex-1 no-underline">
+        <Card className="flex h-full min-h-0 flex-col overflow-hidden border-0 p-0 shadow-none ring-1 ring-black/5">
           {isEmpty ? (
-            <div className="flex min-h-[158px] flex-col items-center justify-center gap-2 bg-secondary text-muted-foreground">
+            <div className="flex h-full min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-secondary text-muted-foreground">
               <span className="grid size-10 place-items-center rounded-full bg-white shadow-sm ring-1 ring-black/5">
                 <Plus className="size-5 text-primary" />
               </span>
-              <span className="text-xs font-semibold">새 클립 추가</span>
+              <span className="text-xs font-semibold">다이어리 기록</span>
             </div>
           ) : (
-            <div className="grid grid-cols-3 gap-px bg-white">
+            <div className="grid h-full min-h-0 flex-1 grid-cols-3 gap-px bg-white">
               {TILES.map((tile) => (
-                <div key={tile} className={`min-h-[158px] ${tile}`} aria-hidden />
+                <div key={tile} className={cn("min-h-0", tile)} aria-hidden />
               ))}
             </div>
           )}

--- a/components/molecules/ThemePreviewStrip.tsx
+++ b/components/molecules/ThemePreviewStrip.tsx
@@ -1,5 +1,4 @@
-import { ThemeChip } from "@/components/atoms";
-import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { TextLink, ThemeChip } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
 import type { UiDiaryTheme } from "@/types/diary/ui";
 
@@ -7,26 +6,49 @@ type ThemePreviewStripProps = {
   themes: UiDiaryTheme[];
 };
 
-const ACCENTS = ["pink", "cyan", "pink", "cyan"] as const;
+const ACCENTS = ["pink", "cyan", "pink", "cyan", "pink"] as const;
+const THEME_SLOT_COUNT = 5;
 
 /** Figma `Hybrid / Diary` stories row */
 export function ThemePreviewStrip({ themes }: ThemePreviewStripProps) {
+  const visibleThemes = themes.slice(0, THEME_SLOT_COUNT);
+
   return (
-    <section aria-label="테마 스토리" className="w-full">
-      <ScrollArea className="w-full whitespace-nowrap">
-        <div className="flex gap-3.5 px-1 pb-2">
-          <ThemeChip name="추가" href={ROUTES.diary.themes.root} accent="add" />
-          {themes.map((theme, index) => (
+    <section aria-label="테마 스토리" className="w-full shrink-0">
+      <TextLink
+        href={ROUTES.diary.themes.root}
+        className="mb-3 block text-[13px] font-bold text-[#161823] no-underline"
+      >
+        테마
+      </TextLink>
+      <div className="grid grid-cols-5 gap-2">
+        {Array.from({ length: THEME_SLOT_COUNT }, (_, index) => {
+          const theme = visibleThemes[index];
+
+          if (!theme) {
+            return (
+              <div
+                key={`theme-slot-${index}`}
+                className="flex w-full flex-col items-center gap-1.5"
+                aria-hidden
+              >
+                <span className="block size-14" />
+                <span className="h-[13px] w-full max-w-16" />
+              </div>
+            );
+          }
+
+          return (
             <ThemeChip
               key={theme.id}
               name={theme.name}
               href={ROUTES.diary.themes.detail(theme.id)}
               accent={ACCENTS[index % ACCENTS.length]}
+              className="w-full max-w-none items-center"
             />
-          ))}
-        </div>
-        <ScrollBar orientation="horizontal" />
-      </ScrollArea>
+          );
+        })}
+      </div>
     </section>
   );
 }

--- a/components/organisms/DiaryHeader.tsx
+++ b/components/organisms/DiaryHeader.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { TextLink } from "@/components/atoms";
-import { Button } from "@/components/ui/button";
+import { DailyIcon, TextLink } from "@/components/atoms";
 import type { ReactNode } from "react";
 
 type DiaryHeaderProps = {
@@ -21,15 +20,14 @@ export function DiaryHeader({
       <h1 className="text-[22px] font-bold tracking-tight text-[#161823]">{title}</h1>
       <div className="flex items-center gap-2">
         {trailing}
-        <Button
+        <button
           type="button"
-          variant="ghost"
-          size="sm"
-          className="h-auto px-2 text-[13px] font-semibold text-muted-foreground"
+          className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)]"
+          aria-label="다이어리 메뉴"
           onClick={onMenuOpen}
         >
-          메뉴
-        </Button>
+          <DailyIcon name="ellipsis" size={20} />
+        </button>
       </div>
     </header>
   );

--- a/components/organisms/DiaryMainSection.tsx
+++ b/components/organisms/DiaryMainSection.tsx
@@ -1,44 +1,33 @@
-import { DailyIcon, TextLink } from "@/components/atoms";
-import { DiaryCard } from "@/components/molecules/DiaryCard";
-import { TopicChip } from "@/components/molecules/TopicChip";
-import { ROUTES } from "@/config/routes";
-import Image from "next/image";
+"use client";
 
-export function DiaryMainSection() {
+import { DiaryDateScrollSection, ThemePreviewStrip } from "@/components/molecules";
+import { DiaryHeader, DiarySideMenu } from "@/components/organisms";
+import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
+import { useState } from "react";
+
+type DiaryMainSectionProps = {
+  entries: UiDiaryDateEntry[];
+  themes: UiDiaryTheme[];
+  error?: string;
+};
+
+export function DiaryMainSection({ entries, themes, error }: DiaryMainSectionProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <section className="flex flex-col gap-4 px-6 pb-8 pt-2" aria-label="다이어리 홈">
-      <header className="flex items-start justify-between gap-[12px] gap-[10px] mb-[4px]">
-        <div>
-          <h1 className="m-0 text-[22px] font-bold leading-normal text-[var(--dl-color-text-primary)]">
-            안녕하세요, 지민님
-          </h1>
-          <p className="m-[6px_0_0] text-[13px] leading-[16px] text-[var(--dl-color-text-secondary)]">오늘의 5초를 자유롭게 남겨보세요.</p>
+    <div className="flex h-[calc(100dvh-80px)] flex-col overflow-hidden">
+      <DiaryHeader onMenuOpen={() => setMenuOpen(true)} />
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+
+      <div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3">
+        <ThemePreviewStrip themes={themes} />
+        {error ? <p className="m-0 mt-3 px-1 text-sm text-red-600">{error}</p> : null}
+        <div className="mt-8 flex min-h-0 flex-1 flex-col gap-4">
+          {entries.map((entry) => (
+            <DiaryDateScrollSection key={entry.date} entry={entry} />
+          ))}
         </div>
-        <TextLink href={ROUTES.mypage.notifications} className="grid w-[44px] h-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline" aria-label="알림">
-          <DailyIcon name="bell" size={20} />
-        </TextLink>
-      </header>
-
-      <div className="flex items-center justify-between">
-        <TopicChip selected>8월 · 6일 기록</TopicChip>
-        <p className="m-0 text-[12px] font-medium text-[var(--dl-color-text-secondary)]">이번 주  3 / 7</p>
       </div>
-
-      <DiaryCard
-        href={ROUTES.diary.date("2026-08-14")}
-        imageSrc="/plip/v13/diary-breakfast.png"
-        dateLabel="8월 14일"
-        duration="00:05"
-        title="8월의 러닝 기록"
-        theme="테마 · 5초 운동 일기"
-        reactions="🔥 12   💜 8   👏 5"
-      />
-
-      <h2 className="m-0 text-[18px] font-semibold text-[var(--dl-color-text-primary)]">최근 기록</h2>
-      <TextLink href={ROUTES.diary.date("2026-08-12")} className="relative h-[160px] overflow-hidden rounded-[16px] no-underline">
-        <Image src="/plip/v13/diary-recent.png" alt="" fill className="object-cover" sizes="354px" />
-        <p className="absolute bottom-[16px] left-[16px] m-0 text-sm font-semibold text-[#fff]">퇴근 후 산책 · 8월 12일</p>
-      </TextLink>
-    </section>
+    </div>
   );
 }

--- a/components/organisms/DiarySideMenu.tsx
+++ b/components/organisms/DiarySideMenu.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { Separator, TextLink } from "@/components/atoms";
+import { DailyIcon, TextLink } from "@/components/atoms";
 import { AnimatedSideSheet } from "@/components/molecules/AnimatedOverlays";
-import { DiaryMenuLink } from "@/components/organisms/DiaryHeader";
 import { ROUTES } from "@/config/routes";
-import type { UiDiaryTheme } from "@/types/diary/ui";
 
 type DiarySideMenuProps = {
   open: boolean;
   onClose: () => void;
-  themes: UiDiaryTheme[];
 };
+
+const MENU_LINK_CLASS =
+  "flex min-h-[52px] items-center gap-[14px] rounded-[14px] border border-[#e3e0ed] bg-[#fff] p-[12px_14px] !text-[#262433] text-sm font-semibold !no-underline";
 
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] as const;
 
@@ -33,32 +33,48 @@ function buildAugust2026Days() {
   return cells;
 }
 
-export function DiarySideMenu({ open, onClose, themes }: DiarySideMenuProps) {
+export function DiarySideMenu({ open, onClose }: DiarySideMenuProps) {
   const cells = buildAugust2026Days();
 
   return (
-    <AnimatedSideSheet open={open} onClose={onClose} aria-label="다이어리 메뉴" className="flex w-[min(300px,_82vw)] h-[100dvh] flex-col gap-[0.75rem] p-[1rem] [border-left:1px_solid_var(--dc-glass-border)] bg-[linear-gradient(180deg,_rgba(255,_255,_255,_0.82),_rgba(255,_255,_255,_0.58))] shadow-[var(--dc-shadow-card)] backdrop-blur-[20px] overflow-y-auto">
-      <div className="flex items-center justify-between gap-[0.75rem]">
-        <p className="m-0 text-[1rem] font-extrabold">Menu</p>
-        <button type="button" className="border-0 bg-[transparent] text-[rgba(0,_0,_0,_0.45)] cursor-pointer text-[0.95rem] font-bold leading-none p-[0.15rem]" aria-label="닫기" onClick={onClose}>
-          ✕
+    <AnimatedSideSheet
+      open={open}
+      onClose={onClose}
+      aria-label="다이어리 메뉴"
+      className="flex w-[min(310px,86vw)] flex-col gap-4 rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-6"
+    >
+      <div className="flex min-h-[48px] shrink-0 items-center justify-between">
+        <h2 className="m-0 text-[22px] font-bold text-[#1f1c29]">다이어리</h2>
+        <button
+          type="button"
+          className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)]"
+          aria-label="닫기"
+          onClick={onClose}
+        >
+          <DailyIcon name="x" size={20} />
         </button>
       </div>
 
-      <DiaryMenuLink href={ROUTES.diary.themes.root}>전체보기</DiaryMenuLink>
-      <Separator className="!m-[0.1rem_0] !border-[rgba(0,_0,_0,_0.08)]" />
-
-      <p className="m-[0.15rem_0_0] text-[rgba(0,_0,_0,_0.4)] text-[0.72rem] font-extrabold tracking-[0.06em] uppercase">Themes</p>
-      <div className="flex flex-col">
-        {themes.map((theme) => (
-          <DiaryMenuLink key={theme.id} href={ROUTES.diary.themes.detail(theme.id)}>
-            {theme.name}
-          </DiaryMenuLink>
-        ))}
+      <div className="flex shrink-0 flex-col gap-2">
+        <TextLink href={ROUTES.diary.themes.root} className={MENU_LINK_CLASS} onClick={onClose}>
+          <DailyIcon name="usersBrand" size={24} />
+          테마 관리
+        </TextLink>
+        <TextLink href={ROUTES.diary.themes.root} className={MENU_LINK_CLASS} onClick={onClose}>
+          <DailyIcon name="grid" size={24} />
+          테마별
+        </TextLink>
+        <TextLink href={ROUTES.diary.root} className={MENU_LINK_CLASS} onClick={onClose}>
+          <DailyIcon name="calendar" size={24} />
+          날짜별
+        </TextLink>
       </div>
 
-      <div className="mt-[0.5rem] flex flex-col gap-[0.85rem] p-[0.85rem] border border-[var(--dc-glass-border)] rounded-[var(--dc-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px]" aria-label="캘린더">
-        <div className="flex items-center justify-between gap-[0.5rem] [&_p]:m-0 [&_p]:flex-1 [&_p]:text-center [&_p]:text-[0.88rem] [&_p]:font-extrabold [&_p]:text-[#111] [&_button]:w-[2rem] [&_button]:h-[2rem] [&_button]:border-0 [&_button]:rounded-[999px] [&_button]:bg-[#fff] [&_button]:text-[#111] [&_button]:cursor-pointer [&_button]:text-[1.1rem] [&_button]:leading-none">
+      <div
+        className="flex shrink-0 flex-col gap-[0.85rem] rounded-[var(--dc-radius)] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] p-[0.85rem] shadow-[var(--dc-shadow)] backdrop-blur-[20px]"
+        aria-label="캘린더"
+      >
+        <div className="flex items-center justify-between gap-[0.5rem] [&_button]:h-[2rem] [&_button]:w-[2rem] [&_button]:cursor-pointer [&_button]:rounded-[999px] [&_button]:border-0 [&_button]:bg-[#fff] [&_button]:text-[1.1rem] [&_button]:leading-none [&_button]:text-[#111] [&_p]:m-0 [&_p]:flex-1 [&_p]:text-center [&_p]:text-[0.88rem] [&_p]:font-extrabold [&_p]:text-[#111]">
           <button type="button" aria-label="이전 달">
             ‹
           </button>
@@ -67,7 +83,7 @@ export function DiarySideMenu({ open, onClose, themes }: DiarySideMenuProps) {
             ›
           </button>
         </div>
-        <div className="grid grid-cols-[repeat(7,_minmax(0,_1fr))] gap-[0.2rem] [&_span]:inline-flex [&_span]:h-[1.35rem] [&_span]:items-center [&_span]:justify-center [&_span]:text-[rgba(0,_0,_0,_0.4)] [&_span]:text-[0.7rem] [&_span]:font-bold">
+        <div className="grid grid-cols-[repeat(7,_minmax(0,_1fr))] gap-[0.2rem] [&_span]:inline-flex [&_span]:h-[1.35rem] [&_span]:items-center [&_span]:justify-center [&_span]:text-[0.7rem] [&_span]:font-bold [&_span]:text-[rgba(0,_0,_0,_0.4)]">
           {WEEKDAYS.map((day) => (
             <span key={day}>{day}</span>
           ))}
@@ -78,13 +94,16 @@ export function DiarySideMenu({ open, onClose, themes }: DiarySideMenuProps) {
               <TextLink
                 key={`${cell.day}-${index}`}
                 href={ROUTES.diary.date(cell.date)}
-                className={`!inline-flex aspect-[1] items-center justify-center rounded-[999px] !text-[#111] !text-[0.8rem] !font-bold !no-underline [&.is-selected]:bg-[var(--dc-accent)] [&.is-selected]:!text-[#fff] [&.is-outside]:!text-[rgba(0,_0,_0,_0.28)] ${cell.day === 11 ? "is-selected" : ""}`}
+                className={`!inline-flex aspect-[1] items-center justify-center rounded-[999px] !text-[0.8rem] !font-bold !text-[#111] !no-underline [&.is-outside]:!text-[rgba(0,_0,_0,_0.28)] [&.is-selected]:bg-[var(--dc-accent)] [&.is-selected]:!text-[#fff] ${cell.day === 11 ? "is-selected" : ""}`}
                 onClick={onClose}
               >
                 {cell.day}
               </TextLink>
             ) : (
-              <span key={`${cell.day}-${index}`} className="!inline-flex aspect-[1] items-center justify-center rounded-[999px] !text-[#111] !text-[0.8rem] !font-bold !no-underline [&.is-selected]:bg-[var(--dc-accent)] [&.is-selected]:!text-[#fff] [&.is-outside]:!text-[rgba(0,_0,_0,_0.28)] is-outside">
+              <span
+                key={`${cell.day}-${index}`}
+                className="!inline-flex aspect-[1] items-center justify-center rounded-[999px] !text-[0.8rem] !font-bold !text-[rgba(0,_0,_0,_0.28)]"
+              >
                 {cell.day}
               </span>
             ),

--- a/components/organisms/DiaryThemesListSection.tsx
+++ b/components/organisms/DiaryThemesListSection.tsx
@@ -2,7 +2,7 @@
 import leftoverStyles from "@/components/styles/leftover.module.css";
 
 import { deleteThemeAction } from "@/actions/diaryActions";
-import { TextLink } from "@/components/atoms";
+import { DailyIcon, TextLink } from "@/components/atoms";
 import { AnimatedDropdown } from "@/components/molecules/AnimatedOverlays";
 import { CreateThemeDialog } from "@/components/organisms/CreateThemeDialog";
 import { ROUTES } from "@/config/routes";
@@ -154,16 +154,25 @@ export function DiaryThemesListSection({ themes, error: fetchError }: DiaryTheme
   return (
     <>
       <div className="flex flex-col gap-[0.95rem] p-[0.9rem_1rem_1.5rem]">
-        <div className={`${leftoverStyles.plipDiaryThemesHead} flex items-center justify-between gap-3`}>
-          <h2>Themes</h2>
+        <header className="grid grid-cols-[44px_1fr_auto] items-center gap-[10px]">
+          <TextLink
+            href={ROUTES.diary.root}
+            className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline"
+            aria-label="뒤로"
+          >
+            <DailyIcon name="chevronLeft" size={20} />
+          </TextLink>
+          <div className={leftoverStyles.plipDiaryThemesHead}>
+            <h2>테마</h2>
+          </div>
           <button
             type="button"
-            className="border border-[var(--dc-glass-border)] rounded-[var(--dc-btn-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px] p-[0.4rem_0.85rem] text-[var(--dc-fg-primary)] text-[0.8rem] font-medium cursor-pointer"
+            className="border border-[var(--dc-glass-border)] rounded-[var(--dc-btn-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] p-[0.4rem_0.85rem] text-[0.8rem] font-medium text-[var(--dc-fg-primary)] shadow-[var(--dc-shadow)] backdrop-blur-[20px] cursor-pointer"
             onClick={openCreateDialog}
           >
             생성
           </button>
-        </div>
+        </header>
 
         {fetchError || error ? (
           <p className="m-0 px-1 text-sm text-red-600">{fetchError ?? error}</p>

--- a/components/templates/DiaryMainTemplate.tsx
+++ b/components/templates/DiaryMainTemplate.tsx
@@ -1,10 +1,17 @@
 import { DiaryMainSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
+import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
 
-export function DiaryMainTemplate() {
+type DiaryMainTemplateProps = {
+  entries: UiDiaryDateEntry[];
+  themes: UiDiaryTheme[];
+  error?: string;
+};
+
+export function DiaryMainTemplate({ entries, themes, error }: DiaryMainTemplateProps) {
   return (
     <DiaryTemplate>
-      <DiaryMainSection />
+      <DiaryMainSection entries={entries} themes={themes} error={error} />
     </DiaryTemplate>
   );
 }

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -2,7 +2,7 @@ import * as diaryApi from "@/lib/api/diaryApi";
 import type {
   ApiDiaryDateResponse,
   ApiDiaryDateThemeGroup,
-  ApiDiaryHomeItem,
+  ApiDiaryHomeSection,
   ApiDiaryTheme,
   ApiDiaryTimelineDateGroup,
   ApiDiaryTimelineResponse,
@@ -38,11 +38,21 @@ function mapVideoSummary(video: ApiDiaryVideoSummary, themeId: string, date: str
   };
 }
 
-function resolveRelativeLabel(date: string, today = new Date()): string | undefined {
+const HOME_FEED_MAX_DAYS = 3;
+
+function getTodayKstDateString(today = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(today);
+}
+
+function resolveRelativeLabel(date: string, todayDate = getTodayKstDateString()): string | undefined {
   const target = new Date(`${date}T12:00:00`);
-  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  const targetStart = new Date(target.getFullYear(), target.getMonth(), target.getDate());
-  const diffDays = Math.round((todayStart.getTime() - targetStart.getTime()) / 86_400_000);
+  const todayStart = new Date(`${todayDate}T12:00:00`);
+  const diffDays = Math.round((todayStart.getTime() - target.getTime()) / 86_400_000);
 
   if (diffDays === 0) return "오늘";
   if (diffDays === 1) return "어제";
@@ -50,16 +60,44 @@ function resolveRelativeLabel(date: string, today = new Date()): string | undefi
   return undefined;
 }
 
-function mapHomeItem(item: ApiDiaryHomeItem): UiDiaryDateEntry {
-  const thumbnailPaths = item.thumbnailPaths
-    .map((path) => toOptionalThumbnail(path))
+function createEmptyHomeEntry(date: string): UiDiaryDateEntry {
+  return {
+    date,
+    relativeLabel: resolveRelativeLabel(date),
+    hasClips: false,
+    isEmpty: true,
+    thumbnailPaths: [],
+  };
+}
+
+function normalizeHomeFeed(entries: UiDiaryDateEntry[]): UiDiaryDateEntry[] {
+  const todayDate = getTodayKstDateString();
+  const byDate = new Map(entries.map((entry) => [entry.date, entry]));
+
+  if (!byDate.has(todayDate)) {
+    byDate.set(todayDate, createEmptyHomeEntry(todayDate));
+  }
+
+  const todayEntry = byDate.get(todayDate)!;
+  const otherEntries = [...byDate.values()]
+    .filter((entry) => entry.date !== todayDate)
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, HOME_FEED_MAX_DAYS - 1);
+
+  return [todayEntry, ...otherEntries].sort((a, b) => b.date.localeCompare(a.date));
+}
+
+function mapHomeSection(section: ApiDiaryHomeSection): UiDiaryDateEntry {
+  const thumbnailPaths = section.videos
+    .map((video) => toOptionalThumbnail(video.thumbnailUrl))
     .filter((path): path is string => Boolean(path));
+  const hasClips = section.videos.length > 0;
 
   return {
-    date: item.writtenDate,
-    relativeLabel: resolveRelativeLabel(item.writtenDate),
-    hasClips: item.hasVideos,
-    isEmpty: !item.hasVideos,
+    date: section.date,
+    relativeLabel: resolveRelativeLabel(section.date),
+    hasClips,
+    isEmpty: !hasClips,
     thumbnailPaths,
   };
 }
@@ -118,7 +156,8 @@ export async function deleteDiaryTheme(themeId: string): Promise<void> {
 
 export async function getDiaryHomeFeed(): Promise<UiDiaryDateEntry[]> {
   const response = await diaryApi.getDiaryHome();
-  return response.items.map(mapHomeItem);
+  const entries = response.sections.map(mapHomeSection);
+  return normalizeHomeFeed(entries);
 }
 
 export async function getDiaryCalendarDates(year: number, month: number): Promise<string[]> {

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -25,14 +25,23 @@ export type ApiDiaryVideoSummary = {
   thumbnailPath: string | null;
 };
 
-export type ApiDiaryHomeItem = {
-  writtenDate: string;
-  hasVideos: boolean;
-  thumbnailPaths: string[];
+export type ApiDiaryHomeVideo = {
+  id: number;
+  themeId: number;
+  themeName: string;
+  videoUuid: string;
+  caption: string | null;
+  thumbnailUrl: string | null;
+  createdAt: string;
+};
+
+export type ApiDiaryHomeSection = {
+  date: string;
+  videos: ApiDiaryHomeVideo[];
 };
 
 export type ApiDiaryHomeResponse = {
-  items: ApiDiaryHomeItem[];
+  sections: ApiDiaryHomeSection[];
 };
 
 export type ApiDiaryCalendarResponse = {


### PR DESCRIPTION
## 작업 내용

Swagger `GET /home` 응답(`sections`)에 맞게 Home DTO·Service 매퍼를 수정하고, `/diary` RSC에서 홈 피드·테마 목록을 fetch해 Hybrid Atomic UI를 연결했다. Daily Loop 하드코딩을 제거하고 KST 기준 오늘 포함 최대 3일 피드를 정규화했다. 사이드 메뉴·테마 페이지 헤더 등 기존 컴포넌트 조합으로 UI를 맞췄다.

## 관련 이슈

Close #55

## 변경 사항

### 1. Home DTO 및 Service 매핑

- **파일:** `types/diary/api.ts`, `services/diaryService.ts`
- **설명:** Home 응답을 `{ sections: [{ date, videos }] }` 구조로 반영하고, KST 오늘 포함 최대 3일 피드 정규화 로직 추가

```typescript
// services/diaryService.ts
function normalizeHomeFeed(entries: UiDiaryDateEntry[]): UiDiaryDateEntry[] {
  const todayDate = getTodayKstDateString();
  const byDate = new Map(entries.map((entry) => [entry.date, entry]));

  if (!byDate.has(todayDate)) {
    byDate.set(todayDate, createEmptyHomeEntry(todayDate));
  }

  const todayEntry = byDate.get(todayDate)!;
  const otherEntries = [...byDate.values()]
    .filter((entry) => entry.date !== todayDate)
    .sort((a, b) => b.date.localeCompare(a.date))
    .slice(0, HOME_FEED_MAX_DAYS - 1);

  return [todayEntry, ...otherEntries].sort((a, b) => b.date.localeCompare(a.date));
}
```

### 2. `/diary` RSC fetch 및 Hybrid Template 연동

- **파일:** `app/(diary)/diary/page.tsx`, `components/templates/DiaryMainTemplate.tsx`, `components/organisms/DiaryMainSection.tsx`
- **설명:** RSC에서 `getDiaryHomeFeed` · `listDiaryThemes` 병렬 fetch 후 Hybrid 컴포넌트 조합

```typescript
// app/(diary)/diary/page.tsx
[entries, themes] = await Promise.all([getDiaryHomeFeed(), listDiaryThemes()]);
return <DiaryMainTemplate entries={entries} themes={themes} error={error} />;
```

### 3. Hybrid UI 조합 (테마 스트립 · 3일 피드 · 메뉴)

- **파일:** `components/molecules/ThemePreviewStrip.tsx`, `components/molecules/DiaryDateScrollSection.tsx`, `components/organisms/DiaryHeader.tsx`, `components/organisms/DiarySideMenu.tsx`
- **설명:** 5칸 고정 테마 행, 3일 1/3 레이아웃, 아지트형 메뉴 아이콘·사이드 메뉴(테마 관리/테마별/날짜별 + 캘린더)

### 4. 테마 페이지 헤더

- **파일:** `components/organisms/DiaryThemesListSection.tsx`
- **설명:** 아지트형 뒤로가기 버튼 추가, 타이틀 `테마`로 변경

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — `/diary` 홈 피드 · 메뉴 · `/diary/themes`

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인
