### PR TITLE
[#64] Feature : 아지트 상세 토픽 갤러리에 토픽·영상 조회 API 연동

### DIFF
--- a/app/(agit)/agit/[agitId]/page.tsx
+++ b/app/(agit)/agit/[agitId]/page.tsx
@@ -1,19 +1,31 @@
 import { AgitDetailTemplate } from "@/components/templates";
 import { ApiError } from "@/lib/api/apiFetch";
-import { getAgit } from "@/services/agitService";
+import { getAgitAndMembers } from "@/services/agitService";
+import { getTopicGallery } from "@/services/topicService";
 import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicGallery } from "@/types/topic/ui";
 
 type AgitDetailPageProps = {
   params: Promise<{ agitId: string }>;
 };
 
+const EMPTY_GALLERY: UiTopicGallery = { topic: null, videos: [] };
+
 export default async function AgitDetailPage({ params }: AgitDetailPageProps) {
   const { agitId } = await params;
   let agit: UiAgit | null = null;
+  let gallery: UiTopicGallery = EMPTY_GALLERY;
   let error: string | undefined;
+  let galleryError: string | undefined;
 
   try {
-    agit = await getAgit(agitId);
+    const detail = await getAgitAndMembers(agitId);
+    agit = detail.agit;
+    try {
+      gallery = await getTopicGallery(agitId, detail.members);
+    } catch (caught) {
+      galleryError = caught instanceof Error ? caught.message : "토픽을 불러오지 못했습니다.";
+    }
   } catch (caught) {
     if (caught instanceof ApiError && (caught.status === 403 || caught.status === 404)) {
       agit = null;
@@ -22,5 +34,5 @@ export default async function AgitDetailPage({ params }: AgitDetailPageProps) {
     }
   }
 
-  return <AgitDetailTemplate agit={agit} error={error} />;
+  return <AgitDetailTemplate agit={agit} gallery={gallery} error={error} galleryError={galleryError} />;
 }

--- a/components/organisms/AgitDetailSection.tsx
+++ b/components/organisms/AgitDetailSection.tsx
@@ -1,18 +1,40 @@
 "use client";
 
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
-import { TopicViewerSection } from "@/components/organisms/TopicViewerSection";
+import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
+import { DailyIcon, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
 import type { UiAgit } from "@/types/agit/ui";
-import { TextLink } from "@/components/atoms";
+import type { UiTopicGallery } from "@/types/topic/ui";
 import { useState } from "react";
 
 type AgitDetailSectionProps = {
   agit: UiAgit | null;
+  gallery: UiTopicGallery;
   error?: string;
+  galleryError?: string;
 };
 
-export function AgitDetailSection({ agit, error }: AgitDetailSectionProps) {
+function formatTopicMeta(gallery: UiTopicGallery): string {
+  const topic = gallery.topic;
+  if (!topic) {
+    return "아직 토픽이 없습니다";
+  }
+
+  const parsed = new Date(topic.startAt);
+  const date = Number.isNaN(parsed.getTime())
+    ? ""
+    : new Intl.DateTimeFormat("ko-KR", {
+        timeZone: "Asia/Seoul",
+        month: "long",
+        day: "numeric",
+      }).format(parsed);
+  const title = topic.title ? `#${topic.title}` : "";
+  const count = `${gallery.videos.length}개 영상`;
+  return [date, title, count].filter(Boolean).join(" · ");
+}
+
+export function AgitDetailSection({ agit, gallery, error, galleryError }: AgitDetailSectionProps) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   if (error) {
@@ -37,10 +59,32 @@ export function AgitDetailSection({ agit, error }: AgitDetailSectionProps) {
     );
   }
 
+  const heading = gallery.topic?.isToday || !gallery.topic ? "오늘의 토픽" : gallery.topic.title || "토픽";
+
   return (
-    <>
-      <TopicViewerSection agitId={agit.id} onMenuClick={() => setMenuOpen(true)} />
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="grid shrink-0 grid-cols-[44px_1fr_44px] items-start gap-[10px] p-[12px_23px_0]">
+        <TextLink href={ROUTES.agit.root} className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline" aria-label="뒤로">
+          <DailyIcon name="chevronLeft" size={20} />
+        </TextLink>
+        <div className="min-w-0 pt-[14px]">
+          <h1 className="m-0 text-[22px] font-bold leading-[27px] text-[var(--dl-color-text-primary)]">{heading}</h1>
+          <p className="m-[4px_0_0] text-xs leading-[16px] text-[var(--dl-color-text-secondary)]">{formatTopicMeta(gallery)}</p>
+        </div>
+        <button type="button" className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)]" aria-label="아지트 메뉴" onClick={() => setMenuOpen(true)}>
+          <DailyIcon name="ellipsis" size={20} />
+        </button>
+      </header>
+
+      {galleryError ? (
+        <section className="px-6 py-8">
+          <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">{galleryError}</p>
+        </section>
+      ) : (
+        <TopicGallerySection videos={gallery.videos} captureHref={ROUTES.agit.upload(agit.id)} />
+      )}
+
       <AgitMenuDrawer agit={agit} open={menuOpen} onClose={() => setMenuOpen(false)} />
-    </>
+    </div>
   );
 }

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -10,6 +10,7 @@ import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTempl
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicGallery } from "@/types/topic/ui";
 
 export function AgitListTemplate({
   items,
@@ -27,14 +28,18 @@ export function AgitListTemplate({
 
 export function AgitDetailTemplate({
   agit,
+  gallery,
   error,
+  galleryError,
 }: {
   agit: UiAgit | null;
+  gallery: UiTopicGallery;
   error?: string;
+  galleryError?: string;
 }) {
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
-      <AgitDetailSection agit={agit} error={error} />
+      <AgitDetailSection agit={agit} gallery={gallery} error={error} galleryError={galleryError} />
     </AppChromeTemplate>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -30,6 +30,11 @@ export const API_ENDPOINTS = {
     detail: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}`),
     leave: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}/leave`),
   },
+  topic: {
+    list: gatewayPath("topic", "/api/v1/topics"),
+    videos: (topicUuid: string) =>
+      gatewayPath("topic", `/api/v1/topics/${topicUuid}/videos`),
+  },
   diary: {
     themes: gatewayPath("diary", "/api/v1/diaries/themes"),
     themeDetail: (themeId: string) => gatewayPath("diary", `/api/v1/diaries/themes/${themeId}`),

--- a/lib/api/topicApi.ts
+++ b/lib/api/topicApi.ts
@@ -1,0 +1,29 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { getActorUserHeaders } from "@/lib/api/actorHeaders";
+import { apiFetch } from "@/lib/api/apiFetch";
+import { getApiUrl } from "@/lib/api/env";
+import { withAuthRetry } from "@/lib/api/withAuthRetry";
+import type { ApiTopic, ApiTopicVideo } from "@/types/topic/api";
+
+function topicFetch<T>(path: string, options: Parameters<typeof apiFetch>[1] = {}): Promise<T> {
+  return withAuthRetry(async () =>
+    apiFetch<T>(path, {
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      ...options,
+    }),
+  );
+}
+
+export async function listTopics(agitUuid: string): Promise<ApiTopic[]> {
+  return topicFetch<ApiTopic[]>(API_ENDPOINTS.topic.list, {
+    method: "GET",
+    searchParams: { agitUuid },
+  });
+}
+
+export async function listTopicVideos(topicUuid: string): Promise<ApiTopicVideo[]> {
+  return topicFetch<ApiTopicVideo[]>(API_ENDPOINTS.topic.videos(topicUuid), {
+    method: "GET",
+  });
+}

--- a/lib/topic/selectAgitTopic.ts
+++ b/lib/topic/selectAgitTopic.ts
@@ -1,0 +1,27 @@
+import type { ApiTopic } from "@/types/topic/api";
+
+export function toKstDateString(value: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(value);
+}
+
+export function isSameKstDate(iso: string, today = new Date()): boolean {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+  return toKstDateString(parsed) === toKstDateString(today);
+}
+
+/** 오늘(KST) startAt 토픽. 없으면 목록 첫 항목(최신). 0개면 null. */
+export function selectAgitTopic(topics: ApiTopic[], today = new Date()): ApiTopic | null {
+  if (topics.length === 0) {
+    return null;
+  }
+  const todayTopic = topics.find((topic) => isSameKstDate(topic.startAt, today));
+  return todayTopic ?? topics[0] ?? null;
+}

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -37,9 +37,20 @@ export async function listMyAgits(): Promise<UiAgit[]> {
   return items.map(mapMyAgit);
 }
 
-export async function getAgit(agitId: string): Promise<UiAgit> {
+export async function getAgitAndMembers(agitId: string): Promise<{
+  agit: UiAgit;
+  members: ApiAgitDetail["members"];
+}> {
   const item = await agitApi.getAgit(agitId);
-  return mapAgitDetail(item);
+  return {
+    agit: mapAgitDetail(item),
+    members: item.members ?? [],
+  };
+}
+
+export async function getAgit(agitId: string): Promise<UiAgit> {
+  const { agit } = await getAgitAndMembers(agitId);
+  return agit;
 }
 
 function mapCreatedAgit(item: ApiCreateAgitResponse): UiAgit {

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -1,0 +1,88 @@
+import type { ApiAgitDetailMember } from "@/types/agit/api";
+import type { ApiTopic, ApiTopicVideo } from "@/types/topic/api";
+import type { UiTopicGallery, UiTopicVideo } from "@/types/topic/ui";
+import * as topicApi from "@/lib/api/topicApi";
+import { isSameKstDate, selectAgitTopic } from "@/lib/topic/selectAgitTopic";
+import * as videoService from "@/services/videoService";
+
+const FALLBACK_THUMBNAIL = "/plip/v13/topic-video-1.png";
+const FALLBACK_AVATAR = "/plip/v13/profile-avatar.svg";
+const FALLBACK_NICKNAME = "멤버";
+
+type MemberProfile = {
+  nickname: string;
+  profileImageSrc: string;
+};
+
+function memberMap(members: ApiAgitDetailMember[]): Map<string, MemberProfile> {
+  const map = new Map<string, MemberProfile>();
+  for (const member of members) {
+    map.set(member.userUuid, {
+      nickname: member.nickname.trim() || FALLBACK_NICKNAME,
+      profileImageSrc: member.profileImagePath?.trim() || FALLBACK_AVATAR,
+    });
+  }
+  return map;
+}
+
+function profileOf(userUuid: string, members: Map<string, MemberProfile>): MemberProfile {
+  return (
+    members.get(userUuid) ?? {
+      nickname: FALLBACK_NICKNAME,
+      profileImageSrc: FALLBACK_AVATAR,
+    }
+  );
+}
+
+async function mapTopicVideo(
+  item: ApiTopicVideo,
+  members: Map<string, MemberProfile>,
+): Promise<UiTopicVideo> {
+  const attached = profileOf(item.userUuid, members);
+  try {
+    const detail = await videoService.getVideoDetail(item.videoUuid);
+    const profile = profileOf(detail.userUuid || item.userUuid, members);
+    return {
+      id: item.videoUuid,
+      thumbnailSrc: detail.thumbnailUrl?.trim() || FALLBACK_THUMBNAIL,
+      profileImageSrc: profile.profileImageSrc,
+      profileNickname: profile.nickname,
+      uploadedAt: detail.createdAt.toISOString(),
+      caption: detail.caption?.trim() ?? "",
+    };
+  } catch {
+    return {
+      id: item.videoUuid,
+      thumbnailSrc: FALLBACK_THUMBNAIL,
+      profileImageSrc: attached.profileImageSrc,
+      profileNickname: attached.nickname,
+      uploadedAt: item.createdAt,
+      caption: "",
+    };
+  }
+}
+
+function mapSummary(topic: ApiTopic): UiTopicGallery["topic"] {
+  return {
+    id: topic.topicUuid,
+    title: topic.title?.trim() ?? "",
+    startAt: topic.startAt,
+    isToday: isSameKstDate(topic.startAt),
+  };
+}
+
+export async function getTopicGallery(
+  agitUuid: string,
+  members: ApiAgitDetailMember[],
+): Promise<UiTopicGallery> {
+  const topics = await topicApi.listTopics(agitUuid);
+  const selected = selectAgitTopic(topics);
+  if (!selected) {
+    return { topic: null, videos: [] };
+  }
+
+  const topicVideos = await topicApi.listTopicVideos(selected.topicUuid);
+  const profiles = memberMap(members);
+  const videos = await Promise.all(topicVideos.map((item) => mapTopicVideo(item, profiles)));
+  return { topic: mapSummary(selected), videos };
+}

--- a/types/topic/api.ts
+++ b/types/topic/api.ts
@@ -1,0 +1,16 @@
+export type ApiTopic = {
+  topicUuid: string;
+  agitUuid: string;
+  creatorUuid: string;
+  title: string | null;
+  startAt: string;
+  videoCount: number;
+  uploadedByMe: boolean | null;
+  createdAt: string;
+};
+
+export type ApiTopicVideo = {
+  videoUuid: string;
+  userUuid: string;
+  createdAt: string;
+};

--- a/types/topic/ui.ts
+++ b/types/topic/ui.ts
@@ -11,3 +11,15 @@ export type UiTopic = {
   id: string;
   videos: UiTopicVideo[];
 };
+
+export type UiTopicSummary = {
+  id: string;
+  title: string;
+  startAt: string;
+  isToday: boolean;
+};
+
+export type UiTopicGallery = {
+  topic: UiTopicSummary | null;
+  videos: UiTopicVideo[];
+};


### PR DESCRIPTION
## 작업 내용

아지트 상세에서 목업 클립 대신 게이트웨이 토픽 조회 API로 갤러리를 채운다. KST 오늘 `startAt` 토픽을 우선하고, 없으면 목록 최신 1개를 쓰며, 영상이 없으면 촬영 슬롯을 보여준다. 썸네일·캡션은 기존 video 상세를 쓰고, 닉네임·프로필은 아지트 멤버와 조인한다.

## 관련 이슈

Close #64

## 변경 사항

### 1. 토픽 목록·영상 API 클라이언트

- **파일:** `config/api-endpoints.ts`, `types/topic/api.ts`, `lib/api/topicApi.ts`
- **설명:** Gateway `GET /api/v1/topics`, `GET /api/v1/topics/{topicUuid}/videos`를 agit/diary와 같은 `apiFetch` + 인증 헤더로 호출한다.

```typescript
export async function listTopics(agitUuid: string): Promise<ApiTopic[]> {
  return topicFetch<ApiTopic[]>(API_ENDPOINTS.topic.list, {
    method: "GET",
    searchParams: { agitUuid },
  });
}

export async function listTopicVideos(topicUuid: string): Promise<ApiTopicVideo[]> {
  return topicFetch<ApiTopicVideo[]>(API_ENDPOINTS.topic.videos(topicUuid), {
    method: "GET",
  });
}
```

### 2. 오늘 토픽 선택 및 갤러리 매핑

- **파일:** `lib/topic/selectAgitTopic.ts`, `services/topicService.ts`, `services/agitService.ts`, `types/topic/ui.ts`
- **설명:** 오늘(KST) 토픽이 있으면 그 항목, 없으면 목록 첫 항목, 0개면 빈 갤러리. 토픽 영상 UUID를 video 상세와 아지트 멤버 프로필로 `UiTopicVideo`에 맞춘다. 상세 실패 시 플레이스홀더 타일을 남긴다.

```typescript
export function selectAgitTopic(topics: ApiTopic[], today = new Date()): ApiTopic | null {
  if (topics.length === 0) {
    return null;
  }
  const todayTopic = topics.find((topic) => isSameKstDate(topic.startAt, today));
  return todayTopic ?? topics[0] ?? null;
}

export async function getTopicGallery(
  agitUuid: string,
  members: ApiAgitDetailMember[],
): Promise<UiTopicGallery> {
  const topics = await topicApi.listTopics(agitUuid);
  const selected = selectAgitTopic(topics);
  if (!selected) {
    return { topic: null, videos: [] };
  }
  const topicVideos = await topicApi.listTopicVideos(selected.topicUuid);
  const videos = await Promise.all(topicVideos.map((item) => mapTopicVideo(item, memberMap(members))));
  return { topic: mapSummary(selected), videos };
}
```

### 3. 아지트 상세에 TopicGallerySection 연결

- **파일:** `app/(agit)/agit/[agitId]/page.tsx`, `components/templates/AgitTemplates.tsx`, `components/organisms/AgitDetailSection.tsx`
- **설명:** 아지트와 갤러리를 분리해 조회하고, 목업 `TopicViewerSection` 대신 갤러리 organism을 붙인다. 아지트 오류·토픽 오류·빈 슬롯을 구분한다. `/topic-preview`는 변경하지 않는다.

```tsx
try {
  const detail = await getAgitAndMembers(agitId);
  agit = detail.agit;
  try {
    gallery = await getTopicGallery(agitId, detail.members);
  } catch (caught) {
    galleryError = caught instanceof Error ? caught.message : "토픽을 불러오지 못했습니다.";
  }
} catch (caught) {
  if (caught instanceof ApiError && (caught.status === 403 || caught.status === 404)) {
    agit = null;
  } else {
    error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
  }
}
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`) — `/agit/{agitUuid}`에서 오늘/최신 토픽 갤러리, 빈 슬롯, 토픽 API 실패 메시지

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
