### PR TITLE
[#72] Feature : 아지트에서 멤버리스트 추방·방장 위임 API 연동

### DIFF
--- a/actions/agitActions.ts
+++ b/actions/agitActions.ts
@@ -25,6 +25,30 @@ export async function leaveAgitAction(agitId: string): Promise<ActionResult<void
   }
 }
 
+export async function banAgitMemberAction(
+  agitId: string,
+  ampId: number,
+): Promise<ActionResult<void>> {
+  try {
+    await agitService.banAgitMember(agitId, ampId);
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function transferAgitHostAction(
+  agitId: string,
+  ampId: number,
+): Promise<ActionResult<void>> {
+  try {
+    await agitService.transferAgitHost(agitId, ampId);
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
 export async function createAgitAction(
   input: UiCreateAgitInput,
 ): Promise<ActionResult<UiAgit>> {

--- a/app/(agit)/agit/[agitId]/members/page.tsx
+++ b/app/(agit)/agit/[agitId]/members/page.tsx
@@ -12,15 +12,18 @@ export default async function AgitMembersPage({ params }: PageProps) {
   const { agitId } = await params;
   let agit: UiAgit | null = null;
   let members: ApiAgitDetailMember[] = [];
+  let currentUserUuid: string | undefined;
 
   try {
     const detail = await getAgitAndMembers(agitId);
     agit = detail.agit;
-    const userUuid = await getServerUserUuid();
-    members = sortAgitMembers(detail.members, userUuid);
+    currentUserUuid = await getServerUserUuid();
+    members = sortAgitMembers(detail.members, currentUserUuid);
   } catch {
     agit = null;
   }
 
-  return <AgitMembersTemplate agit={agit} members={members} />;
+  return (
+    <AgitMembersTemplate agit={agit} members={members} currentUserUuid={currentUserUuid} />
+  );
 }

--- a/components/molecules/MemberManageRow.tsx
+++ b/components/molecules/MemberManageRow.tsx
@@ -1,4 +1,4 @@
-import { DailyIcon } from "@/components/atoms";
+import { DailyIcon, SubmitButton } from "@/components/atoms";
 
 type MemberManageRowProps = {
   name: string;
@@ -6,9 +6,15 @@ type MemberManageRowProps = {
   host?: boolean;
   selected?: boolean;
   showMenu?: boolean;
+  showActions?: boolean;
+  actionsDisabled?: boolean;
   variant?: "hub" | "manage";
   onSelect?: () => void;
+  onTransfer?: () => void;
+  onBan?: () => void;
 };
+
+const rowActionClass = "h-8 w-auto min-w-0 shrink-0 px-2.5 py-0 text-[11px] leading-4";
 
 export function MemberManageRow({
   name,
@@ -16,8 +22,12 @@ export function MemberManageRow({
   host = false,
   selected = false,
   showMenu = false,
+  showActions = false,
+  actionsDisabled = false,
   variant = "manage",
   onSelect,
+  onTransfer,
+  onBan,
 }: MemberManageRowProps) {
   const rowClass = [
     "flex items-center gap-[10px] min-h-[64px] p-[8px_12px] border border-[var(--dl-color-border-default)] rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-elevated)]",
@@ -43,11 +53,34 @@ export function MemberManageRow({
         ) : (
           <span className="text-[var(--dl-color-text-danger)] ml-auto text-[11px] font-medium text-[var(--dl-color-text-brand)] whitespace-nowrap">방장</span>
         )
-      ) : (
+      ) : showActions ? (
+        <span className="ml-auto flex shrink-0 items-center gap-1">
+          <SubmitButton
+            type="button"
+            variant="outline"
+            className={rowActionClass}
+            disabled={actionsDisabled}
+            aria-label={`${name} 위임`}
+            onClick={onTransfer}
+          >
+            위임
+          </SubmitButton>
+          <SubmitButton
+            type="button"
+            variant="danger"
+            className={rowActionClass}
+            disabled={actionsDisabled}
+            aria-label={`${name} 추방`}
+            onClick={onBan}
+          >
+            추방
+          </SubmitButton>
+        </span>
+      ) : variant === "hub" ? (
         <span className={`text-[var(--dl-color-text-danger)] ml-auto text-[11px] font-medium text-[var(--dl-color-text-brand)] whitespace-nowrap${selected ? " text-[var(--dl-color-text-danger)] m-dlMemberManageActionsDanger" : ""}`}>
           위임&nbsp;&nbsp;|&nbsp;&nbsp;추방
         </span>
-      )}
+      ) : null}
       {showMenu ? (
         <button type="button" className="grid w-[44px] h-[44px] place-items-center border-0 rounded-[12px] bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-primary)] cursor-pointer shrink-0" aria-label={`${name} 더보기`}>
           <DailyIcon name="ellipsis" size={20} />

--- a/components/organisms/MembersPermissionsSection.tsx
+++ b/components/organisms/MembersPermissionsSection.tsx
@@ -1,21 +1,162 @@
+"use client";
+
+import { banAgitMemberAction, transferAgitHostAction } from "@/actions/agitActions";
+import { SubmitButton } from "@/components/atoms";
 import { MemberManageRow } from "@/components/molecules/MemberManageRow";
-import type { ApiAgitDetailMember } from "@/types/agit/api";
+import { toast } from "@/components/ui/toast";
+import type { ApiAgitDetailMember, ApiAgitMemberRole } from "@/types/agit/api";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 type MembersPermissionsSectionProps = {
+  agitId: string;
   members: ApiAgitDetailMember[];
+  myRole?: ApiAgitMemberRole;
+  currentUserUuid?: string;
 };
 
-export function MembersPermissionsSection({ members }: MembersPermissionsSectionProps) {
+type ConfirmAction = "ban" | "transfer";
+
+type ConfirmTarget = {
+  action: ConfirmAction;
+  member: ApiAgitDetailMember;
+};
+
+function canShowActions(
+  myRole: ApiAgitMemberRole | undefined,
+  member: ApiAgitDetailMember,
+  currentUserUuid?: string,
+): boolean {
+  if (myRole !== "HOST" || member.role !== "GUEST") {
+    return false;
+  }
+  if (currentUserUuid && member.userUuid === currentUserUuid) {
+    return false;
+  }
+  return true;
+}
+
+export function MembersPermissionsSection({
+  agitId,
+  members,
+  myRole,
+  currentUserUuid,
+}: MembersPermissionsSectionProps) {
+  const router = useRouter();
+  const [confirm, setConfirm] = useState<ConfirmTarget | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  function closeConfirm() {
+    if (submitting) return;
+    setConfirm(null);
+  }
+
+  async function handleConfirm() {
+    if (!confirm || submitting) return;
+    const ampId = confirm.member.ampId;
+    if (ampId == null) return;
+
+    setSubmitting(true);
+    const result =
+      confirm.action === "ban"
+        ? await banAgitMemberAction(agitId, ampId)
+        : await transferAgitHostAction(agitId, ampId);
+
+    if (!result.ok) {
+      toast.add({
+        type: "error",
+        title: confirm.action === "ban" ? "멤버를 추방하지 못했습니다" : "방장을 위임하지 못했습니다",
+        description: result.error,
+      });
+      setSubmitting(false);
+      return;
+    }
+
+    setConfirm(null);
+    setSubmitting(false);
+    toast.add({
+      type: "success",
+      title: confirm.action === "ban" ? "멤버를 추방했습니다" : "방장 권한을 위임했습니다",
+    });
+    router.refresh();
+  }
+
+  const confirmTitleId = "agit-member-action-title";
+
   return (
-    <section className="flex w-full flex-col gap-3.5">
-      {members.map((member) => (
-        <MemberManageRow
-          key={member.userUuid}
-          name={member.nickname}
-          meta={member.role === "HOST" ? "방장" : "멤버"}
-          host={member.role === "HOST"}
-        />
-      ))}
+    <section className="relative flex w-full flex-col gap-3.5">
+      {members.map((member) => {
+        const showActions = canShowActions(myRole, member, currentUserUuid);
+        return (
+          <MemberManageRow
+            key={member.userUuid}
+            name={member.nickname}
+            meta={member.role === "HOST" ? "방장" : "멤버"}
+            host={member.role === "HOST"}
+            showActions={showActions}
+            actionsDisabled={member.ampId == null}
+            onTransfer={
+              showActions ? () => setConfirm({ action: "transfer", member }) : undefined
+            }
+            onBan={showActions ? () => setConfirm({ action: "ban", member }) : undefined}
+          />
+        );
+      })}
+
+      {confirm ? (
+        <div className="fixed inset-0 z-[42] flex items-center justify-center p-6">
+          <button
+            type="button"
+            className="absolute inset-0 border-0 bg-[rgba(0,0,0,0.32)]"
+            aria-label="취소"
+            disabled={submitting}
+            onClick={closeConfirm}
+          />
+          <div
+            role="dialog"
+            aria-modal
+            aria-labelledby={confirmTitleId}
+            className="relative z-[1] w-full max-w-[280px] rounded-[20px] border border-[#e3e0ed] bg-[#fbfaff] p-5 shadow-[0_8px_24px_rgba(31,28,41,0.12)]"
+          >
+            <p id={confirmTitleId} className="m-0 text-base font-semibold text-[#1f1c29]">
+              {confirm.action === "ban"
+                ? `${confirm.member.nickname} 님을 추방할까요?`
+                : `${confirm.member.nickname} 님에게 방장을 위임할까요?`}
+            </p>
+            <p className="m-[8px_0_0] text-xs text-[#756e8a]">
+              {confirm.action === "ban"
+                ? "추방하면 이 아지트에 다시 들어올 수 없습니다."
+                : "방장 권한이 넘어가고 본인은 멤버가 됩니다."}
+            </p>
+            <div className="mt-4 flex gap-2">
+              <SubmitButton
+                type="button"
+                variant="outline"
+                className="flex-1"
+                disabled={submitting}
+                onClick={closeConfirm}
+              >
+                취소
+              </SubmitButton>
+              <SubmitButton
+                type="button"
+                variant={confirm.action === "ban" ? "danger" : "brand"}
+                className="flex-1"
+                disabled={submitting}
+                onClick={handleConfirm}
+              >
+                {submitting
+                  ? confirm.action === "ban"
+                    ? "추방 중..."
+                    : "위임 중..."
+                  : confirm.action === "ban"
+                    ? "추방"
+                    : "위임"}
+              </SubmitButton>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -62,9 +62,11 @@ export function TopicCreateTemplate({ agitId }: AgitIdProps) {
 export function MembersPermissionsTemplate({
   agit,
   members,
+  currentUserUuid,
 }: {
   agit: UiAgit | null;
   members: ApiAgitDetailMember[];
+  currentUserUuid?: string;
 }) {
   if (!agit) return <RoomMissing />;
 
@@ -76,7 +78,12 @@ export function MembersPermissionsTemplate({
     <AgitFlowChrome>
       <AuthTopBar title="멤버리스트" backHref={ROUTES.agit.detail(agit.id)} />
       <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">{countLabel}</p>
-      <MembersPermissionsSection members={members} />
+      <MembersPermissionsSection
+        agitId={agit.id}
+        members={members}
+        myRole={agit.myRole}
+        currentUserUuid={currentUserUuid}
+      />
     </AgitFlowChrome>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -30,6 +30,10 @@ export const API_ENDPOINTS = {
     detail: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}`),
     memberMe: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}/members/me`),
     leave: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}/leave`),
+    ban: (agitUuid: string, ampId: number) =>
+      gatewayPath("agit", `/api/v1/agits/${agitUuid}/members/${ampId}/ban`),
+    transferHost: (agitUuid: string, ampId: number) =>
+      gatewayPath("agit", `/api/v1/agits/${agitUuid}/members/${ampId}/transfer-host`),
   },
   topic: {
     list: gatewayPath("topic", "/api/v1/topics"),

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -55,6 +55,26 @@ export async function leaveAgit(agitUuid: string): Promise<void> {
   );
 }
 
+export async function banAgitMember(agitUuid: string, ampId: number): Promise<void> {
+  await withAuthRetry(async () =>
+    apiFetch<void>(API_ENDPOINTS.agit.ban(agitUuid, ampId), {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function transferAgitHost(agitUuid: string, ampId: number): Promise<void> {
+  await withAuthRetry(async () =>
+    apiFetch<void>(API_ENDPOINTS.agit.transferHost(agitUuid, ampId), {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
 export async function updateAgit(
   agitUuid: string,
   body: ApiUpdateAgitRequest,

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -98,6 +98,14 @@ export async function leaveAgit(agitId: string): Promise<void> {
   await agitApi.leaveAgit(agitId);
 }
 
+export async function banAgitMember(agitId: string, ampId: number): Promise<void> {
+  await agitApi.banAgitMember(agitId, ampId);
+}
+
+export async function transferAgitHost(agitId: string, ampId: number): Promise<void> {
+  await agitApi.transferAgitHost(agitId, ampId);
+}
+
 export async function updateAgit(agitId: string, body: ApiUpdateAgitRequest): Promise<UiAgit> {
   await agitApi.updateAgit(agitId, body);
   return getAgit(agitId);

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -8,6 +8,7 @@ export type ApiAgitMemberRole = "HOST" | "GUEST";
 export type ApiAgitStatus = "ACTIVE" | "DELETED";
 
 export type ApiAgitDetailMember = {
+  ampId: number | null;
   userUuid: string;
   nickname: string;
   profileImagePath: string | null;


### PR DESCRIPTION
## 작업 내용

아지트 멤버리스트에서 방장이 게스트를 추방하거나 방장 권한을 위임할 수 있게 했습니다. 상세 조회 멤버의 `ampId`와 기존 ban / transfer-host API에 연결하며, 확인 다이얼로그·토스트·목록 새로고침은 나가기와 같은 패턴입니다. 백엔드 추가 작업은 없고, 선행 agit 상세 `ampId` 배포가 전제입니다.

## 관련 이슈

Close #72

## 변경 사항

### 1. 추방·위임 API 연동 계층

- **파일:** `types/agit/api.ts`, `config/api-endpoints.ts`, `lib/api/agitApi.ts`, `services/agitService.ts`, `actions/agitActions.ts`
- **설명:** 상세 멤버에 `ampId`를 두고, `POST .../members/{ampId}/ban`·`transfer-host`를 `leaveAgit`과 같이 204 빈 본문으로 호출합니다.

```typescript
export async function banAgitMemberAction(
  agitId: string,
  ampId: number,
): Promise<ActionResult<void>> {
  try {
    await agitService.banAgitMember(agitId, ampId);
    return actionSuccess(undefined);
  } catch (error) {
    return toActionError(error);
  }
}
```

### 2. 멤버리스트 위임·추방 UI

- **파일:** `components/molecules/MemberManageRow.tsx`, `components/organisms/MembersPermissionsSection.tsx`, `components/templates/RoomManageTemplates.tsx`, `app/(agit)/agit/[agitId]/members/page.tsx`
- **설명:** HOST만 GUEST 행에 `SubmitButton`을 보입니다. 본인 행은 숨기고 `ampId`가 없으면 disabled입니다. 섹션 단일 확인 다이얼로그 후 성공 시 토스트와 `router.refresh()`로 리스트에 남고, 실패는 `result.error`를 그대로 보여 다이얼로그를 유지합니다.

```typescript
function canShowActions(
  myRole: ApiAgitMemberRole | undefined,
  member: ApiAgitDetailMember,
  currentUserUuid?: string,
): boolean {
  if (myRole !== "HOST" || member.role !== "GUEST") {
    return false;
  }
  if (currentUserUuid && member.userUuid === currentUserUuid) {
    return false;
  }
  return true;
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - HOST: GUEST 행 위임·추방 확인 후 API 호출, 성공 시 목록 갱신
  - GUEST: 위임·추방 버튼 없음
  - `ampId` 없으면 버튼 disabled

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인
