### PR TITLE
[#60,#66,#67,#68,#69,#70] Feature : 아지트 하위 화면 연동과 토스트·드로어 보정

### DIFF
--- a/actions/agitActions.ts
+++ b/actions/agitActions.ts
@@ -3,7 +3,7 @@
 import { ApiError } from "@/lib/api/apiFetch";
 import * as agitService from "@/services/agitService";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
-import { parseCreateAgitInput } from "@/types/agit/schema";
+import { parseAgitNickname, parseCreateAgitInput, parseUpdateAgitInput } from "@/types/agit/schema";
 import type { UiAgit, UiCreateAgitInput } from "@/types/agit/ui";
 
 function toActionError(error: unknown): ActionResult<never> {
@@ -36,6 +36,46 @@ export async function createAgitAction(
   try {
     const agit = await agitService.createAgit(parsed.data);
     return actionSuccess(agit);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function updateAgitAction(
+  agitId: string,
+  input: {
+    agitName: unknown;
+    description?: unknown;
+    maximumCapacity: unknown;
+    thumbnailPath?: unknown;
+  },
+  minCapacity: number,
+): Promise<ActionResult<UiAgit>> {
+  const parsed = parseUpdateAgitInput(input, { minCapacity });
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    const agit = await agitService.updateAgit(agitId, parsed.data);
+    return actionSuccess(agit);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function updateMyAgitProfileAction(
+  agitId: string,
+  nickname: unknown,
+): Promise<ActionResult<void>> {
+  const parsed = parseAgitNickname(nickname);
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    await agitService.updateMyMemberProfile(agitId, { nickname: parsed.nickname });
+    return actionSuccess(undefined);
   } catch (error) {
     return toActionError(error);
   }

--- a/app/(agit)/agit/[agitId]/manage/page.tsx
+++ b/app/(agit)/agit/[agitId]/manage/page.tsx
@@ -1,4 +1,8 @@
 import { AgitManageTemplate } from "@/components/templates";
+import { ROUTES } from "@/config/routes";
+import { getAgit } from "@/services/agitService";
+import type { UiAgit } from "@/types/agit/ui";
+import { redirect } from "next/navigation";
 
 type PageProps = {
   params: Promise<{ agitId: string }>;
@@ -6,5 +10,17 @@ type PageProps = {
 
 export default async function AgitManagePage({ params }: PageProps) {
   const { agitId } = await params;
-  return <AgitManageTemplate agitId={agitId} />;
+  let agit: UiAgit | null = null;
+
+  try {
+    agit = await getAgit(agitId);
+  } catch {
+    redirect(ROUTES.agit.detail(agitId));
+  }
+
+  if (!agit || agit.myRole !== "HOST") {
+    redirect(ROUTES.agit.detail(agitId));
+  }
+
+  return <AgitManageTemplate agit={agit} />;
 }

--- a/app/(agit)/agit/[agitId]/members/page.tsx
+++ b/app/(agit)/agit/[agitId]/members/page.tsx
@@ -1,4 +1,8 @@
 import { AgitMembersTemplate } from "@/components/templates";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import { getAgitAndMembers, sortAgitMembers } from "@/services/agitService";
+import type { ApiAgitDetailMember } from "@/types/agit/api";
+import type { UiAgit } from "@/types/agit/ui";
 
 type PageProps = {
   params: Promise<{ agitId: string }>;
@@ -6,5 +10,17 @@ type PageProps = {
 
 export default async function AgitMembersPage({ params }: PageProps) {
   const { agitId } = await params;
-  return <AgitMembersTemplate agitId={agitId} />;
+  let agit: UiAgit | null = null;
+  let members: ApiAgitDetailMember[] = [];
+
+  try {
+    const detail = await getAgitAndMembers(agitId);
+    agit = detail.agit;
+    const userUuid = await getServerUserUuid();
+    members = sortAgitMembers(detail.members, userUuid);
+  } catch {
+    agit = null;
+  }
+
+  return <AgitMembersTemplate agit={agit} members={members} />;
 }

--- a/app/(agit)/agit/[agitId]/profile/edit/page.tsx
+++ b/app/(agit)/agit/[agitId]/profile/edit/page.tsx
@@ -1,0 +1,26 @@
+import { AgitProfileEditTemplate } from "@/components/templates";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import { getAgitAndMembers } from "@/services/agitService";
+import type { UiAgit } from "@/types/agit/ui";
+
+type PageProps = {
+  params: Promise<{ agitId: string }>;
+};
+
+export default async function AgitProfileEditPage({ params }: PageProps) {
+  const { agitId } = await params;
+  let agit: UiAgit | null = null;
+  let nickname = "";
+
+  try {
+    const detail = await getAgitAndMembers(agitId);
+    agit = detail.agit;
+    const userUuid = await getServerUserUuid();
+    const me = detail.members.find((member) => member.userUuid === userUuid);
+    nickname = me?.nickname ?? "";
+  } catch {
+    agit = null;
+  }
+
+  return <AgitProfileEditTemplate agit={agit} nickname={nickname} />;
+}

--- a/components/organisms/AgitManageForm.tsx
+++ b/components/organisms/AgitManageForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { updateAgitAction } from "@/actions/agitActions";
+import { SubmitButton } from "@/components/atoms";
+import { AuthField, CapacityStepper } from "@/components/molecules";
+import { ThumbnailUpload } from "@/components/molecules/ThumbnailUpload";
+import { toast } from "@/components/ui/toast";
+import { ROUTES } from "@/config/routes";
+import {
+  AGIT_DEFAULT_MAX_CAPACITY,
+  AGIT_DESCRIPTION_MAX_LENGTH,
+  AGIT_NAME_MAX_LENGTH,
+} from "@/types/agit/schema";
+import type { UiAgit } from "@/types/agit/ui";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type AgitManageFormProps = {
+  agit: UiAgit;
+};
+
+export function AgitManageForm({ agit }: AgitManageFormProps) {
+  const router = useRouter();
+  const minCapacity = Math.max(agit.memberCount, 1);
+  const [capacity, setCapacity] = useState(
+    Math.max(agit.maxMembers ?? minCapacity, minCapacity),
+  );
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(formData: FormData) {
+    if (pending) return;
+    setError(null);
+    setPending(true);
+
+    const result = await updateAgitAction(
+      agit.id,
+      {
+        agitName: formData.get("title"),
+        description: formData.get("intro"),
+        maximumCapacity: capacity,
+      },
+      minCapacity,
+    );
+
+    setPending(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    toast.add({ type: "success", title: "아지트 정보를 저장했습니다" });
+    router.push(ROUTES.agit.detail(agit.id));
+    router.refresh();
+  }
+
+  return (
+    <form className="flex w-full flex-col gap-3.5" action={handleSubmit}>
+      <ThumbnailUpload />
+
+      <AuthField
+        id="manage-title"
+        name="title"
+        label="아지트 제목"
+        hint={`최대 ${AGIT_NAME_MAX_LENGTH}자`}
+        placeholder="새벽 기상 인증"
+        defaultValue={agit.name}
+        maxLength={AGIT_NAME_MAX_LENGTH}
+        required
+      />
+      <AuthField
+        id="manage-intro"
+        name="intro"
+        label="소개글"
+        hint={`최대 ${AGIT_DESCRIPTION_MAX_LENGTH}자`}
+        placeholder="함께 아침 루틴을 기록해요"
+        defaultValue={agit.description}
+        maxLength={AGIT_DESCRIPTION_MAX_LENGTH}
+      />
+
+      <p className="m-0 text-[14px] font-medium text-[var(--dl-color-text-primary)]">최대 인원</p>
+      <div className="flex min-h-[68px] items-center justify-between gap-[12px] rounded-[12px] bg-[var(--dl-color-bg-brand-subtle)] p-[13px_14px]">
+        <div>
+          <p className="m-0 text-sm font-semibold text-[var(--dl-color-text-primary)]">{capacity}명</p>
+          <p className="m-[4px_0_0] text-[11px] text-[var(--dl-color-text-secondary)]">
+            현재 인원 {agit.memberCount}명 · 최대 {AGIT_DEFAULT_MAX_CAPACITY}명
+          </p>
+        </div>
+        <CapacityStepper
+          value={capacity}
+          min={minCapacity}
+          max={AGIT_DEFAULT_MAX_CAPACITY}
+          onChange={setCapacity}
+          compact
+        />
+      </div>
+      <p className="m-0 text-[11px] text-[var(--dl-color-text-tertiary)]">
+        정원은 현재 멤버 수보다 작게 줄일 수 없어요.
+      </p>
+
+      {error ? <p className="m-0 text-[12px] text-red-600">{error}</p> : null}
+
+      <div className="mt-auto flex w-full flex-col gap-[14px]">
+        <SubmitButton variant="brand" disabled={pending}>
+          {pending ? "저장 중..." : "저장"}
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -20,13 +20,37 @@ type AgitMenuDrawerProps = {
 };
 
 const MENU = [
-  { id: "chat" as const, label: "채팅", href: (id: string) => ROUTES.agit.chat(id) },
-  { id: "members" as const, label: "멤버리스트", href: (id: string) => ROUTES.agit.members(id) },
-  { id: "profile" as const, label: "내프로필관리", href: (id: string) => ROUTES.agit.profile(id) },
-  { id: "manage" as const, label: "아지트관리", href: (id: string) => ROUTES.agit.manage(id) },
+  {
+    id: "topics" as const,
+    label: "토픽관리",
+    href: (id: string) => ROUTES.agit.topics(id),
+    hostOnly: true,
+  },
+  { id: "chat" as const, label: "채팅", href: (id: string) => ROUTES.agit.chat(id), hostOnly: false },
+  {
+    id: "members" as const,
+    label: "멤버리스트",
+    href: (id: string) => ROUTES.agit.members(id),
+    hostOnly: false,
+  },
+  {
+    id: "profile" as const,
+    label: "내프로필관리",
+    href: (id: string) => ROUTES.agit.profileEdit(id),
+    hostOnly: false,
+  },
+  {
+    id: "manage" as const,
+    label: "아지트관리",
+    href: (id: string) => ROUTES.agit.manage(id),
+    hostOnly: true,
+  },
 ];
 
 function MenuItemIcon({ id }: { id: (typeof MENU)[number]["id"] }) {
+  if (id === "topics") {
+    return <DailyIcon name="list" size={24} />;
+  }
   if (id === "chat") {
     return <DailyIcon name="message" size={24} />;
   }
@@ -44,12 +68,19 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
   const router = useRouter();
   const [copied, setCopied] = useState(false);
   const [leaving, setLeaving] = useState(false);
+  const [confirmLeave, setConfirmLeave] = useState(false);
   const inviteCode = agit.inviteCode?.trim() ?? "";
+  const menuItems = MENU.filter((item) => !item.hostOnly || agit.myRole === "HOST");
 
   async function copyInviteCode() {
     if (!inviteCode) return;
     const ok = await copyText(inviteCode);
     setCopied(ok);
+  }
+
+  function handleClose() {
+    setConfirmLeave(false);
+    onClose();
   }
 
   async function handleLeave() {
@@ -65,7 +96,7 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
       setLeaving(false);
       return;
     }
-    onClose();
+    handleClose();
     toast.add({
       type: "success",
       title: "아지트에서 나갔습니다",
@@ -80,37 +111,42 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
       <button
         type="button"
         className={cn(
-          "fixed inset-0 z-[40] border-0 bg-[rgba(0,0,0,0.32)] [transition:opacity_280ms_ease] motion-reduce:transition-none",
+          "absolute inset-0 z-[40] border-0 bg-[rgba(0,0,0,0.32)] [transition:opacity_280ms_ease] motion-reduce:transition-none",
           visible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
         )}
         aria-label="메뉴 닫기"
-        onClick={onClose}
+        onClick={handleClose}
       />
       <aside
         className={cn(
-          "fixed top-0 right-0 z-[41] flex h-dvh w-[min(310px,86vw)] flex-col gap-2.5 rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-6 [transition:transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+          "absolute top-0 right-0 z-[41] flex h-full w-[min(310px,86%)] flex-col gap-2.5 rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-24 [transition:transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           visible ? "[transform:translateX(0)]" : "[transform:translateX(100%)]",
         )}
         aria-label="아지트 메뉴"
         aria-hidden={!visible}
       >
-        <div className="flex shrink-0 items-center justify-between min-h-[48px]">
+        <div className="flex min-h-[48px] shrink-0 items-center justify-between">
           <h2 className="m-0 text-[22px] font-bold text-[#1f1c29]">{agit.name}</h2>
-          <button type="button" className="grid w-[44px] h-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)]" aria-label="닫기" onClick={onClose}>
+          <button
+            type="button"
+            className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)]"
+            aria-label="닫기"
+            onClick={handleClose}
+          >
             <DailyIcon name="x" size={20} />
           </button>
         </div>
 
         <button
           type="button"
-          className="flex min-h-[32px] w-full shrink-0 items-center justify-between gap-2 p-[6px_10px] border border-[#e3e0ed] rounded-[10px] bg-[#fff] text-left cursor-pointer disabled:cursor-default"
+          className="flex min-h-[32px] w-full shrink-0 cursor-pointer items-center justify-between gap-2 rounded-[10px] border border-[#e3e0ed] bg-[#fff] p-[6px_10px] text-left disabled:cursor-default"
           onClick={copyInviteCode}
           disabled={!inviteCode}
           aria-label="초대코드 복사"
         >
           <div className="flex min-w-0 items-center gap-2">
             <Link2 className="size-3.5 shrink-0 text-[#262433]" strokeWidth={2} />
-            <p className="m-0 overflow-hidden text-xs font-medium tracking-[0.04em] text-[#262433] [text-overflow:ellipsis] whitespace-nowrap">
+            <p className="m-0 overflow-hidden text-xs font-medium tracking-[0.04em] text-[#262433] whitespace-nowrap [text-overflow:ellipsis]">
               {inviteCode || "초대코드"}
             </p>
           </div>
@@ -133,8 +169,13 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
 
           <Separator className="!m-1 !border-[#e3e0ed]" />
 
-          {MENU.map((item) => (
-            <TextLink key={item.id} href={item.href(agit.id)} className="flex min-h-[52px] items-center gap-[14px] p-[12px_14px] border border-[#e3e0ed] rounded-[14px] bg-[#fff] !text-[#262433] text-sm font-semibold !no-underline" onClick={onClose}>
+          {menuItems.map((item) => (
+            <TextLink
+              key={item.id}
+              href={item.href(agit.id)}
+              className="flex min-h-[52px] items-center gap-[14px] rounded-[14px] border border-[#e3e0ed] bg-[#fff] p-[12px_14px] text-sm font-semibold !text-[#262433] !no-underline"
+              onClick={handleClose}
+            >
               <MenuItemIcon id={item.id} />
               {item.label}
             </TextLink>
@@ -144,15 +185,54 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
         <div className="flex shrink-0 flex-col items-end gap-2">
           <button
             type="button"
-            className="grid w-[44px] h-[44px] place-items-center rounded-[var(--dl-radius-md)] border border-[#e3e0ed] bg-[#fff] cursor-pointer disabled:opacity-50"
+            className="grid h-[44px] w-[44px] cursor-pointer place-items-center rounded-[var(--dl-radius-md)] border border-[#e3e0ed] bg-[#fff] disabled:opacity-50"
             aria-label="아지트 나가기"
             disabled={leaving}
-            onClick={handleLeave}
+            onClick={() => setConfirmLeave(true)}
           >
             <LogOut className="size-5 text-[#d84545]" strokeWidth={2} />
           </button>
         </div>
       </aside>
+
+      {confirmLeave ? (
+        <div className="absolute inset-0 z-[42] flex items-center justify-center p-6">
+          <button
+            type="button"
+            className="absolute inset-0 border-0 bg-[rgba(0,0,0,0.32)]"
+            aria-label="취소"
+            onClick={() => setConfirmLeave(false)}
+          />
+          <div
+            role="dialog"
+            aria-modal
+            aria-labelledby="agit-leave-title"
+            className="relative z-[1] w-full max-w-[280px] rounded-[20px] border border-[#e3e0ed] bg-[#fbfaff] p-5 shadow-[0_8px_24px_rgba(31,28,41,0.12)]"
+          >
+            <p id="agit-leave-title" className="m-0 text-base font-semibold text-[#1f1c29]">
+              아지트에서 나가시겠어요?
+            </p>
+            <p className="m-[8px_0_0] text-xs text-[#756e8a]">나가면 목록에서 이 아지트가 사라집니다.</p>
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                className="flex h-11 flex-1 items-center justify-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] text-sm font-medium text-[#262433]"
+                onClick={() => setConfirmLeave(false)}
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                className="flex h-11 flex-1 items-center justify-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-danger)] text-sm font-medium text-[var(--dl-color-text-danger)] disabled:opacity-50"
+                disabled={leaving}
+                onClick={handleLeave}
+              >
+                {leaving ? "나가는 중..." : "나가기"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/components/organisms/AgitProfileEditForm.tsx
+++ b/components/organisms/AgitProfileEditForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { updateMyAgitProfileAction } from "@/actions/agitActions";
+import { SubmitButton } from "@/components/atoms";
+import { AuthField } from "@/components/molecules";
+import { toast } from "@/components/ui/toast";
+import { ROUTES } from "@/config/routes";
+import { AGIT_NICKNAME_MAX_LENGTH, AGIT_NICKNAME_MIN_LENGTH } from "@/types/agit/schema";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type AgitProfileEditFormProps = {
+  agitId: string;
+  nickname: string;
+};
+
+export function AgitProfileEditForm({ agitId, nickname }: AgitProfileEditFormProps) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(formData: FormData) {
+    if (pending) return;
+    setError(null);
+    setPending(true);
+
+    const result = await updateMyAgitProfileAction(agitId, formData.get("nickname"));
+    setPending(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    toast.add({ type: "success", title: "프로필을 저장했습니다" });
+    router.push(ROUTES.agit.detail(agitId));
+    router.refresh();
+  }
+
+  return (
+    <form className="flex w-full flex-col gap-3.5" action={handleSubmit}>
+      <p className="m-0 text-[16px] font-semibold text-[var(--dl-color-text-primary)]">사진과 닉네임</p>
+
+      <div className="flex min-h-[84px] w-full items-center gap-[12px] rounded-[14px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[14px] text-left">
+        <div className="h-[56px] w-[56px] shrink-0 overflow-hidden rounded-[999px]">
+          <Image src="/plip/v13/profile-avatar.svg" alt="" width={56} height={56} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="m-0 text-sm font-semibold leading-[18px] text-[var(--dl-color-text-primary)]">프로필 사진</p>
+          <p className="m-0 text-[13px] leading-[16px] text-[var(--dl-color-text-secondary)]">아지트에서 사용할 프로필</p>
+        </div>
+        <button
+          type="button"
+          className="cursor-pointer whitespace-nowrap border-0 bg-[transparent] text-xs font-medium text-[var(--dl-color-text-brand)]"
+        >
+          사진 변경
+        </button>
+      </div>
+
+      <AuthField
+        id="profile-nickname"
+        name="nickname"
+        label="닉네임"
+        hint={`영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자`}
+        placeholder="보드왕"
+        defaultValue={nickname}
+        maxLength={AGIT_NICKNAME_MAX_LENGTH}
+        pattern="[0-9A-Za-z가-힣]{2,12}"
+        title="영문·숫자·한글 2~12자, 특수문자와 공백 불가"
+        required
+      />
+
+      {error ? <p className="m-0 text-[12px] text-red-600">{error}</p> : null}
+
+      <div className="mt-auto flex w-full flex-col gap-[14px]">
+        <SubmitButton variant="brand" disabled={pending}>
+          {pending ? "저장 중..." : "저장"}
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}

--- a/components/organisms/ChatMoreSheet.tsx
+++ b/components/organisms/ChatMoreSheet.tsx
@@ -9,6 +9,7 @@ type ChatMoreSheetProps = {
   agitId: string;
   open: boolean;
   notify: boolean;
+  myRole?: "HOST" | "GUEST";
   onClose: () => void;
   onToggleNotify: () => void;
 };
@@ -48,10 +49,12 @@ export function ChatMoreSheet({
   agitId,
   open,
   notify,
+  myRole,
   onClose,
   onToggleNotify,
 }: ChatMoreSheetProps) {
   const { mounted, visible } = useOverlayTransition(open);
+  const items = MENU.filter((item) => item.id !== "manage" || myRole !== "GUEST");
 
   if (!mounted) return null;
 
@@ -60,7 +63,7 @@ export function ChatMoreSheet({
       <button
         type="button"
         className={cn(
-          "fixed inset-0 z-[41] border-0 bg-[rgba(0,0,0,0.32)] [transition:opacity_280ms_ease] motion-reduce:transition-none",
+          "absolute inset-0 z-[41] border-0 bg-[rgba(0,0,0,0.32)] [transition:opacity_280ms_ease] motion-reduce:transition-none",
           visible ? "opacity-100" : "opacity-0",
         )}
         aria-label="메뉴 닫기"
@@ -68,7 +71,7 @@ export function ChatMoreSheet({
       />
       <div
         className={cn(
-          "fixed bottom-[96px] left-1/2 z-[42] flex w-[min(300px,calc(100%-48px))] flex-col gap-2 rounded-[20px] bg-[rgba(252,251,255,0.98)] p-3 shadow-[0_8px_24px_rgba(0,0,0,0.22)] [transition:opacity_280ms_ease,transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+          "absolute bottom-[96px] left-1/2 z-[42] flex w-[min(300px,calc(100%-48px))] flex-col gap-2 rounded-[20px] bg-[rgba(252,251,255,0.98)] p-3 shadow-[0_8px_24px_rgba(0,0,0,0.22)] [transition:opacity_280ms_ease,transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           visible
             ? "opacity-100 [transform:translate(-50%,0)_scale(1)]"
             : "opacity-0 [transform:translate(-50%,12px)_scale(0.96)]",
@@ -91,7 +94,7 @@ export function ChatMoreSheet({
           </span>
         </button>
 
-        {MENU.map((item) => (
+        {items.map((item) => (
           <TextLink
             key={item.id}
             href={item.href(agitId)}

--- a/components/organisms/MembersPermissionsSection.tsx
+++ b/components/organisms/MembersPermissionsSection.tsx
@@ -1,44 +1,21 @@
-"use client";
-
-import { SubmitButton } from "@/components/atoms";
 import { MemberManageRow } from "@/components/molecules/MemberManageRow";
-import { NoticeCard } from "@/components/molecules/NoticeCard";
-import { useState } from "react";
+import type { ApiAgitDetailMember } from "@/types/agit/api";
 
-const MEMBERS = [
-  { id: "me", name: "안지민", meta: "방장 · 오늘 참여", host: true },
-  { id: "min", name: "김민지", meta: "멤버 · 3분 전", host: false },
-  { id: "jun", name: "박서준", meta: "멤버 · 1시간 전", host: false },
-  { id: "ha", name: "윤하늘", meta: "멤버 · 어제", host: false },
-] as const;
+type MembersPermissionsSectionProps = {
+  members: ApiAgitDetailMember[];
+};
 
-export function MembersPermissionsSection() {
-  const [selectedId, setSelectedId] = useState<string>("ha");
-
+export function MembersPermissionsSection({ members }: MembersPermissionsSectionProps) {
   return (
     <section className="flex w-full flex-col gap-3.5">
-      <NoticeCard tone="brand" title="새벽 기상 인증" body="남은 자리 1명" />
-
-      {MEMBERS.map((member) => (
+      {members.map((member) => (
         <MemberManageRow
-          key={member.id}
-          name={member.name}
-          meta={member.meta}
-          host={member.host}
-          selected={!member.host && member.id === selectedId}
-          onSelect={member.host ? undefined : () => setSelectedId(member.id)}
+          key={member.userUuid}
+          name={member.nickname}
+          meta={member.role === "HOST" ? "방장" : "멤버"}
+          host={member.role === "HOST"}
         />
       ))}
-
-      <NoticeCard
-        tone="danger"
-        title="추방 시 즉시 퇴장"
-        body="선택한 사용자는 현재 아지트에 다시 참여해야 합니다."
-      />
-
-      <SubmitButton variant="danger" className="w-full">
-        선택한 멤버 추방
-      </SubmitButton>
     </section>
   );
 }

--- a/components/organisms/RoomChatSection.tsx
+++ b/components/organisms/RoomChatSection.tsx
@@ -104,6 +104,7 @@ export function RoomChatSection({ agit }: RoomChatSectionProps) {
         agitId={agit.id}
         open={menuOpen}
         notify={notify}
+        myRole={agit.myRole}
         onClose={() => setMenuOpen(false)}
         onToggleNotify={() => setNotify((current) => !current)}
       />

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -4,61 +4,133 @@ import { DailyIcon, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
 import { useState } from "react";
 
-const INITIAL_TOPICS = [
-  { id: "today", title: "오늘의 한 컷", meta: "매일 · 1인 1영상", clips: 12 },
-  { id: "workout", title: "운동 인증", meta: "평일 · 릴레이", clips: 8 },
-  { id: "weekend", title: "주말 산책", meta: "주말 · 그리드", clips: 0 },
-] as const;
+type TopicSectionId = "ongoing" | "upcoming" | "past";
 
-type LayoutId = "grid" | "list" | "relay";
+type MockTopic = {
+  id: string;
+  title: string;
+  meta: string;
+  clips: number;
+  section: TopicSectionId;
+};
+
+const INITIAL_TOPICS: MockTopic[] = [
+  { id: "today", title: "오늘의 한 컷", meta: "매일 · 1인 1영상", clips: 12, section: "ongoing" },
+  { id: "workout", title: "운동 인증", meta: "평일 · 릴레이", clips: 8, section: "ongoing" },
+  { id: "weekend", title: "주말 산책", meta: "주말 · 그리드", clips: 0, section: "upcoming" },
+  { id: "archive", title: "지난 챌린지", meta: "종료됨", clips: 21, section: "past" },
+];
+
+const SECTIONS: { id: TopicSectionId; label: string }[] = [
+  { id: "ongoing", label: "진행중" },
+  { id: "upcoming", label: "다가오는" },
+  { id: "past", label: "지난" },
+];
 
 type TopicsLayoutSectionProps = {
   agitId: string;
 };
 
 export function TopicsLayoutSection({ agitId }: TopicsLayoutSectionProps) {
-  const [topics, setTopics] = useState([...INITIAL_TOPICS]);
-  const [layout, setLayout] = useState<LayoutId>("grid");
+  const [topics, setTopics] = useState(INITIAL_TOPICS);
+  const [openSections, setOpenSections] = useState<Record<TopicSectionId, boolean>>({
+    ongoing: true,
+    upcoming: true,
+    past: true,
+  });
+
+  function toggleSection(id: TopicSectionId) {
+    setOpenSections((current) => ({ ...current, [id]: !current[id] }));
+  }
 
   return (
     <section className="flex w-full flex-col gap-3.5">
-      <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)] text-[13px]">토픽별 영상 상태와 표시 방식을 한 화면에서 관리</p>
+      <p className="m-0 text-[13px] font-normal leading-5 text-[var(--dl-color-text-secondary)]">
+        토픽을 진행 상태별로 보고 목업으로 만들고 지울 수 있어요
+      </p>
 
-      <div className="flex items-center justify-between">
-        <h2 className="m-0 text-base font-semibold leading-[23px] text-[var(--dl-color-text-primary)] text-[17px]">토픽</h2>
-        <span className="inline-flex items-center justify-center h-[28px] rounded-[14px] p-[0_12px] text-xs font-semibold leading-none bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]">{topics.length}개 사용 중</span>
-      </div>
-
-      <TextLink href={ROUTES.agit.topicCreate(agitId)} className="inline-flex h-[44px] w-full items-center justify-center gap-[8px] rounded-[var(--dl-radius-md)] p-[12px_20px] text-sm font-medium leading-5 !no-underline border-0 bg-[var(--dl-color-bg-brand-subtle)] border-0 bg-[var(--dl-color-bg-brand-subtle)] !text-[var(--dl-color-text-brand)] shadow-[none] [backdrop-filter:none] m-dlBtnSecondary no-underline">
+      <TextLink
+        href={ROUTES.agit.topicCreate(agitId)}
+        className="m-dlBtnSecondary inline-flex h-[44px] w-full items-center justify-center gap-[8px] rounded-[var(--dl-radius-md)] border-0 bg-[var(--dl-color-bg-brand-subtle)] p-[12px_20px] text-sm font-medium leading-5 !text-[var(--dl-color-text-brand)] !no-underline shadow-[none] [backdrop-filter:none]"
+      >
         <DailyIcon name="plus" size={16} />
         토픽 만들기
       </TextLink>
 
-      {topics.map((topic) => (
-        <div key={topic.id} className="flex w-full items-center gap-[10px] border border-[var(--dl-color-border-default)] rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]">
-          <DailyIcon name="grip" size={18} />
-          <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
-            <p className="m-0 text-sm font-medium leading-5 text-[var(--dl-color-text-primary)] font-semibold">{topic.title}</p>
-            <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">{topic.meta}</p>
+      {SECTIONS.map((section) => {
+        const items = topics.filter((topic) => topic.section === section.id);
+        const open = openSections[section.id];
+
+        return (
+          <div key={section.id} className="flex flex-col gap-2">
+            <button
+              type="button"
+              className="flex min-h-[40px] items-center justify-between"
+              onClick={() => toggleSection(section.id)}
+              aria-expanded={open}
+            >
+              <h2 className="m-0 text-[17px] font-semibold leading-[23px] text-[var(--dl-color-text-primary)]">
+                {section.label}
+              </h2>
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-flex h-[28px] items-center justify-center rounded-[14px] bg-[var(--dl-color-bg-brand-subtle)] p-[0_12px] text-xs font-semibold leading-none text-[var(--dl-color-text-brand)]">
+                  {items.length}개
+                </span>
+                <DailyIcon
+                  name="chevronRight"
+                  size={16}
+                  className={open ? "rotate-90" : ""}
+                />
+              </span>
+            </button>
+
+            {open
+              ? items.map((topic) => (
+                  <div
+                    key={topic.id}
+                    className="flex w-full items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]"
+                  >
+                    <DailyIcon name="grip" size={18} />
+                    <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                      <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
+                        {topic.title}
+                      </p>
+                      <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
+                        {topic.meta}
+                      </p>
+                    </div>
+                    <div className="flex flex-col items-end gap-1.5">
+                      <span
+                        className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
+                          topic.clips === 0
+                            ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
+                            : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
+                        }`}
+                      >
+                        {topic.clips}개 영상
+                      </span>
+                      {topic.clips === 0 ? (
+                        <button
+                          type="button"
+                          className="text-[12px] font-semibold text-[var(--dl-color-text-danger)]"
+                          onClick={() =>
+                            setTopics((current) => current.filter((item) => item.id !== topic.id))
+                          }
+                        >
+                          삭제
+                        </button>
+                      ) : (
+                        <span className="text-[12px] font-semibold text-[var(--dl-color-text-tertiary)]">
+                          삭제 불가
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))
+              : null}
           </div>
-          <div className="flex flex-col items-end gap-1.5">
-            <span className={`inline-flex items-center justify-center h-[28px] rounded-[14px] p-[0_12px] text-xs font-semibold leading-none bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)] ${topic.clips === 0 ? "bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)] m-dlBadgeSuccess" : ""}`}>
-              {topic.clips}개 영상
-            </span>
-            {topic.clips === 0 ? (
-              <button
-                type="button"
-                className="text-[12px] font-semibold text-[var(--dl-color-text-danger)]"
-                onClick={() => setTopics((current) => current.filter((item) => item.id !== topic.id))}
-              >
-                삭제
-              </button>
-            ) : (
-              <span className="text-[12px] font-semibold text-[var(--dl-color-text-tertiary)]">삭제 불가</span>
-            )}
-          </div>
-        </div>
-      ))}
+        );
+      })}
 
       <div className="flex w-full items-center gap-[10px] rounded-[12px] bg-[var(--dl-color-bg-warning)] p-[12px_14px]">
         <DailyIcon name="alert" size={18} />
@@ -66,28 +138,6 @@ export function TopicsLayoutSection({ agitId }: TopicsLayoutSectionProps) {
           영상이 등록된 토픽은 삭제할 수 없어요.
         </p>
       </div>
-
-      <h2 className="m-0 text-base font-semibold leading-[23px] text-[var(--dl-color-text-primary)] text-[17px]">그룹 영상 표시 방식</h2>
-      <div className="grid w-full grid-cols-[repeat(3,_1fr)] gap-[12px]">
-        {(
-          [
-            { id: "grid", label: "그리드", icon: "grid" },
-            { id: "list", label: "리스트", icon: "list" },
-            { id: "relay", label: "꼬리물기", icon: "chevronRight" },
-          ] as const
-        ).map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            className={`flex min-h-[104px] flex-col items-center justify-center gap-[12px] border border-[var(--dl-color-border-default)] rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] ${layout === item.id ? "border border-[var(--dl-color-border-brand)] bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)] m-dlLayoutActive" : ""}`}
-            onClick={() => setLayout(item.id)}
-          >
-            <DailyIcon name={item.icon} size={22} />
-            <span className="text-[13px] font-semibold">{item.label}</span>
-          </button>
-        ))}
-      </div>
-      <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)] text-[12px]">선택한 형식은 다음 업로드부터 적용됩니다.</p>
     </section>
   );
 }

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -1,4 +1,6 @@
 export { AgitMenuDrawer } from "./AgitMenuDrawer";
+export { AgitManageForm } from "./AgitManageForm";
+export { AgitProfileEditForm } from "./AgitProfileEditForm";
 export { ChatMoreSheet } from "./ChatMoreSheet";
 export { MoveTopicSheet } from "./MoveTopicSheet";
 export { TopicCreateForm } from "./TopicCreateForm";

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -50,6 +50,7 @@ export {
   InvitesSafetyTemplate as AgitSafetyTemplate,
   MembersPermissionsTemplate as AgitMembersTemplate,
   RoomManageHubTemplate as AgitManageTemplate,
+  RoomProfileEditTemplate as AgitProfileEditTemplate,
   TopicCreateTemplate as AgitTopicCreateTemplate,
   TopicsLayoutTemplate as AgitTopicsTemplate,
 } from "./RoomManageTemplates";

--- a/components/templates/AppChromeTemplate.tsx
+++ b/components/templates/AppChromeTemplate.tsx
@@ -1,3 +1,4 @@
+import { ui } from "@/components/atoms/styles";
 import { BottomNavigation, type BottomNavTab } from "@/components/molecules/BottomNavigation";
 import type { ReactNode } from "react";
 
@@ -31,5 +32,13 @@ export function AppChromeTemplate({
       </div>
       {showNav ? <BottomNavigation active={activeTab} variant={variant} /> : null}
     </div>
+  );
+}
+
+export function AgitFlowChrome({ children }: { children: ReactNode }) {
+  return (
+    <AppChromeTemplate activeTab="agit" variant="light">
+      <div className={`${ui.authContent} min-h-0 flex-1 overflow-y-auto`}>{children}</div>
+    </AppChromeTemplate>
   );
 }

--- a/components/templates/RoomFlowTemplates.tsx
+++ b/components/templates/RoomFlowTemplates.tsx
@@ -6,6 +6,7 @@ import { InviteConfirmSection } from "@/components/organisms/InviteConfirmSectio
 import { JoinCompleteSection } from "@/components/organisms/JoinCompleteSection";
 import { PublicRoomDetail } from "@/components/organisms/PublicRoomDetail";
 import { RoomProfileSelect } from "@/components/organisms/RoomProfileSelect";
+import { AgitFlowChrome } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
@@ -51,19 +52,19 @@ export function InviteConfirmTemplate({ agitId }: { agitId: string }) {
 
 export function CreateRoomBasicTemplate() {
   return (
-    <DailyLoopAuthTemplate>
+    <AgitFlowChrome>
       <AuthTopBar title="아지트 만들기" backHref={ROUTES.agit.root} step="1 / 2 · 기본 정보" />
       <CreateRoomBasicForm />
-    </DailyLoopAuthTemplate>
+    </AgitFlowChrome>
   );
 }
 
 export function CreateRoomAccessTemplate() {
   return (
-    <DailyLoopAuthTemplate>
+    <AgitFlowChrome>
       <AuthTopBar title="아지트 만들기" backHref={ROUTES.agit.create} step="2 / 2 · 프로필" />
       <CreateRoomAccessForm />
-    </DailyLoopAuthTemplate>
+    </AgitFlowChrome>
   );
 }
 

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -1,82 +1,106 @@
-import { DailyIcon, TextLink } from "@/components/atoms";
+import { TextLink } from "@/components/atoms";
 import { AuthTopBar } from "@/components/molecules/AuthTopBar";
+import { AgitManageForm } from "@/components/organisms/AgitManageForm";
+import { AgitProfileEditForm } from "@/components/organisms/AgitProfileEditForm";
 import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySection";
 import { MembersPermissionsSection } from "@/components/organisms/MembersPermissionsSection";
-import { RoomManageHub } from "@/components/organisms/RoomManageHub";
 import { TopicCreateForm } from "@/components/organisms/TopicCreateForm";
 import { TopicsLayoutSection } from "@/components/organisms/TopicsLayoutSection";
+import { AgitFlowChrome } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import type { ApiAgitDetailMember } from "@/types/agit/api";
+import type { UiAgit } from "@/types/agit/ui";
 
 type AgitIdProps = { agitId: string };
 
 function RoomMissing() {
   return (
-    <DailyLoopAuthTemplate>
+    <AgitFlowChrome>
       <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">방을 찾을 수 없습니다.</p>
-      <TextLink href={ROUTES.agit.root} className="!text-[var(--dl-color-text-brand)] text-sm font-medium leading-5 !no-underline hover:!underline">
+      <TextLink href={ROUTES.agit.root} className="text-sm font-medium leading-5 !text-[var(--dl-color-text-brand)] !no-underline hover:!underline">
         목록으로
       </TextLink>
-    </DailyLoopAuthTemplate>
+    </AgitFlowChrome>
   );
 }
 
-export function RoomManageHubTemplate({ agitId }: AgitIdProps) {
-  const agit = getAgitById(agitId);
+export function RoomManageHubTemplate({ agit }: { agit: UiAgit | null }) {
   if (!agit) return <RoomMissing />;
 
   return (
-    <DailyLoopAuthTemplate>
-      <div className="flex flex-col gap-[16px] px-6 pb-8 pt-3">
-        <header className="flex items-start justify-between gap-[12px] gap-[10px] mb-[4px]">
-          <TextLink href={ROUTES.agit.detail(agit.id)} className="grid w-[44px] h-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline" aria-label="뒤로">
-            <DailyIcon name="chevronLeft" size={20} />
-          </TextLink>
-          <div className="pt-[14px] min-w-0 flex-1">
-            <h1 className="m-0 text-[26px] font-bold leading-[31px] text-[var(--dl-color-text-primary)] text-[24px] leading-[1.15]">방 관리</h1>
-            <p className="m-[4px_0_0] text-xs font-medium text-[var(--dl-color-text-brand)]">방장 · {agit.ownerName ?? "안지민"}</p>
-          </div>
-        </header>
-        <RoomManageHub agit={agit} />
-      </div>
-    </DailyLoopAuthTemplate>
+    <AgitFlowChrome>
+      <AuthTopBar title="아지트관리" backHref={ROUTES.agit.detail(agit.id)} />
+      <AgitManageForm agit={agit} />
+    </AgitFlowChrome>
   );
 }
 
 export function TopicsLayoutTemplate({ agitId }: AgitIdProps) {
   return (
-    <DailyLoopAuthTemplate>
-      <AuthTopBar title="토픽 관리" backHref={ROUTES.agit.manage(agitId)} />
+    <AgitFlowChrome>
+      <AuthTopBar title="토픽관리" backHref={ROUTES.agit.detail(agitId)} />
       <TopicsLayoutSection agitId={agitId} />
-    </DailyLoopAuthTemplate>
+    </AgitFlowChrome>
   );
 }
 
 export function TopicCreateTemplate({ agitId }: AgitIdProps) {
   return (
-    <DailyLoopAuthTemplate>
+    <AgitFlowChrome>
       <AuthTopBar
         title="토픽 만들기"
         backHref={ROUTES.agit.topics(agitId)}
         step="토픽 진행 기간과 적용 아이템을 정합니다"
       />
       <TopicCreateForm />
-    </DailyLoopAuthTemplate>
+    </AgitFlowChrome>
   );
 }
 
-export function MembersPermissionsTemplate({ agitId }: AgitIdProps) {
+export function MembersPermissionsTemplate({
+  agit,
+  members,
+}: {
+  agit: UiAgit | null;
+  members: ApiAgitDetailMember[];
+}) {
+  if (!agit) return <RoomMissing />;
+
+  const countLabel = agit.maxMembers
+    ? `${agit.memberCount} / ${agit.maxMembers}명`
+    : `${agit.memberCount}명`;
+
   return (
-    <DailyLoopAuthTemplate>
-      <AuthTopBar title="멤버 관리" backHref={ROUTES.agit.manage(agitId)} />
-      <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">4 / 5명 · 방장만 권한을 변경할 수 있어요</p>
-      <MembersPermissionsSection />
-    </DailyLoopAuthTemplate>
+    <AgitFlowChrome>
+      <AuthTopBar title="멤버리스트" backHref={ROUTES.agit.detail(agit.id)} />
+      <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">{countLabel}</p>
+      <MembersPermissionsSection members={members} />
+    </AgitFlowChrome>
+  );
+}
+
+export function RoomProfileEditTemplate({
+  agit,
+  nickname,
+}: {
+  agit: UiAgit | null;
+  nickname: string;
+}) {
+  if (!agit) return <RoomMissing />;
+
+  return (
+    <AgitFlowChrome>
+      <AuthTopBar title="내프로필관리" backHref={ROUTES.agit.detail(agit.id)} />
+      <AgitProfileEditForm agitId={agit.id} nickname={nickname} />
+    </AgitFlowChrome>
   );
 }
 
 export function InvitesSafetyTemplate({ agitId }: AgitIdProps) {
+  if (!getAgitById(agitId)) return <RoomMissing />;
+
   return (
     <DailyLoopAuthTemplate>
       <p className="m-0 text-xs font-semibold leading-[17px] text-[var(--dl-color-text-brand)]">03 · SAFETY</p>

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -11,6 +11,7 @@ export {
   AgitSearchTemplate,
   AgitTopicsTemplate,
   AgitManageTemplate,
+  AgitProfileEditTemplate,
   AgitSafetyTemplate,
   AgitTopicCreateTemplate,
 } from "./AgitTemplates";

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -22,7 +22,7 @@ function ToastViewport({ className, ...props }: ToastPrimitive.Viewport.Props) {
     <ToastPrimitive.Viewport
       data-slot="toast-viewport"
       className={cn(
-        "pointer-events-none absolute inset-x-4 bottom-4 z-[60] mx-auto w-auto max-w-[min(100%,20rem)] outline-none",
+        "pointer-events-none absolute inset-x-4 bottom-[96px] z-[60] mx-auto w-auto max-w-[min(100%,20rem)] outline-none",
         className
       )}
       {...props}
@@ -62,7 +62,7 @@ function ToastContent({ className, ...props }: ToastPrimitive.Content.Props) {
     <ToastPrimitive.Content
       data-slot="toast-content"
       className={cn(
-        "flex h-full items-center gap-3 overflow-hidden p-4 transition-opacity duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] data-behind:opacity-0 data-expanded:opacity-100",
+        "flex h-full items-center gap-2.5 overflow-hidden px-3.5 py-3 transition-opacity duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] data-behind:opacity-0 data-expanded:opacity-100",
         className
       )}
       {...props}

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -28,6 +28,7 @@ export const API_ENDPOINTS = {
     create: gatewayPath("agit", "/api/v1/agits"),
     me: gatewayPath("agit", "/api/v1/agits/me"),
     detail: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}`),
+    memberMe: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}/members/me`),
     leave: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}/leave`),
   },
   topic: {

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -25,6 +25,7 @@ export const ROUTES = {
     enter: (agitId: string) => `/agit/${agitId}/enter` as const,
     invite: (agitId: string) => `/agit/${agitId}/invite` as const,
     profile: (agitId: string) => `/agit/${agitId}/profile` as const,
+    profileEdit: (agitId: string) => `/agit/${agitId}/profile/edit` as const,
     joined: (agitId: string) => `/agit/${agitId}/joined` as const,
     members: (agitId: string) => `/agit/${agitId}/members` as const,
     topics: (agitId: string) => `/agit/${agitId}/topics` as const,

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -3,7 +3,16 @@ import { getActorUserHeaders } from "@/lib/api/actorHeaders";
 import { apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl } from "@/lib/api/env";
 import { withAuthRetry } from "@/lib/api/withAuthRetry";
-import type { ApiAgitDetail, ApiCreateAgitRequest, ApiCreateAgitResponse, ApiMyAgitItem } from "@/types/agit/api";
+import type {
+  ApiAgitDetail,
+  ApiCreateAgitRequest,
+  ApiCreateAgitResponse,
+  ApiMyAgitItem,
+  ApiUpdateAgitRequest,
+  ApiUpdateAgitResponse,
+  ApiUpdateMyMemberProfileRequest,
+  ApiUpdateMyMemberProfileResponse,
+} from "@/types/agit/api";
 
 export async function getMyAgits(): Promise<ApiMyAgitItem[]> {
   return withAuthRetry(async () =>
@@ -42,6 +51,34 @@ export async function leaveAgit(agitUuid: string): Promise<void> {
       method: "POST",
       baseUrl: getApiUrl(),
       headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function updateAgit(
+  agitUuid: string,
+  body: ApiUpdateAgitRequest,
+): Promise<ApiUpdateAgitResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiUpdateAgitResponse>(API_ENDPOINTS.agit.detail(agitUuid), {
+      method: "PATCH",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      body,
+    }),
+  );
+}
+
+export async function updateMyMemberProfile(
+  agitUuid: string,
+  body: ApiUpdateMyMemberProfileRequest,
+): Promise<ApiUpdateMyMemberProfileResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiUpdateMyMemberProfileResponse>(API_ENDPOINTS.agit.memberMe(agitUuid), {
+      method: "PATCH",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      body,
     }),
   );
 }

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -21,6 +21,11 @@ async function getServerAuthJwtSafe() {
   }
 }
 
+export async function getServerUserUuid(): Promise<string | undefined> {
+  const jwt = await getServerAuthJwtSafe();
+  return typeof jwt?.userUuid === "string" && jwt.userUuid.length > 0 ? jwt.userUuid : undefined;
+}
+
 export async function getServerAccessToken(): Promise<string | undefined> {
   const override = getRequestAccessTokenOverride();
   if (override) {

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -1,5 +1,14 @@
 import * as agitApi from "@/lib/api/agitApi";
-import type { ApiAgitDetail, ApiCreateAgitRequest, ApiCreateAgitResponse, ApiMyAgitItem } from "@/types/agit/api";
+import type {
+  ApiAgitDetail,
+  ApiAgitDetailMember,
+  ApiCreateAgitRequest,
+  ApiCreateAgitResponse,
+  ApiMyAgitItem,
+  ApiUpdateAgitRequest,
+  ApiUpdateMyMemberProfileRequest,
+  ApiUpdateMyMemberProfileResponse,
+} from "@/types/agit/api";
 import type { UiAgit, UiCreateAgitInput } from "@/types/agit/ui";
 
 const DEFAULT_COVER_GRADIENT = "linear-gradient(104deg, #2e1f52 0%, #7a5cfa 100%)";
@@ -29,7 +38,22 @@ function mapAgitDetail(item: ApiAgitDetail): UiAgit {
     thumbnailSrc: item.thumbnailPath ?? undefined,
     inviteCode: item.code,
     joined: true,
+    myRole: item.myRole,
   };
+}
+
+export function sortAgitMembers(
+  members: ApiAgitDetailMember[],
+  currentUserUuid?: string,
+): ApiAgitDetailMember[] {
+  return [...members].sort((a, b) => {
+    const rank = (member: ApiAgitDetailMember) => {
+      if (member.role === "HOST") return 0;
+      if (currentUserUuid && member.userUuid === currentUserUuid) return 1;
+      return 2;
+    };
+    return rank(a) - rank(b);
+  });
 }
 
 export async function listMyAgits(): Promise<UiAgit[]> {
@@ -66,11 +90,24 @@ function mapCreatedAgit(item: ApiCreateAgitResponse): UiAgit {
     thumbnailSrc: item.thumbnailPath ?? undefined,
     inviteCode: item.code,
     joined: true,
+    myRole: item.role,
   };
 }
 
 export async function leaveAgit(agitId: string): Promise<void> {
   await agitApi.leaveAgit(agitId);
+}
+
+export async function updateAgit(agitId: string, body: ApiUpdateAgitRequest): Promise<UiAgit> {
+  await agitApi.updateAgit(agitId, body);
+  return getAgit(agitId);
+}
+
+export async function updateMyMemberProfile(
+  agitId: string,
+  body: ApiUpdateMyMemberProfileRequest,
+): Promise<ApiUpdateMyMemberProfileResponse> {
+  return agitApi.updateMyMemberProfile(agitId, body);
 }
 
 export async function createAgit(input: UiCreateAgitInput): Promise<UiAgit> {

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -55,3 +55,28 @@ export type ApiCreateAgitResponse = {
   profileImagePath: string | null;
   role: ApiAgitMemberRole;
 };
+
+export type ApiUpdateAgitRequest = {
+  agitName: string;
+  description?: string;
+  maximumCapacity: number;
+  thumbnailPath?: string;
+};
+
+export type ApiUpdateAgitResponse = {
+  agitUuid: string;
+  agitName: string;
+  description: string | null;
+  maximumCapacity: number;
+  thumbnailPath: string | null;
+};
+
+export type ApiUpdateMyMemberProfileRequest = {
+  nickname?: string;
+  profileImagePath?: string;
+};
+
+export type ApiUpdateMyMemberProfileResponse = {
+  nickname: string;
+  profileImagePath: string | null;
+};

--- a/types/agit/schema.ts
+++ b/types/agit/schema.ts
@@ -1,4 +1,4 @@
-import type { ApiCreateAgitRequest } from "@/types/agit/api";
+import type { ApiCreateAgitRequest, ApiUpdateAgitRequest } from "@/types/agit/api";
 
 export const AGIT_NAME_MAX_LENGTH = 20;
 export const AGIT_DESCRIPTION_MAX_LENGTH = 100;
@@ -59,13 +59,11 @@ export function parseCreateAgitInput(input: {
     };
   }
 
-  const nickname = asTrimmedString(input.nickname);
-  if (!AGIT_NICKNAME_PATTERN.test(nickname)) {
-    return {
-      ok: false,
-      error: `닉네임은 영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자이며, 특수문자와 공백을 사용할 수 없습니다.`,
-    };
+  const nicknameResult = parseAgitNickname(input.nickname);
+  if (!nicknameResult.ok) {
+    return nicknameResult;
   }
+  const nickname = nicknameResult.nickname;
 
   const thumbnailPath = asOptionalPath(input.thumbnailPath);
   const profileImagePath = asOptionalPath(input.profileImagePath);
@@ -79,6 +77,79 @@ export function parseCreateAgitInput(input: {
       nickname,
       ...(thumbnailPath ? { thumbnailPath } : {}),
       ...(profileImagePath ? { profileImagePath } : {}),
+    },
+  };
+}
+
+export type NicknameParseResult =
+  | { ok: true; nickname: string }
+  | { ok: false; error: string };
+
+export function parseAgitNickname(value: unknown): NicknameParseResult {
+  const nickname = asTrimmedString(value);
+  if (!AGIT_NICKNAME_PATTERN.test(nickname)) {
+    return {
+      ok: false,
+      error: `닉네임은 영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자이며, 특수문자와 공백을 사용할 수 없습니다.`,
+    };
+  }
+  return { ok: true, nickname };
+}
+
+export type UpdateAgitParseResult =
+  | { ok: true; data: ApiUpdateAgitRequest }
+  | { ok: false; error: string };
+
+export function parseUpdateAgitInput(
+  input: {
+    agitName: unknown;
+    description?: unknown;
+    maximumCapacity: unknown;
+    thumbnailPath?: unknown;
+  },
+  options: { minCapacity: number },
+): UpdateAgitParseResult {
+  const agitName = asTrimmedString(input.agitName);
+  if (!agitName) {
+    return { ok: false, error: "아지트 제목은 필수입니다." };
+  }
+  if (agitName.length > AGIT_NAME_MAX_LENGTH) {
+    return { ok: false, error: `아지트 제목은 ${AGIT_NAME_MAX_LENGTH}자 이하여야 합니다.` };
+  }
+
+  const description = asTrimmedString(input.description);
+  if (description.length > AGIT_DESCRIPTION_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `소개글은 ${AGIT_DESCRIPTION_MAX_LENGTH}자 이하여야 합니다.`,
+    };
+  }
+
+  const maximumCapacity =
+    typeof input.maximumCapacity === "number"
+      ? input.maximumCapacity
+      : Number(input.maximumCapacity);
+  if (!Number.isInteger(maximumCapacity)) {
+    return { ok: false, error: "인원수는 필수입니다." };
+  }
+
+  const minCapacity = Math.max(options.minCapacity, 1);
+  if (maximumCapacity < minCapacity || maximumCapacity > AGIT_DEFAULT_MAX_CAPACITY) {
+    return {
+      ok: false,
+      error: `인원수는 ${minCapacity} 이상 ${AGIT_DEFAULT_MAX_CAPACITY} 이하여야 합니다.`,
+    };
+  }
+
+  const thumbnailPath = asOptionalPath(input.thumbnailPath);
+
+  return {
+    ok: true,
+    data: {
+      agitName,
+      ...(description ? { description } : {}),
+      maximumCapacity,
+      ...(thumbnailPath ? { thumbnailPath } : {}),
     },
   };
 }

--- a/types/agit/ui.ts
+++ b/types/agit/ui.ts
@@ -1,5 +1,7 @@
 export type UiAgitVisibility = "public" | "private";
 
+export type UiAgitRole = "HOST" | "GUEST";
+
 export type UiMyAgit = {
   id: string;
   name: string;
@@ -40,6 +42,7 @@ export type UiAgit = {
   joined?: boolean;
   hasNewChat?: boolean;
   hasTodayTopic?: boolean;
+  myRole?: UiAgitRole;
 };
 
 export type UiAgitMember = {


### PR DESCRIPTION
## 작업 내용

아지트 하위 화면(멤버리스트, 내프로필관리, 아지트관리, 토픽관리 목업)을 상세 데이터·PATCH API와 연결한다. 생성·관리 계열에 하단 아지트 탭을 붙이고, 토스트와 메뉴 드로어가 PC 폰 프레임·하단 내비와 겹치지 않도록 맞춘다. HOST만 아지트관리·토픽관리에 진입할 수 있다.

## 관련 이슈

Close #66
#60,#66,#67,#68,#69,#70

## 변경 사항

### 1. 아지트 수정·내 프로필 PATCH와 myRole 연동

- **파일:** `lib/api/agitApi.ts`, `services/agitService.ts`, `actions/agitActions.ts`, `types/agit/api.ts`, `types/agit/ui.ts`, `types/agit/schema.ts`, `config/api-endpoints.ts`, `config/routes.ts`, `lib/auth/server-token.ts`
- **설명:** `PATCH /agits/{uuid}`, `PATCH /agits/{uuid}/members/me`를 추가하고 상세 응답의 `myRole`을 UI에 매핑한다. 멤버 정렬은 HOST → 본인 → 나머지이다.

```typescript
export async function updateAgit(
  agitUuid: string,
  body: ApiUpdateAgitRequest,
): Promise<ApiUpdateAgitResponse> {
  return withAuthRetry(async () =>
    apiFetch<ApiUpdateAgitResponse>(API_ENDPOINTS.agit.detail(agitUuid), {
      method: "PATCH",
      baseUrl: getApiUrl(),
      headers: await getActorUserHeaders(),
      body,
    }),
  );
}

export async function updateMyMemberProfile(
  agitUuid: string,
  body: ApiUpdateMyMemberProfileRequest,
): Promise<ApiUpdateMyMemberProfileResponse> {
  return withAuthRetry(async () =>
    apiFetch<ApiUpdateMyMemberProfileResponse>(API_ENDPOINTS.agit.memberMe(agitUuid), {
      method: "PATCH",
      baseUrl: getApiUrl(),
      headers: await getActorUserHeaders(),
      body,
    }),
  );
}
```

### 2. 토스트·드로어 프레임 배치와 생성 화면 하단 탭

- **파일:** `components/ui/toast.tsx`, `components/templates/AppChromeTemplate.tsx`, `components/templates/RoomFlowTemplates.tsx`, `components/organisms/AgitMenuDrawer.tsx`, `components/organisms/ChatMoreSheet.tsx`, `components/organisms/RoomChatSection.tsx`
- **설명:** 토스트 Viewport를 하단 내비 위(`96px`)로 올리고, 드로어·채팅 더보기를 프레임 기준 `absolute`로 둔다. 나가기는 확인 후에만 호출한다. 생성 1·2단계는 `AgitFlowChrome`으로 감싼다.

```tsx
export function AgitFlowChrome({ children }: { children: ReactNode }) {
  return (
    <AppChromeTemplate activeTab="agit" variant="light">
      <div className={`${ui.authContent} min-h-0 flex-1 overflow-y-auto`}>{children}</div>
    </AppChromeTemplate>
  );
}
```

```tsx
"pointer-events-none absolute inset-x-4 bottom-[96px] z-[60] mx-auto w-auto max-w-[min(100%,20rem)] outline-none"
```

### 3. 멤버·프로필·아지트관리·토픽관리 화면

- **파일:** `app/(agit)/agit/[agitId]/members/page.tsx`, `app/(agit)/agit/[agitId]/manage/page.tsx`, `app/(agit)/agit/[agitId]/profile/edit/page.tsx`, `components/organisms/AgitManageForm.tsx`, `components/organisms/AgitProfileEditForm.tsx`, `components/organisms/MembersPermissionsSection.tsx`, `components/organisms/TopicsLayoutSection.tsx`, `components/templates/RoomManageTemplates.tsx`
- **설명:** 멤버리스트는 상세 `members`를 표시하고 위임|추방은 UI만 유지한다. 프로필 수정은 닉네임 PATCH 후 상세로 돌아간다. 아지트관리는 생성 1단계와 같은 폼이며 HOST가 아니면 상세로 redirect한다. 토픽관리는 진행중/다가오는/지난 섹션 목업이다.

```tsx
if (!agit || agit.myRole !== "HOST") {
  redirect(ROUTES.agit.detail(agitId));
}

return <AgitManageTemplate agit={agit} />;
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] 토스트가 하단 탭 위에 보이는지
  - [x] 드로어 나가기 확인 후 목록으로 이동하는지
  - [x] HOST만 아지트관리·토픽관리 메뉴가 보이는지
  - [x] 멤버리스트 정렬(HOST → 본인 → 나머지)
  - [x] 프로필·아지트관리 저장 후 토스트와 상세 이동

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인
