### PR TITLE
[#59] Feature : 다이어리 날짜·테마 상세 API 연동

### DIFF
--- a/app/(diary)/diary/[date]/page.tsx
+++ b/app/(diary)/diary/[date]/page.tsx
@@ -1,5 +1,7 @@
 import { DiaryDateTemplate } from "@/components/templates";
-import { parseDiaryDateParam } from "@/config/diary-mock";
+import { getDiaryDateGroup } from "@/services/diaryService";
+import type { UiDiaryDateGroup } from "@/types/diary/ui";
+import { parseDiaryDateParam, shiftDiaryDate } from "@/types/diary/schema";
 import { notFound } from "next/navigation";
 
 type DiaryDatePageProps = {
@@ -14,5 +16,22 @@ export default async function DiaryDatePage({ params }: DiaryDatePageProps) {
     notFound();
   }
 
-  return <DiaryDateTemplate date={parsedDate} />;
+  let dateGroup: UiDiaryDateGroup = { date: parsedDate, themes: [] };
+  let error: string | undefined;
+
+  try {
+    dateGroup = await getDiaryDateGroup(parsedDate);
+  } catch (caught) {
+    dateGroup = { date: parsedDate, themes: [] };
+    error = caught instanceof Error ? caught.message : "날짜 상세를 불러오지 못했습니다.";
+  }
+
+  return (
+    <DiaryDateTemplate
+      dateGroup={dateGroup}
+      prevDate={shiftDiaryDate(parsedDate, -1)}
+      nextDate={shiftDiaryDate(parsedDate, 1)}
+      error={error}
+    />
+  );
 }

--- a/app/(diary)/diary/[date]/page.tsx
+++ b/app/(diary)/diary/[date]/page.tsx
@@ -1,7 +1,12 @@
 import { DiaryDateTemplate } from "@/components/templates";
 import { getDiaryDateGroup } from "@/services/diaryService";
 import type { UiDiaryDateGroup } from "@/types/diary/ui";
-import { parseDiaryDateParam, shiftDiaryDate } from "@/types/diary/schema";
+import {
+  getTodayKstDateString,
+  isFutureDiaryDate,
+  parseDiaryDateParam,
+  shiftDiaryDate,
+} from "@/types/diary/schema";
 import { notFound } from "next/navigation";
 
 type DiaryDatePageProps = {
@@ -12,9 +17,12 @@ export default async function DiaryDatePage({ params }: DiaryDatePageProps) {
   const { date } = await params;
   const parsedDate = parseDiaryDateParam(date);
 
-  if (!parsedDate) {
+  if (!parsedDate || isFutureDiaryDate(parsedDate)) {
     notFound();
   }
+
+  const nextDate = shiftDiaryDate(parsedDate, 1);
+  const canGoNext = !isFutureDiaryDate(nextDate, getTodayKstDateString());
 
   let dateGroup: UiDiaryDateGroup = { date: parsedDate, themes: [] };
   let error: string | undefined;
@@ -30,7 +38,8 @@ export default async function DiaryDatePage({ params }: DiaryDatePageProps) {
     <DiaryDateTemplate
       dateGroup={dateGroup}
       prevDate={shiftDiaryDate(parsedDate, -1)}
-      nextDate={shiftDiaryDate(parsedDate, 1)}
+      nextDate={nextDate}
+      canGoNext={canGoNext}
       error={error}
     />
   );

--- a/app/(diary)/diary/themes/[themeId]/page.tsx
+++ b/app/(diary)/diary/themes/[themeId]/page.tsx
@@ -1,5 +1,8 @@
 import { DiaryThemeDetailTemplate } from "@/components/templates";
-import { getThemeById } from "@/config/diary-mock";
+import { ApiError } from "@/lib/api/apiFetch";
+import { getDiaryThemeTimeline } from "@/services/diaryService";
+import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
+import { parseThemeId } from "@/types/diary/schema";
 import { notFound } from "next/navigation";
 
 type DiaryThemePageProps = {
@@ -8,13 +11,34 @@ type DiaryThemePageProps = {
 
 export default async function DiaryThemePage({ params }: DiaryThemePageProps) {
   const { themeId } = await params;
-  const theme = getThemeById(themeId);
+  const parsedId = parseThemeId(themeId);
 
-  if (!theme) {
+  if (!parsedId.ok) {
     notFound();
   }
 
+  let themeName = "";
+  let dateGroups: UiDiaryThemeDateGroup[] = [];
+  let error: string | undefined;
+
+  try {
+    const result = await getDiaryThemeTimeline(parsedId.data);
+    themeName = result.theme.name;
+    dateGroups = result.dateGroups;
+  } catch (caught) {
+    if (caught instanceof ApiError && caught.status === 404) {
+      notFound();
+    }
+
+    error = caught instanceof Error ? caught.message : "테마 상세를 불러오지 못했습니다.";
+  }
+
   return (
-    <DiaryThemeDetailTemplate themeId={theme.id} themeName={theme.name} />
+    <DiaryThemeDetailTemplate
+      themeId={parsedId.data}
+      themeName={themeName}
+      dateGroups={dateGroups}
+      error={error}
+    />
   );
 }

--- a/components/molecules/DiaryThemeClipGroup.tsx
+++ b/components/molecules/DiaryThemeClipGroup.tsx
@@ -1,21 +1,88 @@
+"use client";
+
 import { TextLink } from "@/components/atoms";
 import { formatDiaryDate } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiDiaryClip } from "@/types/diary/ui";
+import { useState } from "react";
 
 type DiaryThemeClipGroupProps = {
   themeName: string;
   date: string;
   clipCount: number;
+  clips?: UiDiaryClip[];
   showDateLink?: boolean;
 };
 
-function ThumbGrid({ count }: { count: number }) {
-  const items = Array.from({ length: Math.max(count, 0) }, (_, index) => index);
+const THUMB_GRID_CLASS = "grid w-full grid-cols-[repeat(3,_minmax(0,_1fr))] gap-[1px] bg-[#fff]";
+
+const THUMB_PLACEHOLDER_CLASS =
+  "aspect-[1_/_1] w-full rounded-[0] bg-[linear-gradient(160deg,_rgba(37,_244,_238,_0.12),_transparent_50%),_linear-gradient(145deg,_#5a5a5a,_#1f1f1f)] [&:nth-child(3n+2)]:bg-[linear-gradient(160deg,_rgba(254,_44,_85,_0.16),_transparent_55%),_linear-gradient(145deg,_#4a4a4a,_#181818)] [&:nth-child(3n)]:bg-[linear-gradient(145deg,_#6a6a6a,_#242424)]";
+
+const THUMB_IMAGE_CLASS = "aspect-[1_/_1] h-full w-full rounded-[0] object-cover";
+
+function isRenderableThumbnail(src?: string): boolean {
+  const trimmed = src?.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (trimmed.startsWith("/")) {
+    return true;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function DiaryClipThumb({ thumbnailSrc }: { thumbnailSrc?: string }) {
+  const [failed, setFailed] = useState(!isRenderableThumbnail(thumbnailSrc));
+
+  if (failed) {
+    return <div className={THUMB_PLACEHOLDER_CLASS} aria-hidden />;
+  }
+
   return (
-    <div className="grid grid-cols-[repeat(3,_minmax(0,_1fr))] gap-[1px] bg-[#fff]">
-      {items.map((item) => (
-        <div key={item} className="aspect-[1_/_1] rounded-[0] bg-[linear-gradient(160deg,_rgba(37,_244,_238,_0.12),_transparent_50%),_linear-gradient(145deg,_#5a5a5a,_#1f1f1f)] [&:nth-child(3n + 2)]:bg-[linear-gradient(160deg,_rgba(254,_44,_85,_0.16),_transparent_55%),_linear-gradient(145deg,_#4a4a4a,_#181818)] [&:nth-child(3n)]:bg-[linear-gradient(145deg,_#6a6a6a,_#242424)]" aria-hidden />
-      ))}
+    <div className={`${THUMB_PLACEHOLDER_CLASS} overflow-hidden`}>
+      <img
+        src={thumbnailSrc}
+        alt=""
+        className={THUMB_IMAGE_CLASS}
+        onError={() => setFailed(true)}
+        onLoad={(event) => {
+          if (event.currentTarget.naturalWidth === 0) {
+            setFailed(true);
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+function ThumbGrid({ clips, clipCount }: { clips?: UiDiaryClip[]; clipCount: number }) {
+  const slotCount = Math.min(Math.max(clipCount, clips?.length ?? 0), 5);
+
+  if (slotCount === 0) {
+    return null;
+  }
+
+  return (
+    <div className={THUMB_GRID_CLASS}>
+      {Array.from({ length: slotCount }, (_, index) => {
+        const clip = clips?.[index];
+        const slotKey = clip?.id ?? `slot-${index}`;
+
+        return (
+          <DiaryClipThumb
+            key={slotKey}
+            thumbnailSrc={clip?.thumbnailSrc}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -24,6 +91,7 @@ export function DiaryThemeClipGroup({
   themeName,
   date,
   clipCount,
+  clips,
   showDateLink = false,
 }: DiaryThemeClipGroupProps) {
   const title = showDateLink ? formatDiaryDate(date) : themeName;
@@ -37,7 +105,7 @@ export function DiaryThemeClipGroup({
       ) : (
         <h3 className="m-0 text-[0.88rem] font-extrabold !text-[#111] !no-underline">{title}</h3>
       )}
-      <ThumbGrid count={Math.min(clipCount, 5)} />
+      <ThumbGrid clips={clips} clipCount={clipCount} />
     </section>
   );
 }

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -1,59 +1,48 @@
 import { TextLink } from "@/components/atoms";
 import { DiaryThemeClipGroup } from "@/components/molecules";
-import {
-  DIARY_DATE_GROUPS,
-  DIARY_MAIN_ENTRIES,
-  formatDiaryDate,
-} from "@/config/diary-mock";
+import { formatDiaryDate } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiDiaryDateThemeGroup } from "@/types/diary/ui";
 
 type DiaryDateDetailSectionProps = {
   date: string;
+  themes: UiDiaryDateThemeGroup[];
+  prevDate: string;
+  nextDate: string;
+  error?: string;
 };
 
-export function DiaryDateDetailSection({ date }: DiaryDateDetailSectionProps) {
-  const groups = DIARY_DATE_GROUPS[date] ?? [];
-  const index = DIARY_MAIN_ENTRIES.findIndex((entry) => entry.date === date);
-  const prev = index > 0 ? DIARY_MAIN_ENTRIES[index - 1] : undefined;
-  const next =
-    index >= 0 && index < DIARY_MAIN_ENTRIES.length - 1
-      ? DIARY_MAIN_ENTRIES[index + 1]
-      : undefined;
-
+export function DiaryDateDetailSection({
+  date,
+  themes,
+  prevDate,
+  nextDate,
+  error,
+}: DiaryDateDetailSectionProps) {
   return (
     <div className="flex flex-col gap-[1.15rem] p-[0.9rem_1rem_1.75rem]">
       <div className="grid grid-cols-[2.25rem_1fr_2.25rem] items-center gap-[0.5rem]">
-        {prev ? (
-          <TextLink
-            href={ROUTES.diary.date(prev.date)}
-            className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]"
-            aria-label="이전 날짜"
-          >
-            ‹
-          </TextLink>
-        ) : (
-          <span className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28] is-disabled" aria-hidden>
-            ‹
-          </span>
-        )}
+        <TextLink
+          href={ROUTES.diary.date(prevDate)}
+          className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]"
+          aria-label="이전 날짜"
+        >
+          ‹
+        </TextLink>
         <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{formatDiaryDate(date)}</h2>
-        {next ? (
-          <TextLink
-            href={ROUTES.diary.date(next.date)}
-            className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]"
-            aria-label="다음 날짜"
-          >
-            ›
-          </TextLink>
-        ) : (
-          <span className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28] is-disabled" aria-hidden>
-            ›
-          </span>
-        )}
+        <TextLink
+          href={ROUTES.diary.date(nextDate)}
+          className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]"
+          aria-label="다음 날짜"
+        >
+          ›
+        </TextLink>
       </div>
 
-      {groups.length > 0 ? (
-        groups.map((group) => (
+      {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
+
+      {themes.length > 0 ? (
+        themes.map((group) => (
           <DiaryThemeClipGroup
             key={group.themeId}
             themeName={group.themeName}

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -1,58 +1,177 @@
-import { TextLink } from "@/components/atoms";
+"use client";
+
+import { DailyIcon, TextLink } from "@/components/atoms";
 import { DiaryThemeClipGroup } from "@/components/molecules";
 import { formatDiaryDate } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
 import type { UiDiaryDateThemeGroup } from "@/types/diary/ui";
+import { useRouter } from "next/navigation";
+import { useRef, type PointerEvent } from "react";
 
 type DiaryDateDetailSectionProps = {
   date: string;
   themes: UiDiaryDateThemeGroup[];
   prevDate: string;
   nextDate: string;
+  canGoNext: boolean;
   error?: string;
 };
+
+const SWIPE_THRESHOLD = 48;
+const NAV_ARROW_CLASS =
+  "!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]";
 
 export function DiaryDateDetailSection({
   date,
   themes,
   prevDate,
   nextDate,
+  canGoNext,
   error,
 }: DiaryDateDetailSectionProps) {
+  const router = useRouter();
+  const pointerStart = useRef<{ x: number; y: number; scrollTop: number } | null>(null);
+
+  function isInteractiveTarget(target: EventTarget | null): boolean {
+    return target instanceof Element && Boolean(target.closest("a, button, input, textarea, select"));
+  }
+
+  function getRelativeX(clientX: number, element: HTMLDivElement): number {
+    const rect = element.getBoundingClientRect();
+    return (clientX - rect.left) / rect.width;
+  }
+
+  function goPrev() {
+    router.push(ROUTES.diary.date(prevDate));
+  }
+
+  function goNext() {
+    if (!canGoNext) {
+      return;
+    }
+
+    router.push(ROUTES.diary.date(nextDate));
+  }
+
+  function handlePointerDown(event: PointerEvent<HTMLDivElement>) {
+    if (isInteractiveTarget(event.target)) {
+      pointerStart.current = null;
+      return;
+    }
+
+    pointerStart.current = {
+      x: event.clientX,
+      y: event.clientY,
+      scrollTop: event.currentTarget.scrollTop,
+    };
+  }
+
+  function handlePointerUp(event: PointerEvent<HTMLDivElement>) {
+    if (!pointerStart.current) {
+      return;
+    }
+
+    const start = pointerStart.current;
+    pointerStart.current = null;
+
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+
+    if (Math.abs(event.currentTarget.scrollTop - start.scrollTop) > 5) {
+      return;
+    }
+
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    const startRatio = getRelativeX(start.x, event.currentTarget);
+
+    if (Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy)) {
+      if (dx < 0) {
+        goNext();
+      } else {
+        goPrev();
+      }
+      return;
+    }
+
+    if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
+      if (startRatio < 1 / 8) {
+        goPrev();
+      } else if (startRatio > 7 / 8) {
+        goNext();
+      }
+    }
+  }
+
+  function handlePointerCancel() {
+    pointerStart.current = null;
+  }
+
   return (
-    <div className="flex flex-col gap-[1.15rem] p-[0.9rem_1rem_1.75rem]">
-      <div className="grid grid-cols-[2.25rem_1fr_2.25rem] items-center gap-[0.5rem]">
-        <TextLink
-          href={ROUTES.diary.date(prevDate)}
-          className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]"
-          aria-label="이전 날짜"
-        >
-          ‹
-        </TextLink>
-        <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{formatDiaryDate(date)}</h2>
-        <TextLink
-          href={ROUTES.diary.date(nextDate)}
-          className="!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]"
-          aria-label="다음 날짜"
-        >
-          ›
-        </TextLink>
+    <div className="flex h-[calc(100dvh-80px)] flex-col overflow-hidden bg-[var(--dc-page-bg)]">
+      <div className="shrink-0 px-4 pb-[1.15rem] pt-[0.9rem]">
+        <header className="mb-[1.15rem] grid grid-cols-[44px_1fr_44px] items-center gap-[10px]">
+          <TextLink
+            href={ROUTES.diary.root}
+            className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline"
+            aria-label="뒤로"
+          >
+            <DailyIcon name="chevronLeft" size={20} />
+          </TextLink>
+          <span className="sr-only">{formatDiaryDate(date)}</span>
+          <span className="w-[44px]" aria-hidden />
+        </header>
+
+        <div className="grid grid-cols-[2.25rem_1fr_2.25rem] items-center gap-[0.5rem]">
+          <TextLink
+            href={ROUTES.diary.date(prevDate)}
+            className={NAV_ARROW_CLASS}
+            aria-label="이전 날짜"
+          >
+            ‹
+          </TextLink>
+          <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{formatDiaryDate(date)}</h2>
+          {canGoNext ? (
+            <TextLink
+              href={ROUTES.diary.date(nextDate)}
+              className={NAV_ARROW_CLASS}
+              aria-label="다음 날짜"
+            >
+              ›
+            </TextLink>
+          ) : (
+            <span className={`${NAV_ARROW_CLASS} is-disabled`} aria-hidden>
+              ›
+            </span>
+          )}
+        </div>
       </div>
 
-      {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
+      <div
+        className="flex min-h-0 flex-1 flex-col gap-[1.15rem] overflow-y-auto px-4 pb-7 touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none]"
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+      >
+        {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
 
-      {themes.length > 0 ? (
-        themes.map((group) => (
-          <DiaryThemeClipGroup
-            key={group.themeId}
-            themeName={group.themeName}
-            date={date}
-            clipCount={group.clipCount}
-          />
-        ))
-      ) : (
-        <p className="m-[2rem_0_0] text-center text-[0.85rem] font-semibold text-[rgba(0,_0,_0,_0.4)]">해당 날짜의 클립이 없습니다.</p>
-      )}
+        {themes.length > 0 ? (
+          themes.map((group) => (
+            <DiaryThemeClipGroup
+              key={group.themeId}
+              themeName={group.themeName}
+              date={date}
+              clipCount={group.clipCount}
+              clips={group.clips}
+            />
+          ))
+        ) : (
+          <p className="m-[2rem_0_0] text-center text-[0.85rem] font-semibold text-[rgba(0,_0,_0,_0.4)]">
+            해당 날짜의 다이어리 기록이 없습니다.
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/organisms/DiaryThemeDetailSection.tsx
+++ b/components/organisms/DiaryThemeDetailSection.tsx
@@ -1,24 +1,27 @@
 import { IconButton } from "@/components/atoms";
 import { DiaryThemeClipGroup } from "@/components/molecules";
-import { DIARY_THEME_DATE_GROUPS } from "@/config/diary-mock";
+import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
 
 type DiaryThemeDetailSectionProps = {
   themeId: string;
   themeName: string;
+  dateGroups: UiDiaryThemeDateGroup[];
+  error?: string;
 };
 
 export function DiaryThemeDetailSection({
-  themeId,
   themeName,
+  dateGroups,
+  error,
 }: DiaryThemeDetailSectionProps) {
-  const groups = DIARY_THEME_DATE_GROUPS[themeId] ?? [];
-
   return (
     <div className="flex flex-col gap-[1.15rem] p-[0.9rem_1rem_1.75rem]">
       <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{themeName}</h2>
 
-      {groups.length > 0 ? (
-        groups.map((group) => (
+      {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
+
+      {dateGroups.length > 0 ? (
+        dateGroups.map((group) => (
           <DiaryThemeClipGroup
             key={group.date}
             themeName={themeName}

--- a/components/organisms/DiaryThemeDetailSection.tsx
+++ b/components/organisms/DiaryThemeDetailSection.tsx
@@ -1,5 +1,8 @@
-import { IconButton } from "@/components/atoms";
+"use client";
+
+import { DailyIcon, IconButton, TextLink } from "@/components/atoms";
 import { DiaryThemeClipGroup } from "@/components/molecules";
+import { ROUTES } from "@/config/routes";
 import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
 
 type DiaryThemeDetailSectionProps = {
@@ -16,7 +19,17 @@ export function DiaryThemeDetailSection({
 }: DiaryThemeDetailSectionProps) {
   return (
     <div className="flex flex-col gap-[1.15rem] p-[0.9rem_1rem_1.75rem]">
-      <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{themeName}</h2>
+      <header className="grid grid-cols-[44px_1fr_44px] items-center gap-[10px]">
+        <TextLink
+          href={ROUTES.diary.themes.root}
+          className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline"
+          aria-label="뒤로"
+        >
+          <DailyIcon name="chevronLeft" size={20} />
+        </TextLink>
+        <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{themeName}</h2>
+        <span className="w-[44px]" aria-hidden />
+      </header>
 
       {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
 
@@ -27,6 +40,7 @@ export function DiaryThemeDetailSection({
             themeName={themeName}
             date={group.date}
             clipCount={group.clipCount}
+            clips={group.clips}
             showDateLink
           />
         ))

--- a/components/templates/DiaryDateTemplate.tsx
+++ b/components/templates/DiaryDateTemplate.tsx
@@ -1,14 +1,29 @@
 import { DiaryDateDetailSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
+import type { UiDiaryDateGroup } from "@/types/diary/ui";
 
 type DiaryDateTemplateProps = {
-  date: string;
+  dateGroup: UiDiaryDateGroup;
+  prevDate: string;
+  nextDate: string;
+  error?: string;
 };
 
-export function DiaryDateTemplate({ date }: DiaryDateTemplateProps) {
+export function DiaryDateTemplate({
+  dateGroup,
+  prevDate,
+  nextDate,
+  error,
+}: DiaryDateTemplateProps) {
   return (
     <DiaryTemplate>
-      <DiaryDateDetailSection date={date} />
+      <DiaryDateDetailSection
+        date={dateGroup.date}
+        themes={dateGroup.themes}
+        prevDate={prevDate}
+        nextDate={nextDate}
+        error={error}
+      />
     </DiaryTemplate>
   );
 }

--- a/components/templates/DiaryDateTemplate.tsx
+++ b/components/templates/DiaryDateTemplate.tsx
@@ -6,6 +6,7 @@ type DiaryDateTemplateProps = {
   dateGroup: UiDiaryDateGroup;
   prevDate: string;
   nextDate: string;
+  canGoNext: boolean;
   error?: string;
 };
 
@@ -13,15 +14,17 @@ export function DiaryDateTemplate({
   dateGroup,
   prevDate,
   nextDate,
+  canGoNext,
   error,
 }: DiaryDateTemplateProps) {
   return (
-    <DiaryTemplate>
+    <DiaryTemplate fixedMain>
       <DiaryDateDetailSection
         date={dateGroup.date}
         themes={dateGroup.themes}
         prevDate={prevDate}
         nextDate={nextDate}
+        canGoNext={canGoNext}
         error={error}
       />
     </DiaryTemplate>

--- a/components/templates/DiaryTemplate.tsx
+++ b/components/templates/DiaryTemplate.tsx
@@ -3,13 +3,23 @@ import type { ReactNode } from "react";
 
 type DiaryTemplateProps = {
   children: ReactNode;
+  /** true면 main 스크롤 없이 자식이 높이·내부 스크롤을 관리 (날짜 상세 등) */
+  fixedMain?: boolean;
 };
 
-export function DiaryTemplate({ children }: DiaryTemplateProps) {
+export function DiaryTemplate({ children, fixedMain = false }: DiaryTemplateProps) {
   return (
     <div className="mx-auto flex min-h-dvh w-full max-w-full flex-col bg-[var(--dc-page-bg)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dc-fg-primary)] md:h-full md:min-h-0">
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
-        <main className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none]">{children}</main>
+        <main
+          className={
+            fixedMain
+              ? "flex min-h-0 w-full flex-1 flex-col overflow-hidden"
+              : "flex min-h-0 w-full flex-1 flex-col overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none]"
+          }
+        >
+          {children}
+        </main>
       </div>
       <BottomNavigation active="diary" variant="light" />
     </div>

--- a/components/templates/DiaryThemeDetailTemplate.tsx
+++ b/components/templates/DiaryThemeDetailTemplate.tsx
@@ -1,18 +1,28 @@
 import { DiaryThemeDetailSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
+import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
 
 type DiaryThemeDetailTemplateProps = {
   themeId: string;
   themeName: string;
+  dateGroups: UiDiaryThemeDateGroup[];
+  error?: string;
 };
 
 export function DiaryThemeDetailTemplate({
   themeId,
   themeName,
+  dateGroups,
+  error,
 }: DiaryThemeDetailTemplateProps) {
   return (
     <DiaryTemplate>
-      <DiaryThemeDetailSection themeId={themeId} themeName={themeName} />
+      <DiaryThemeDetailSection
+        themeId={themeId}
+        themeName={themeName}
+        dateGroups={dateGroups}
+        error={error}
+      />
     </DiaryTemplate>
   );
 }

--- a/config/diary-mock.ts
+++ b/config/diary-mock.ts
@@ -77,10 +77,3 @@ export function formatDiaryWeekday(date: string): string {
   const parsed = new Date(`${date}T12:00:00`);
   return weekdays[parsed.getDay()];
 }
-
-export function parseDiaryDateParam(date: string): string | null {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return null;
-  }
-  return date;
-}

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -4,8 +4,7 @@ import type {
   ApiDiaryDateSection,
   ApiDiaryHomeSection,
   ApiDiaryTheme,
-  ApiDiaryTimelineDateGroup,
-  ApiDiaryTimelineResponse,
+  ApiDiaryTimelineSection,
   ApiDiaryVideoSummary,
 } from "@/types/diary/api";
 import type {
@@ -113,11 +112,11 @@ function mapDateThemeGroup(group: ApiDiaryDateSection, date: string): UiDiaryDat
   };
 }
 
-function mapTimelineDateGroup(group: ApiDiaryTimelineDateGroup, themeId: string): UiDiaryThemeDateGroup {
+function mapTimelineSection(section: ApiDiaryTimelineSection, themeId: string): UiDiaryThemeDateGroup {
   return {
-    date: group.writtenDate,
-    clipCount: group.videoCount,
-    clips: group.videos.map((video) => mapVideoSummary(video, themeId, group.writtenDate)),
+    date: section.date,
+    clipCount: section.videos.length,
+    clips: section.videos.map((video) => mapVideoSummary(video, themeId, section.date)),
   };
 }
 
@@ -126,10 +125,6 @@ function mapDateResponse(response: ApiDiaryDateResponse): UiDiaryDateGroup {
     date: response.date,
     themes: response.sections.map((group) => mapDateThemeGroup(group, response.date)),
   };
-}
-
-function mapTimelineResponse(response: ApiDiaryTimelineResponse): UiDiaryThemeDateGroup[] {
-  return response.dates.map((group) => mapTimelineDateGroup(group, response.themeId));
 }
 
 export async function listDiaryThemes(): Promise<UiDiaryTheme[]> {
@@ -176,13 +171,14 @@ export async function getDiaryThemeTimeline(themeId: string): Promise<{
   theme: UiDiaryTheme;
   dateGroups: UiDiaryThemeDateGroup[];
 }> {
-  const response = await diaryApi.getDiaryThemeTimeline(themeId);
+  const [theme, timeline] = await Promise.all([
+    diaryApi.getDiaryTheme(themeId).then(mapTheme),
+    diaryApi.getDiaryThemeTimeline(themeId),
+  ]);
+
   return {
-    theme: {
-      id: response.themeId,
-      name: response.themeName,
-    },
-    dateGroups: mapTimelineResponse(response),
+    theme,
+    dateGroups: timeline.sections.map((section) => mapTimelineSection(section, themeId)),
   };
 }
 

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -1,7 +1,7 @@
 import * as diaryApi from "@/lib/api/diaryApi";
 import type {
   ApiDiaryDateResponse,
-  ApiDiaryDateThemeGroup,
+  ApiDiaryDateSection,
   ApiDiaryHomeSection,
   ApiDiaryTheme,
   ApiDiaryTimelineDateGroup,
@@ -31,10 +31,10 @@ function toOptionalThumbnail(path: string | null): string | undefined {
 
 function mapVideoSummary(video: ApiDiaryVideoSummary, themeId: string, date: string): UiDiaryClip {
   return {
-    id: video.diaryVideoId,
+    id: String(video.id),
     themeId,
     date,
-    thumbnailSrc: toOptionalThumbnail(video.thumbnailPath),
+    thumbnailSrc: toOptionalThumbnail(video.thumbnailUrl),
   };
 }
 
@@ -102,12 +102,14 @@ function mapHomeSection(section: ApiDiaryHomeSection): UiDiaryDateEntry {
   };
 }
 
-function mapDateThemeGroup(group: ApiDiaryDateThemeGroup, date: string): UiDiaryDateThemeGroup {
+function mapDateThemeGroup(group: ApiDiaryDateSection, date: string): UiDiaryDateThemeGroup {
+  const themeId = String(group.themeId);
+
   return {
-    themeId: group.themeId,
+    themeId,
     themeName: group.themeName,
     clipCount: group.videos.length,
-    clips: group.videos.map((video) => mapVideoSummary(video, group.themeId, date)),
+    clips: group.videos.map((video) => mapVideoSummary(video, themeId, date)),
   };
 }
 
@@ -121,8 +123,8 @@ function mapTimelineDateGroup(group: ApiDiaryTimelineDateGroup, themeId: string)
 
 function mapDateResponse(response: ApiDiaryDateResponse): UiDiaryDateGroup {
   return {
-    date: response.writtenDate,
-    themes: response.themes.map((group) => mapDateThemeGroup(group, response.writtenDate)),
+    date: response.date,
+    themes: response.sections.map((group) => mapDateThemeGroup(group, response.date)),
   };
 }
 

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -24,16 +24,32 @@ function mapTheme(theme: ApiDiaryTheme): UiDiaryTheme {
   };
 }
 
-function toOptionalThumbnail(path: string | null): string | undefined {
-  return path?.trim() ? path : undefined;
+function toOptionalThumbnail(path: string | null | undefined): string | undefined {
+  return path?.trim() ? path.trim() : undefined;
 }
 
-function mapVideoSummary(video: ApiDiaryVideoSummary, themeId: string, date: string): UiDiaryClip {
+function mapVideoSummary(
+  video: ApiDiaryVideoSummary,
+  themeId: string,
+  date: string,
+  index: number,
+): UiDiaryClip {
+  const legacyVideo = video as ApiDiaryVideoSummary & {
+    diaryVideoId?: string | number;
+    thumbnailPath?: string | null;
+  };
+  const clipId =
+    legacyVideo.id != null
+      ? String(legacyVideo.id)
+      : legacyVideo.diaryVideoId != null
+        ? String(legacyVideo.diaryVideoId)
+        : legacyVideo.videoUuid ?? `${themeId}-${date}-${index}`;
+
   return {
-    id: String(video.id),
+    id: clipId,
     themeId,
     date,
-    thumbnailSrc: toOptionalThumbnail(video.thumbnailUrl),
+    thumbnailSrc: toOptionalThumbnail(legacyVideo.thumbnailUrl ?? legacyVideo.thumbnailPath),
   };
 }
 
@@ -103,27 +119,45 @@ function mapHomeSection(section: ApiDiaryHomeSection): UiDiaryDateEntry {
 
 function mapDateThemeGroup(group: ApiDiaryDateSection, date: string): UiDiaryDateThemeGroup {
   const themeId = String(group.themeId);
+  const legacyGroup = group as ApiDiaryDateSection & {
+    diaryVideos?: ApiDiaryVideoSummary[];
+  };
+  const videos = Array.isArray(group.videos)
+    ? group.videos
+    : Array.isArray(legacyGroup.diaryVideos)
+      ? legacyGroup.diaryVideos
+      : [];
 
   return {
     themeId,
     themeName: group.themeName,
-    clipCount: group.videos.length,
-    clips: group.videos.map((video) => mapVideoSummary(video, themeId, date)),
+    clipCount: videos.length,
+    clips: videos.map((video, index) => mapVideoSummary(video, themeId, date, index)),
   };
 }
 
 function mapTimelineSection(section: ApiDiaryTimelineSection, themeId: string): UiDiaryThemeDateGroup {
+  const videos = Array.isArray(section.videos) ? section.videos : [];
+
   return {
     date: section.date,
-    clipCount: section.videos.length,
-    clips: section.videos.map((video) => mapVideoSummary(video, themeId, section.date)),
+    clipCount: videos.length,
+    clips: videos.map((video, index) => mapVideoSummary(video, themeId, section.date, index)),
   };
 }
 
-function mapDateResponse(response: ApiDiaryDateResponse): UiDiaryDateGroup {
+function mapDateResponse(
+  response: ApiDiaryDateResponse & {
+    themes?: ApiDiaryDateSection[];
+    writtenDate?: string;
+  },
+): UiDiaryDateGroup {
+  const date = response.date ?? response.writtenDate ?? "";
+  const sections = response.sections ?? response.themes ?? [];
+
   return {
-    date: response.date,
-    themes: response.sections.map((group) => mapDateThemeGroup(group, response.date)),
+    date,
+    themes: sections.map((group) => mapDateThemeGroup(group, date)),
   };
 }
 

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -21,8 +21,11 @@ export type ApiUpdateDiaryThemeNameRequest = {
 };
 
 export type ApiDiaryVideoSummary = {
-  diaryVideoId: string;
-  thumbnailPath: string | null;
+  id: number;
+  videoUuid: string;
+  caption: string | null;
+  thumbnailUrl: string | null;
+  createdAt: string;
 };
 
 export type ApiDiaryHomeVideo = {
@@ -50,15 +53,15 @@ export type ApiDiaryCalendarResponse = {
   writtenDates: string[];
 };
 
-export type ApiDiaryDateThemeGroup = {
-  themeId: string;
+export type ApiDiaryDateSection = {
+  themeId: number;
   themeName: string;
   videos: ApiDiaryVideoSummary[];
 };
 
 export type ApiDiaryDateResponse = {
-  writtenDate: string;
-  themes: ApiDiaryDateThemeGroup[];
+  date: string;
+  sections: ApiDiaryDateSection[];
 };
 
 export type ApiDiaryTimelineDateGroup = {

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -64,16 +64,13 @@ export type ApiDiaryDateResponse = {
   sections: ApiDiaryDateSection[];
 };
 
-export type ApiDiaryTimelineDateGroup = {
-  writtenDate: string;
-  videoCount: number;
+export type ApiDiaryTimelineSection = {
+  date: string;
   videos: ApiDiaryVideoSummary[];
 };
 
 export type ApiDiaryTimelineResponse = {
-  themeId: string;
-  themeName: string;
-  dates: ApiDiaryTimelineDateGroup[];
+  sections: ApiDiaryTimelineSection[];
 };
 
 export type ApiDiaryTopicTransferRequest = {

--- a/types/diary/schema.ts
+++ b/types/diary/schema.ts
@@ -53,3 +53,16 @@ export function shiftDiaryDate(date: string, days: number): string {
     day: "2-digit",
   }).format(parsed);
 }
+
+export function getTodayKstDateString(today = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(today);
+}
+
+export function isFutureDiaryDate(date: string, today = getTodayKstDateString()): boolean {
+  return date > today;
+}

--- a/types/diary/schema.ts
+++ b/types/diary/schema.ts
@@ -24,8 +24,32 @@ export function parseThemeName(value: unknown): ThemeNameParseResult {
 
 export function parseThemeId(value: unknown): ThemeNameParseResult {
   const themeId = asTrimmedString(value);
-  if (!themeId) {
+  if (!themeId || !/^\d+$/.test(themeId)) {
     return { ok: false, error: "테마 ID가 올바르지 않습니다." };
   }
   return { ok: true, data: themeId };
+}
+
+export function parseDiaryDateParam(date: string): string | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return null;
+  }
+
+  const parsed = new Date(`${date}T12:00:00`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return date;
+}
+
+export function shiftDiaryDate(date: string, days: number): string {
+  const parsed = new Date(`${date}T12:00:00`);
+  parsed.setDate(parsed.getDate() + days);
+
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(parsed);
 }


### PR DESCRIPTION
## 작업 내용

Swagger `GET /dates/{date}` · `GET /themes/{id}/timeline` DTO를 반영하고 `/diary/[date]` · `/diary/themes/[themeId]` RSC fetch 후 기존 Atomic UI에 연결했다. `config/diary-mock` 의존을 제거하고, 썸네일 플레이스홀더·뒤로가기·날짜 스와이프/1/8 탭 페이징·상단 고정 레이아웃·미래 날짜 이동 차단 등 UX를 보완했다.

## 관련 이슈

Close #59

## 변경 사항

### 1. Date·Timeline DTO 및 Service 매퍼

- **파일:** `types/diary/api.ts`, `services/diaryService.ts`
- **설명:** Date `{ date, sections }` · Timeline `{ sections }` · Video 필드(`id`, `thumbnailUrl` 등) 반영. 테마 상세는 `GET /themes/{id}` + timeline 병렬 호출.

```typescript
export async function getDiaryThemeTimeline(themeId: string): Promise<{
  theme: UiDiaryTheme;
  dateGroups: UiDiaryThemeDateGroup[];
}> {
  const [theme, timeline] = await Promise.all([
    diaryApi.getDiaryTheme(themeId).then(mapTheme),
    diaryApi.getDiaryThemeTimeline(themeId),
  ]);

  return {
    theme,
    dateGroups: timeline.sections.map((section) => mapTimelineSection(section, themeId)),
  };
}
```

### 2. 날짜·테마 상세 RSC 페이지 연동

- **파일:** `app/(diary)/diary/[date]/page.tsx`, `app/(diary)/diary/themes/[themeId]/page.tsx`
- **설명:** RSC에서 API fetch 후 Template props 전달. 미래 날짜·invalid themeId는 `notFound()`.

```typescript
if (!parsedDate || isFutureDiaryDate(parsedDate)) {
  notFound();
}

dateGroup = await getDiaryDateGroup(parsedDate);
return (
  <DiaryDateTemplate
    dateGroup={dateGroup}
    prevDate={shiftDiaryDate(parsedDate, -1)}
    nextDate={nextDate}
    canGoNext={canGoNext}
    error={error}
  />
);
```

### 3. 날짜 상세 UX (고정 헤더·스와이프·플레이스홀더)

- **파일:** `components/organisms/DiaryDateDetailSection.tsx`, `components/molecules/DiaryThemeClipGroup.tsx`, `components/templates/DiaryTemplate.tsx`
- **설명:** 상단(뒤로가기·날짜 네비) 고정 + 콘텐츠 내부 스크롤. 좌우 스와이프·1/8 탭 페이징(요소 기준 좌표). 썸네일 URL 없음/로드 실패 시 그라데이션 플레이스홀더.

```typescript
const startRatio = getRelativeX(start.x, event.currentTarget);

if (Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy)) {
  if (dx < 0) goNext();
  else goPrev();
  return;
}

if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
  if (startRatio < 1 / 8) goPrev();
  else if (startRatio > 7 / 8) goNext();
}
```

### 4. 테마 상세 UI props 연동

- **파일:** `components/organisms/DiaryThemeDetailSection.tsx`, `components/templates/DiaryThemeDetailTemplate.tsx`
- **설명:** mock 제거, API `dateGroups` props 수신. `DiaryThemesListSection`과 동일 패턴 뒤로가기 버튼 추가.

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — `/diary/[date]`, `/diary/themes/[themeId]`

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인