### PR TITLE
Feature/54 토스트 컴포넌트 추가

### DIFF
--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -5,9 +5,11 @@ import { DailyIcon, Separator, TextLink } from "@/components/atoms";
 import { AGIT_TOPICS } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import { useOverlayTransition } from "@/hooks/useOverlayTransition";
+import { toast } from "@/components/ui/toast";
+import { copyText } from "@/lib/copyText";
 import { cn } from "@/lib/utils";
 import type { UiAgit } from "@/types/agit/ui";
-import { Copy, Link2, LogOut, Settings, UserRoundCog } from "lucide-react";
+import { Check, Copy, Link2, LogOut, Settings, UserRoundCog } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -42,30 +44,32 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
   const router = useRouter();
   const [copied, setCopied] = useState(false);
   const [leaving, setLeaving] = useState(false);
-  const [leaveError, setLeaveError] = useState<string | null>(null);
   const inviteCode = agit.inviteCode?.trim() ?? "";
 
   async function copyInviteCode() {
     if (!inviteCode) return;
-    try {
-      await navigator.clipboard.writeText(inviteCode);
-      setCopied(true);
-    } catch {
-      setCopied(false);
-    }
+    const ok = await copyText(inviteCode);
+    setCopied(ok);
   }
 
   async function handleLeave() {
     if (leaving) return;
     setLeaving(true);
-    setLeaveError(null);
     const result = await leaveAgitAction(agit.id);
     if (!result.ok) {
-      setLeaveError(result.error);
+      toast.add({
+        type: "error",
+        title: "아지트를 나가지 못했습니다",
+        description: result.error,
+      });
       setLeaving(false);
       return;
     }
     onClose();
+    toast.add({
+      type: "success",
+      title: "아지트에서 나갔습니다",
+    });
     router.push(ROUTES.agit.root);
   }
 
@@ -110,7 +114,11 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
               {inviteCode || "초대코드"}
             </p>
           </div>
-          <Copy className="size-3.5 shrink-0 text-[var(--dl-color-text-brand)]" strokeWidth={2} aria-hidden />
+          {copied ? (
+            <Check className="size-3.5 shrink-0 text-[var(--dl-color-text-brand)]" strokeWidth={2} aria-hidden />
+          ) : (
+            <Copy className="size-3.5 shrink-0 text-[var(--dl-color-text-brand)]" strokeWidth={2} aria-hidden />
+          )}
           <span className="sr-only">{copied ? "복사됨" : "복사"}</span>
         </button>
 
@@ -134,7 +142,6 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
         </div>
 
         <div className="flex shrink-0 flex-col items-end gap-2">
-          {leaveError ? <p className="m-0 w-full text-right text-xs text-[var(--dl-color-text-danger)]">{leaveError}</p> : null}
           <button
             type="button"
             className="grid w-[44px] h-[44px] place-items-center rounded-[var(--dl-radius-md)] border border-[#e3e0ed] bg-[#fff] cursor-pointer disabled:opacity-50"

--- a/components/providers/AppToaster.tsx
+++ b/components/providers/AppToaster.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Toaster } from "@/components/ui/toast";
+import type { ReactNode } from "react";
+import { useRef } from "react";
+
+type AppToasterProps = {
+  children: ReactNode;
+};
+
+/** 폰 프레임 안에 토스트를 붙인다. PC에서 body fixed로 프레임 밖으로 나가지 않게 한다. */
+export function AppToaster({ children }: AppToasterProps) {
+  const frameRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={frameRef} className="relative flex min-h-dvh flex-1 flex-col md:min-h-0">
+      <Toaster portalContainer={frameRef}>{children}</Toaster>
+    </div>
+  );
+}

--- a/components/templates/AppRouteShell.tsx
+++ b/components/templates/AppRouteShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MobileDeviceFrame } from "@/components/organisms/MobileDeviceFrame";
+import { AppToaster } from "@/components/providers/AppToaster";
 import type { ReactNode } from "react";
 
 type AppRouteShellProps = {
@@ -11,5 +12,9 @@ type AppRouteShellProps = {
  * 실제 모바일은 풀스크린, PC는 Figma(390)와 같은 폰 프레임으로 미리봅니다.
  */
 export function AppRouteShell({ children }: AppRouteShellProps) {
-  return <MobileDeviceFrame>{children}</MobileDeviceFrame>;
+  return (
+    <MobileDeviceFrame>
+      <AppToaster>{children}</AppToaster>
+    </MobileDeviceFrame>
+  );
 }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import * as React from "react"
+import { Toast as ToastPrimitive } from "@base-ui/react/toast"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon, CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const toast = ToastPrimitive.createToastManager()
+
+function ToastProvider({ ...props }: ToastPrimitive.Provider.Props) {
+  return <ToastPrimitive.Provider {...props} />
+}
+
+function ToastPortal({ ...props }: ToastPrimitive.Portal.Props) {
+  return <ToastPrimitive.Portal data-slot="toast-portal" {...props} />
+}
+
+function ToastViewport({ className, ...props }: ToastPrimitive.Viewport.Props) {
+  return (
+    <ToastPrimitive.Viewport
+      data-slot="toast-viewport"
+      className={cn(
+        "pointer-events-none absolute inset-x-4 bottom-4 z-[60] mx-auto w-auto max-w-[min(100%,20rem)] outline-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function Toast({ className, ...props }: ToastPrimitive.Root.Props) {
+  return (
+    <ToastPrimitive.Root
+      data-slot="toast"
+      className={cn(
+        "group/toast pointer-events-auto absolute right-0 bottom-0 z-[calc(1000-var(--toast-index))] w-full origin-bottom rounded-[14px] border border-[#e3e0ed] bg-[#fff] text-[#262433] shadow-[0_8px_24px_rgba(31,28,41,0.12)] will-change-transform outline-none select-none focus-visible:border-[var(--dl-color-text-brand)] focus-visible:ring-[3px] focus-visible:ring-[rgba(93,53,232,0.24)]",
+        "[--gap:0.75rem] [--height:var(--toast-frontmost-height,var(--toast-height))] [--offset-y:calc(var(--toast-offset-y)*-1+calc(var(--toast-index)*var(--gap)*-1)+var(--toast-swipe-movement-y))] [--peek:0.75rem] [--scale:calc(max(0,1-(var(--toast-index)*0.1)))] [--shrink:calc(1-var(--scale))]",
+        "h-(--height) [transform:translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)-(var(--toast-index)*var(--peek))-(var(--shrink)*var(--height))))_scale(var(--scale))] [transition:transform_500ms_cubic-bezier(0.22,1,0.36,1),opacity_500ms,height_150ms]",
+        "after:absolute after:top-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-['']",
+        "data-expanded:h-(--toast-height) data-expanded:[transform:translateX(var(--toast-swipe-movement-x))_translateY(var(--offset-y))]",
+        "data-limited:opacity-0 data-starting-style:[transform:translateY(150%)]",
+        "[&[data-ending-style]:not([data-limited]):not([data-swipe-direction])]:[transform:translateY(150%)]",
+        "data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]",
+        "data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]",
+        "data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]",
+        "data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ToastContent({ className, ...props }: ToastPrimitive.Content.Props) {
+  return (
+    <ToastPrimitive.Content
+      data-slot="toast-content"
+      className={cn(
+        "flex h-full items-center gap-3 overflow-hidden p-4 transition-opacity duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] data-behind:opacity-0 data-expanded:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ToastTitle({ className, ...props }: ToastPrimitive.Title.Props) {
+  return (
+    <ToastPrimitive.Title
+      data-slot="toast-title"
+      className={cn("text-sm font-semibold text-[#1f1c29]", className)}
+      {...props}
+    />
+  )
+}
+
+function ToastDescription({
+  className,
+  ...props
+}: ToastPrimitive.Description.Props) {
+  return (
+    <ToastPrimitive.Description
+      data-slot="toast-description"
+      className={cn("text-xs text-[#756e8a]", className)}
+      {...props}
+    />
+  )
+}
+
+function ToastAction({
+  className,
+  render = <Button variant="outline" size="sm" />,
+  ...props
+}: ToastPrimitive.Action.Props) {
+  return (
+    <ToastPrimitive.Action
+      data-slot="toast-action"
+      render={render}
+      className={cn("shrink-0", className)}
+      {...props}
+    />
+  )
+}
+
+function ToastClose({
+  className,
+  children,
+  render = <Button variant="ghost" size="icon-sm" />,
+  ...props
+}: ToastPrimitive.Close.Props) {
+  return (
+    <ToastPrimitive.Close
+      data-slot="toast-close"
+      aria-label="Close toast"
+      render={render}
+      className={cn(
+        "relative shrink-0 text-muted-foreground after:absolute after:-inset-2 after:content-[''] hover:text-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children ?? (
+        <XIcon aria-hidden="true" />
+      )}
+    </ToastPrimitive.Close>
+  )
+}
+
+function ToastIcon({ type }: { type: string | undefined }) {
+  let icon: React.ReactNode = null
+
+  if (type === "success") {
+    icon = (
+      <CircleCheckIcon className="text-[var(--dl-color-text-success)]" aria-hidden="true" />
+    )
+  }
+
+  if (type === "info") {
+    icon = (
+      <InfoIcon aria-hidden="true" />
+    )
+  }
+
+  if (type === "warning") {
+    icon = (
+      <TriangleAlertIcon aria-hidden="true" />
+    )
+  }
+
+  if (type === "error") {
+    icon = (
+      <OctagonXIcon className="text-[var(--dl-color-text-danger)]" aria-hidden="true" />
+    )
+  }
+
+  if (type === "loading") {
+    icon = (
+      <Loader2Icon className="animate-spin" aria-hidden="true" />
+    )
+  }
+
+  if (!icon) {
+    return null
+  }
+
+  return (
+    <span
+      data-slot="toast-icon"
+      className="shrink-0 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4"
+    >
+      {icon}
+    </span>
+  )
+}
+
+function ToastList() {
+  const { toasts } = ToastPrimitive.useToastManager()
+
+  return toasts.map((toastItem) => (
+    <Toast key={toastItem.id} toast={toastItem}>
+      <ToastContent>
+        <ToastIcon type={toastItem.type} />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <ToastTitle />
+          <ToastDescription />
+        </div>
+        <ToastAction />
+        <ToastClose />
+      </ToastContent>
+    </Toast>
+  ))
+}
+
+function Toaster({
+  children,
+  toastManager = toast,
+  portalContainer,
+  ...props
+}: ToastPrimitive.Provider.Props & {
+  portalContainer?: ToastPrimitive.Portal.Props["container"]
+}) {
+  return (
+    <ToastProvider toastManager={toastManager} {...props}>
+      {children}
+      <ToastPortal container={portalContainer}>
+        <ToastViewport>
+          <ToastList />
+        </ToastViewport>
+      </ToastPortal>
+    </ToastProvider>
+  )
+}
+
+const createToastManager = ToastPrimitive.createToastManager
+const useToastManager = ToastPrimitive.useToastManager
+
+export {
+  Toaster,
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastContent,
+  ToastDescription,
+  ToastPortal,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  createToastManager,
+  toast,
+  useToastManager,
+}

--- a/lib/copyText.ts
+++ b/lib/copyText.ts
@@ -1,0 +1,30 @@
+function copyWithTextarea(value: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.cssText = "position:fixed;top:0;left:0;width:1px;height:1px;opacity:0;";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, value.length);
+  const ok = document.execCommand("copy");
+  document.body.removeChild(textarea);
+  return ok;
+}
+
+/** HTTPS/localhost는 Clipboard API, 그 외(사설 IP HTTP 등)는 textarea 폴백. */
+export async function copyText(value: string): Promise<boolean> {
+  if (!value) return false;
+
+  const canUseClipboard = window.isSecureContext && !!navigator.clipboard?.writeText;
+  if (canUseClipboard) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch {
+      /* fall through */
+    }
+  }
+
+  return copyWithTextarea(value);
+}


### PR DESCRIPTION
## 작업 내용

shadcn Base Toast를 앱 골격으로 추가하고, 아지트 나가기 성공·실패 알림에만 사용한다. PC 폰 프레임 밖으로 나가지 않도록 `Toaster`는 프레임 안에 마운트한다. 초대코드 복사는 기존 인라인 피드백을 유지한다.

## 관련 이슈

Close #54

## 변경 사항

### 1. shadcn Base Toast 골격

- **파일:** `components/ui/toast.tsx`, `components/providers/AppToaster.tsx`, `components/templates/AppRouteShell.tsx`
- **설명:** `npx shadcn add toast`로 Base Toast를 추가한다. Daily Loop 톤(`#fff`, `#e3e0ed`, 성공/위험 색)으로 맞추고, `AppToaster`가 프레임 `ref`를 포털 컨테이너로 넘긴다.

```tsx
export function AppToaster({ children }: AppToasterProps) {
  const frameRef = useRef<HTMLDivElement>(null);

  return (
    <div ref={frameRef} className="relative flex min-h-dvh flex-1 flex-col md:min-h-0">
      <Toaster portalContainer={frameRef}>{children}</Toaster>
    </div>
  );
}
```

### 2. 아지트 나가기에 토스트 적용

- **파일:** `components/organisms/AgitMenuDrawer.tsx`
- **설명:** leave API 실패 시 error 토스트, 성공 시 메뉴를 닫고 success 토스트 후 목록으로 이동한다. 복사는 `copyText` + 아이콘 변경만 사용한다.

```tsx
if (!result.ok) {
  toast.add({
    type: "error",
    title: "아지트를 나가지 못했습니다",
    description: result.error,
  });
  setLeaving(false);
  return;
}
onClose();
toast.add({
  type: "success",
  title: "아지트에서 나갔습니다",
});
router.push(ROUTES.agit.root);
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — 나가기 성공/실패 토스트, 복사는 토스트 없음

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [ ] @headdrop 승인