### PR TITLE
[#74] Feature : 토픽 목록·편집·뷰어 실연동

### DIFF
--- a/actions/topicActions.ts
+++ b/actions/topicActions.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { ApiError } from "@/lib/api/apiFetch";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import * as topicService from "@/services/topicService";
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import type { ApiTopicListStatus } from "@/types/topic/api";
+import { parseCreateTopicInput } from "@/types/topic/schema";
+import type { UiTopicListItem } from "@/types/topic/ui";
+
+function toActionError(error: unknown): ActionResult<never> {
+  if (error instanceof ApiError) {
+    return actionFailure(`[${error.status}] ${error.message}`);
+  }
+  if (error instanceof Error) {
+    return actionFailure(error.message);
+  }
+  return actionFailure("Unknown error");
+}
+
+export async function listTopicsByStatusAction(
+  agitId: string,
+  status: ApiTopicListStatus,
+  limit: number,
+): Promise<ActionResult<UiTopicListItem[]>> {
+  try {
+    const items = await topicService.listTopicsByStatus(agitId, status, limit);
+    return actionSuccess(items);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function createTopicAction(
+  agitId: string,
+  input: { title: unknown; startDate: unknown },
+): Promise<ActionResult<void>> {
+  const creatorUuid = await getServerUserUuid();
+  if (!creatorUuid) {
+    return actionFailure("로그인이 필요합니다.");
+  }
+
+  const parsed = parseCreateTopicInput(input);
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    await topicService.createTopic({
+      agitUuid: agitId,
+      creatorUuid,
+      title: parsed.title,
+      startAt: parsed.startAt,
+    });
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}

--- a/actions/topicActions.ts
+++ b/actions/topicActions.ts
@@ -5,7 +5,7 @@ import { getServerUserUuid } from "@/lib/auth/server-token";
 import * as topicService from "@/services/topicService";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import type { ApiTopicListStatus } from "@/types/topic/api";
-import { parseCreateTopicInput } from "@/types/topic/schema";
+import { parseCreateTopicInput, parseUpdateTopicInput } from "@/types/topic/schema";
 import type { UiTopicListItem } from "@/types/topic/ui";
 
 function toActionError(error: unknown): ActionResult<never> {
@@ -54,6 +54,38 @@ export async function createTopicAction(
     });
     return actionSuccess(undefined);
   } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function updateTopicAction(
+  topicId: string,
+  input: { title: unknown; startDate: unknown },
+): Promise<ActionResult<void>> {
+  const parsed = parseUpdateTopicInput(input);
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    await topicService.updateTopic(topicId, {
+      title: parsed.title,
+      startAt: parsed.startAt,
+    });
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function deleteTopicAction(topicId: string): Promise<ActionResult<void>> {
+  try {
+    await topicService.deleteTopic(topicId);
+    return actionSuccess(undefined);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 409) {
+      return actionFailure("영상이 있는 토픽은 삭제할 수 없어요.");
+    }
     return toActionError(error);
   }
 }

--- a/app/(agit)/agit/[agitId]/topics/[topicId]/edit/page.tsx
+++ b/app/(agit)/agit/[agitId]/topics/[topicId]/edit/page.tsx
@@ -1,0 +1,37 @@
+import { AgitTopicEditTemplate } from "@/components/templates";
+import { ROUTES } from "@/config/routes";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import { getAgit } from "@/services/agitService";
+import { getTopic } from "@/services/topicService";
+import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicDetail } from "@/types/topic/ui";
+import { redirect } from "next/navigation";
+
+type PageProps = {
+  params: Promise<{ agitId: string; topicId: string }>;
+};
+
+export default async function AgitTopicEditPage({ params }: PageProps) {
+  const { agitId, topicId } = await params;
+  let agit: UiAgit | null = null;
+  let topic: UiTopicDetail | null = null;
+
+  try {
+    agit = await getAgit(agitId);
+    topic = await getTopic(topicId);
+  } catch {
+    redirect(ROUTES.agit.topics(agitId));
+  }
+
+  if (!agit || !topic) {
+    redirect(ROUTES.agit.topics(agitId));
+  }
+
+  const currentUserUuid = await getServerUserUuid();
+  const canEdit = agit.myRole === "HOST" || topic.creatorUuid === currentUserUuid;
+  if (!canEdit) {
+    redirect(ROUTES.agit.topics(agitId));
+  }
+
+  return <AgitTopicEditTemplate agit={agit} topic={topic} />;
+}

--- a/app/(agit)/agit/[agitId]/topics/[topicId]/page.tsx
+++ b/app/(agit)/agit/[agitId]/topics/[topicId]/page.tsx
@@ -1,0 +1,30 @@
+import { AgitTopicViewerTemplate } from "@/components/templates";
+import { ROUTES } from "@/config/routes";
+import { getAgitAndMembers } from "@/services/agitService";
+import { getTopicViewer } from "@/services/topicService";
+import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicDetail, UiTopicVideo } from "@/types/topic/ui";
+import { redirect } from "next/navigation";
+
+type PageProps = {
+  params: Promise<{ agitId: string; topicId: string }>;
+};
+
+export default async function AgitTopicViewerPage({ params }: PageProps) {
+  const { agitId, topicId } = await params;
+  let agit: UiAgit | null = null;
+  let topic: UiTopicDetail | null = null;
+  let videos: UiTopicVideo[] = [];
+
+  try {
+    const detail = await getAgitAndMembers(agitId);
+    agit = detail.agit;
+    const viewer = await getTopicViewer(topicId, detail.members);
+    topic = viewer.topic;
+    videos = viewer.videos;
+  } catch {
+    redirect(ROUTES.agit.topics(agitId));
+  }
+
+  return <AgitTopicViewerTemplate agit={agit} topic={topic} videos={videos} />;
+}

--- a/app/(agit)/agit/[agitId]/topics/create/page.tsx
+++ b/app/(agit)/agit/[agitId]/topics/create/page.tsx
@@ -1,4 +1,8 @@
 import { AgitTopicCreateTemplate } from "@/components/templates";
+import { ROUTES } from "@/config/routes";
+import { getAgit } from "@/services/agitService";
+import type { UiAgit } from "@/types/agit/ui";
+import { redirect } from "next/navigation";
 
 type PageProps = {
   params: Promise<{ agitId: string }>;
@@ -6,5 +10,17 @@ type PageProps = {
 
 export default async function AgitTopicCreatePage({ params }: PageProps) {
   const { agitId } = await params;
-  return <AgitTopicCreateTemplate agitId={agitId} />;
+  let agit: UiAgit | null = null;
+
+  try {
+    agit = await getAgit(agitId);
+  } catch {
+    redirect(ROUTES.agit.detail(agitId));
+  }
+
+  if (!agit) {
+    redirect(ROUTES.agit.detail(agitId));
+  }
+
+  return <AgitTopicCreateTemplate agit={agit} />;
 }

--- a/app/(agit)/agit/[agitId]/topics/page.tsx
+++ b/app/(agit)/agit/[agitId]/topics/page.tsx
@@ -1,10 +1,55 @@
 import { AgitTopicsTemplate } from "@/components/templates";
+import { getAgitAndMembers } from "@/services/agitService";
+import { listTopicsByStatus } from "@/services/topicService";
+import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicListSection, UiTopicListSections } from "@/types/topic/ui";
 
 type PageProps = {
   params: Promise<{ agitId: string }>;
 };
 
+const EMPTY_SECTION: UiTopicListSection = { items: [] };
+
+async function loadSection(
+  agitId: string,
+  status: "ONGOING" | "UPCOMING" | "PAST",
+): Promise<UiTopicListSection> {
+  try {
+    const items = await listTopicsByStatus(agitId, status, 10);
+    return { items };
+  } catch (caught) {
+    return {
+      items: [],
+      error: caught instanceof Error ? caught.message : "토픽을 불러오지 못했습니다.",
+    };
+  }
+}
+
 export default async function AgitTopicsPage({ params }: PageProps) {
   const { agitId } = await params;
-  return <AgitTopicsTemplate agitId={agitId} />;
+  let agit: UiAgit | null = null;
+
+  try {
+    const detail = await getAgitAndMembers(agitId);
+    agit = detail.agit;
+  } catch {
+    agit = null;
+  }
+
+  let sections: UiTopicListSections = {
+    ongoing: EMPTY_SECTION,
+    upcoming: EMPTY_SECTION,
+    past: EMPTY_SECTION,
+  };
+
+  if (agit) {
+    const [ongoing, upcoming, past] = await Promise.all([
+      loadSection(agitId, "ONGOING"),
+      loadSection(agitId, "UPCOMING"),
+      loadSection(agitId, "PAST"),
+    ]);
+    sections = { ongoing, upcoming, past };
+  }
+
+  return <AgitTopicsTemplate agit={agit} sections={sections} />;
 }

--- a/app/(agit)/agit/[agitId]/topics/page.tsx
+++ b/app/(agit)/agit/[agitId]/topics/page.tsx
@@ -1,4 +1,5 @@
 import { AgitTopicsTemplate } from "@/components/templates";
+import { getServerUserUuid } from "@/lib/auth/server-token";
 import { getAgitAndMembers } from "@/services/agitService";
 import { listTopicsByStatus } from "@/services/topicService";
 import type { UiAgit } from "@/types/agit/ui";
@@ -28,10 +29,12 @@ async function loadSection(
 export default async function AgitTopicsPage({ params }: PageProps) {
   const { agitId } = await params;
   let agit: UiAgit | null = null;
+  let currentUserUuid: string | undefined;
 
   try {
     const detail = await getAgitAndMembers(agitId);
     agit = detail.agit;
+    currentUserUuid = await getServerUserUuid();
   } catch {
     agit = null;
   }
@@ -51,5 +54,5 @@ export default async function AgitTopicsPage({ params }: PageProps) {
     sections = { ongoing, upcoming, past };
   }
 
-  return <AgitTopicsTemplate agit={agit} sections={sections} />;
+  return <AgitTopicsTemplate agit={agit} sections={sections} currentUserUuid={currentUserUuid} />;
 }

--- a/components/molecules/ManageListRow.tsx
+++ b/components/molecules/ManageListRow.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+export const manageListRowClassName =
+  "flex w-full min-h-[64px] items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]";
+
+type ManageListRowProps = {
+  leading?: ReactNode;
+  title: ReactNode;
+  meta?: ReactNode;
+  trailing?: ReactNode;
+  className?: string;
+};
+
+export function ManageListRow({ leading, title, meta, trailing, className }: ManageListRowProps) {
+  return (
+    <div className={cn(manageListRowClassName, className)}>
+      {leading}
+      <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
+        {typeof title === "string" ? (
+          <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">{title}</p>
+        ) : (
+          title
+        )}
+        {meta == null ? null : typeof meta === "string" ? (
+          <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">{meta}</p>
+        ) : (
+          meta
+        )}
+      </div>
+      {trailing ? <div className="flex shrink-0 items-center gap-1">{trailing}</div> : null}
+    </div>
+  );
+}

--- a/components/molecules/MemberManageRow.tsx
+++ b/components/molecules/MemberManageRow.tsx
@@ -1,4 +1,5 @@
 import { DailyIcon, SubmitButton } from "@/components/atoms";
+import { ManageListRow } from "@/components/molecules/ManageListRow";
 
 type MemberManageRowProps = {
   name: string;
@@ -29,32 +30,18 @@ export function MemberManageRow({
   onTransfer,
   onBan,
 }: MemberManageRowProps) {
-  const rowClass = [
-    "flex items-center gap-[10px] min-h-[64px] p-[8px_12px] border border-[var(--dl-color-border-default)] rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-elevated)]",
-    variant === "hub" ? "" : "",
-    selected ? "border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-danger)] m-dlMemberManageSelected" : "",
-    onSelect ? "w-full border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] cursor-pointer text-left [font:inherit] text-[inherit] m-dlMemberManageInteractive" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  const content = (
+  const trailing = (
     <>
-      <span className="grid w-[40px] h-[40px] place-items-center overflow-hidden rounded-[999px] bg-[var(--dl-color-bg-brand-subtle)] shrink-0 [&_img]:block [&_img]:w-full [&_img]:h-full [&_img]:object-cover">
-        <img src="/plip/v13/profile-avatar.svg" alt="" width={40} height={40} />
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="text-[var(--dl-color-text-danger)] m-0 text-sm font-semibold text-[var(--dl-color-text-primary)]">{name}</p>
-        <p className="m-[4px_0_0] text-[13px] text-[var(--dl-color-text-secondary)] text-xs leading-[16px]">{meta}</p>
-      </div>
       {host ? (
         variant === "hub" ? (
-          <span className="text-[11px] font-medium p-[4px_8px] rounded-[999px] bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)] whitespace-nowrap">방장</span>
+          <span className="whitespace-nowrap rounded-[999px] bg-[var(--dl-color-bg-brand-subtle)] p-[4px_8px] text-[11px] font-medium text-[var(--dl-color-text-brand)]">
+            방장
+          </span>
         ) : (
-          <span className="text-[var(--dl-color-text-danger)] ml-auto text-[11px] font-medium text-[var(--dl-color-text-brand)] whitespace-nowrap">방장</span>
+          <span className="whitespace-nowrap text-[11px] font-medium text-[var(--dl-color-text-brand)]">방장</span>
         )
       ) : showActions ? (
-        <span className="ml-auto flex shrink-0 items-center gap-1">
+        <span className="flex shrink-0 items-center gap-1">
           <SubmitButton
             type="button"
             variant="outline"
@@ -77,25 +64,49 @@ export function MemberManageRow({
           </SubmitButton>
         </span>
       ) : variant === "hub" ? (
-        <span className={`text-[var(--dl-color-text-danger)] ml-auto text-[11px] font-medium text-[var(--dl-color-text-brand)] whitespace-nowrap${selected ? " text-[var(--dl-color-text-danger)] m-dlMemberManageActionsDanger" : ""}`}>
+        <span
+          className={`whitespace-nowrap text-[11px] font-medium text-[var(--dl-color-text-brand)]${selected ? " text-[var(--dl-color-text-danger)] m-dlMemberManageActionsDanger" : ""}`}
+        >
           위임&nbsp;&nbsp;|&nbsp;&nbsp;추방
         </span>
       ) : null}
       {showMenu ? (
-        <button type="button" className="grid w-[44px] h-[44px] place-items-center border-0 rounded-[12px] bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-primary)] cursor-pointer shrink-0" aria-label={`${name} 더보기`}>
+        <button
+          type="button"
+          className="grid h-[44px] w-[44px] shrink-0 cursor-pointer place-items-center rounded-[12px] border-0 bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-primary)]"
+          aria-label={`${name} 더보기`}
+        >
           <DailyIcon name="ellipsis" size={20} />
         </button>
       ) : null}
     </>
   );
 
+  const row = (
+    <ManageListRow
+      className={selected ? "bg-[var(--dl-color-bg-danger)] m-dlMemberManageSelected" : undefined}
+      leading={
+        <span className="grid h-[40px] w-[40px] shrink-0 place-items-center overflow-hidden rounded-[999px] bg-[var(--dl-color-bg-brand-subtle)] [&_img]:block [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
+          <img src="/plip/v13/profile-avatar.svg" alt="" width={40} height={40} />
+        </span>
+      }
+      title={name}
+      meta={meta}
+      trailing={trailing}
+    />
+  );
+
   if (onSelect) {
     return (
-      <button type="button" className={rowClass} onClick={onSelect}>
-        {content}
+      <button
+        type="button"
+        className="w-full cursor-pointer border-0 bg-transparent p-0 text-left [font:inherit] text-[inherit] m-dlMemberManageInteractive"
+        onClick={onSelect}
+      >
+        {row}
       </button>
     );
   }
 
-  return <div className={rowClass}>{content}</div>;
+  return row;
 }

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -1,6 +1,7 @@
 export { ActionSheet } from "./ActionSheet";
 export { AnimatedDialog, AnimatedDropdown, AnimatedSideSheet } from "./AnimatedOverlays";
 export { AgitListRow } from "./AgitListRow";
+export { ManageListRow } from "./ManageListRow";
 export { DestinationToggle } from "./DestinationToggle";
 export { DiaryCard } from "./DiaryCard";
 export { MemberManageRow } from "./MemberManageRow";

--- a/components/organisms/AgitDetailSection.tsx
+++ b/components/organisms/AgitDetailSection.tsx
@@ -62,7 +62,7 @@ export function AgitDetailSection({ agit, gallery, error, galleryError }: AgitDe
   const heading = gallery.topic?.isToday || !gallery.topic ? "오늘의 토픽" : gallery.topic.title || "토픽";
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
       <header className="grid shrink-0 grid-cols-[44px_1fr_44px] items-start gap-[10px] p-[12px_23px_0]">
         <TextLink href={ROUTES.agit.root} className="grid h-[44px] w-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] no-underline" aria-label="뒤로">
           <DailyIcon name="chevronLeft" size={20} />

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -121,11 +121,11 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
   if (!mounted) return null;
 
   return (
-    <>
+    <div className="fixed inset-0 z-[40] md:absolute">
       <button
         type="button"
         className={cn(
-          "absolute inset-0 z-[40] border-0 bg-[rgba(0,0,0,0.32)] [transition:opacity_280ms_ease] motion-reduce:transition-none",
+          "absolute inset-0 border-0 bg-[rgba(0,0,0,0.32)] [transition:opacity_280ms_ease] motion-reduce:transition-none",
           visible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
         )}
         aria-label="메뉴 닫기"
@@ -133,7 +133,7 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
       />
       <aside
         className={cn(
-          "absolute top-0 right-0 z-[41] flex h-full w-[min(310px,86%)] flex-col gap-2.5 rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-24 [transition:transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+          "absolute top-0 right-0 bottom-0 z-[1] flex w-[min(310px,86%)] flex-col gap-2.5 overflow-hidden rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-[calc(1.25rem+80px)] md:pb-5 [transition:transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           visible ? "[transform:translateX(0)]" : "[transform:translateX(100%)]",
         )}
         aria-label="아지트 메뉴"
@@ -224,7 +224,7 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
       </aside>
 
       {confirmLeave ? (
-        <div className="absolute inset-0 z-[42] flex items-center justify-center p-6">
+        <div className="absolute inset-0 z-[2] flex items-center justify-center p-6">
           <button
             type="button"
             className="absolute inset-0 border-0 bg-[rgba(0,0,0,0.32)]"
@@ -261,6 +261,6 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
           </div>
         </div>
       ) : null}
-    </>
+    </div>
   );
 }

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -133,7 +133,7 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
       />
       <aside
         className={cn(
-          "absolute top-0 right-0 bottom-0 z-[1] flex w-[min(310px,86%)] flex-col gap-2.5 overflow-hidden rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-[calc(1.25rem+80px)] md:pb-5 [transition:transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+          "absolute top-0 right-0 bottom-0 z-[1] flex w-[min(310px,86%)] flex-col gap-2.5 overflow-hidden rounded-l-[24px] bg-[#fbfaff] px-6 pt-12 pb-12 md:pb-5 [transition:transform_280ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           visible ? "[transform:translateX(0)]" : "[transform:translateX(100%)]",
         )}
         aria-label="아지트 메뉴"

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { leaveAgitAction } from "@/actions/agitActions";
+import { listTopicsByStatusAction } from "@/actions/topicActions";
 import { DailyIcon, Separator, TextLink } from "@/components/atoms";
-import { AGIT_TOPICS } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import { useOverlayTransition } from "@/hooks/useOverlayTransition";
 import { toast } from "@/components/ui/toast";
 import { copyText } from "@/lib/copyText";
 import { cn } from "@/lib/utils";
 import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicListItem } from "@/types/topic/ui";
 import { Check, Copy, Link2, LogOut, Settings, UserRoundCog } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type AgitMenuDrawerProps = {
   agit: UiAgit;
@@ -69,8 +70,21 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
   const [copied, setCopied] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [confirmLeave, setConfirmLeave] = useState(false);
+  const [ongoingTopics, setOngoingTopics] = useState<UiTopicListItem[]>([]);
   const inviteCode = agit.inviteCode?.trim() ?? "";
   const menuItems = MENU.filter((item) => !item.hostOnly || agit.myRole === "HOST");
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    listTopicsByStatusAction(agit.id, "ONGOING", 3).then((result) => {
+      if (cancelled) return;
+      setOngoingTopics(result.ok ? result.data : []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, agit.id]);
 
   async function copyInviteCode() {
     if (!inviteCode) return;
@@ -160,11 +174,25 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
 
         <div className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto">
           <div className="flex flex-col gap-1" aria-label="진행중인 토픽">
-            {AGIT_TOPICS.map((topic) => (
-              <p key={topic.id} className="m-0 px-1 text-sm font-medium text-[#262433]">
-                {topic.title}
-              </p>
-            ))}
+            <div className="flex min-h-[32px] items-center justify-between gap-2 px-1">
+              <p className="m-0 text-xs font-semibold text-[#756e8a]">진행중</p>
+              <TextLink
+                href={ROUTES.agit.topics(agit.id)}
+                className="text-xs font-semibold !text-[var(--dl-color-text-brand)] !no-underline"
+                onClick={handleClose}
+              >
+                더보기
+              </TextLink>
+            </div>
+            {ongoingTopics.length === 0 ? (
+              <p className="m-0 px-1 text-sm font-medium text-[#756e8a]">아직 토픽이 없어요</p>
+            ) : (
+              ongoingTopics.map((topic) => (
+                <p key={topic.id} className="m-0 px-1 text-sm font-medium text-[#262433]">
+                  {topic.title || "제목 없음"}
+                </p>
+              ))
+            )}
           </div>
 
           <Separator className="!m-1 !border-[#e3e0ed]" />

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -24,7 +24,7 @@ const MENU = [
     id: "topics" as const,
     label: "토픽관리",
     href: (id: string) => ROUTES.agit.topics(id),
-    hostOnly: true,
+    hostOnly: false,
   },
   { id: "chat" as const, label: "채팅", href: (id: string) => ROUTES.agit.chat(id), hostOnly: false },
   {

--- a/components/organisms/TopicCreateForm.tsx
+++ b/components/organisms/TopicCreateForm.tsx
@@ -1,51 +1,80 @@
 "use client";
 
+import { createTopicAction } from "@/actions/topicActions";
 import { SubmitButton } from "@/components/atoms";
 import { AuthField } from "@/components/molecules";
 import { NoticeCard } from "@/components/molecules/NoticeCard";
+import { toast } from "@/components/ui/toast";
+import { ROUTES } from "@/config/routes";
+import { toKstDateString } from "@/lib/topic/selectAgitTopic";
+import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-export function TopicCreateForm() {
-  const [itemSelected, setItemSelected] = useState(true);
+type TopicCreateFormProps = {
+  agitId: string;
+};
+
+export function TopicCreateForm({ agitId }: TopicCreateFormProps) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const today = toKstDateString(new Date());
+
+  async function handleSubmit(formData: FormData) {
+    if (pending) return;
+    setError(null);
+    setPending(true);
+
+    const result = await createTopicAction(agitId, {
+      title: formData.get("title"),
+      startDate: formData.get("startDate"),
+    });
+
+    setPending(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    toast.add({ type: "success", title: "토픽을 만들었습니다" });
+    router.push(ROUTES.agit.detail(agitId));
+    router.refresh();
+  }
 
   return (
-    <form className="flex w-full flex-col gap-3.5">
+    <form className="flex w-full flex-col gap-3.5" action={handleSubmit}>
       <AuthField
         id="topic-name"
-        name="name"
+        name="title"
         label="토픽 이름"
-        defaultValue="#저녁_산책"
-        maxLength={24}
+        hint={`최대 ${TOPIC_TITLE_MAX_LENGTH}자`}
+        placeholder="점심 메뉴"
+        maxLength={TOPIC_TITLE_MAX_LENGTH}
         required
       />
       <AuthField
-        id="topic-range"
-        name="range"
+        id="topic-date"
+        name="startDate"
         label="토픽 진행 날짜"
-        defaultValue="2026.08.18 — 2026.08.31"
+        type="date"
+        defaultValue={today}
         required
       />
-
-      <p className="m-0 text-[16px] font-semibold text-[var(--dl-color-text-primary)]">아이템</p>
-      <button
-        type="button"
-        className={`relative flex min-h-[130px] w-[min(170px,100%)] cursor-pointer flex-col gap-1 rounded-[16px] border border-[var(--dl-color-border-brand)] bg-[var(--dl-color-bg-brand-subtle)] p-[15px] text-left`}
-        onClick={() => setItemSelected((current) => !current)}
-      >
-        <p className="m-0 text-[24px] font-bold text-[var(--dl-color-text-brand)]">＋</p>
-        <p className="m-0 text-sm font-semibold text-[var(--dl-color-text-brand)]">아이템 적용</p>
-        <p className="m-0 text-[11px] text-[var(--dl-color-text-secondary)]">보유 아이템에서 선택</p>
-        {itemSelected ? <span className="inline-flex items-center justify-center w-[fit-content] mt-[8px] p-[6px_12px] rounded-[15px] bg-[var(--dl-color-bg-brand)] text-xs font-medium text-[#fff]">선택됨</span> : null}
-      </button>
 
       <NoticeCard
         tone="brand"
         title="등록 규칙"
-        body="한 사용자는 이 토픽에 영상 1개만 등록할 수 있어요. 방장은 이후 표시 형식을 변경할 수 있습니다."
+        body="한 사용자는 이 토픽에 영상 1개만 등록할 수 있어요. 진행 날짜는 하루입니다."
       />
 
+      {error ? <p className="m-0 text-[12px] text-red-600">{error}</p> : null}
+
       <div className="flex w-full flex-col gap-[14px] mt-auto">
-        <SubmitButton variant="brand">토픽 만들기</SubmitButton>
+        <SubmitButton variant="brand" disabled={pending}>
+          {pending ? "만드는 중..." : "토픽 만들기"}
+        </SubmitButton>
       </div>
     </form>
   );

--- a/components/organisms/TopicEditForm.tsx
+++ b/components/organisms/TopicEditForm.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { deleteTopicAction, updateTopicAction } from "@/actions/topicActions";
+import { SubmitButton } from "@/components/atoms";
+import { AuthField } from "@/components/molecules";
+import { toast } from "@/components/ui/toast";
+import { ROUTES } from "@/config/routes";
+import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
+import type { UiTopicDetail } from "@/types/topic/ui";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type TopicEditFormProps = {
+  agitId: string;
+  topic: UiTopicDetail;
+};
+
+export function TopicEditForm({ agitId, topic }: TopicEditFormProps) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const canDelete = topic.videoCount === 0;
+
+  async function handleSubmit(formData: FormData) {
+    if (pending) return;
+    setError(null);
+    setPending(true);
+
+    const result = await updateTopicAction(topic.id, {
+      title: formData.get("title"),
+      startDate: formData.get("startDate"),
+    });
+
+    setPending(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    toast.add({ type: "success", title: "토픽을 저장했습니다" });
+    router.push(ROUTES.agit.topics(agitId));
+    router.refresh();
+  }
+
+  async function handleDelete() {
+    if (deleting || !canDelete) return;
+    setDeleting(true);
+    const result = await deleteTopicAction(topic.id);
+    if (!result.ok) {
+      toast.add({
+        type: "error",
+        title: "토픽을 삭제하지 못했습니다",
+        description: result.error,
+      });
+      setDeleting(false);
+      setConfirmDelete(false);
+      return;
+    }
+    toast.add({ type: "success", title: "토픽을 삭제했습니다" });
+    router.push(ROUTES.agit.topics(agitId));
+    router.refresh();
+  }
+
+  return (
+    <div className="relative flex w-full flex-1 flex-col">
+      <form className="flex w-full flex-col gap-3.5" action={handleSubmit}>
+        <AuthField
+          id="topic-edit-name"
+          name="title"
+          label="토픽 이름"
+          hint={`최대 ${TOPIC_TITLE_MAX_LENGTH}자`}
+          defaultValue={topic.title}
+          maxLength={TOPIC_TITLE_MAX_LENGTH}
+          required
+        />
+        <AuthField
+          id="topic-edit-date"
+          name="startDate"
+          label="토픽 진행 날짜"
+          type="date"
+          defaultValue={topic.startDate}
+          required
+        />
+
+        {error ? <p className="m-0 text-[12px] text-red-600">{error}</p> : null}
+
+        <div className="mt-auto flex w-full flex-col gap-[14px]">
+          <SubmitButton variant="brand" disabled={pending}>
+            {pending ? "저장 중..." : "저장"}
+          </SubmitButton>
+          <button
+            type="button"
+            className="inline-flex h-[44px] w-full items-center justify-center rounded-[var(--dl-radius-md)] text-sm font-medium text-[var(--dl-color-text-danger)] disabled:opacity-50"
+            disabled={!canDelete}
+            onClick={() => setConfirmDelete(true)}
+          >
+            {canDelete ? "토픽 삭제" : "영상이 있어 삭제할 수 없어요"}
+          </button>
+        </div>
+      </form>
+
+      {confirmDelete ? (
+        <div className="absolute inset-0 z-[42] flex items-center justify-center p-6">
+          <button
+            type="button"
+            className="absolute inset-0 border-0 bg-[rgba(0,0,0,0.32)]"
+            aria-label="취소"
+            onClick={() => setConfirmDelete(false)}
+          />
+          <div
+            role="dialog"
+            aria-modal
+            aria-labelledby="topic-delete-title"
+            className="relative z-[1] w-full max-w-[280px] rounded-[20px] border border-[#e3e0ed] bg-[#fbfaff] p-5 shadow-[0_8px_24px_rgba(31,28,41,0.12)]"
+          >
+            <p id="topic-delete-title" className="m-0 text-base font-semibold text-[#1f1c29]">
+              토픽을 삭제하시겠어요?
+            </p>
+            <p className="m-[8px_0_0] text-xs text-[#756e8a]">삭제하면 목록에서 이 토픽이 사라집니다.</p>
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                className="flex h-11 flex-1 items-center justify-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)] text-sm font-medium text-[#262433]"
+                onClick={() => setConfirmDelete(false)}
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                className="flex h-11 flex-1 items-center justify-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-danger)] text-sm font-medium text-[var(--dl-color-text-danger)] disabled:opacity-50"
+                disabled={deleting}
+                onClick={handleDelete}
+              >
+                {deleting ? "삭제 중..." : "삭제"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/organisms/TopicViewerSection.tsx
+++ b/components/organisms/TopicViewerSection.tsx
@@ -2,20 +2,13 @@
 
 import { DailyIcon, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
-import Image from "next/image";
-
-const CLIPS = [
-  { id: "clip-1", src: "/plip/v13/topic-video-1.png" },
-  { id: "clip-2", src: "/plip/v13/topic-video-2.png" },
-  { id: "clip-3", src: "/plip/v13/topic-video-3.png" },
-  { id: "clip-4", src: "/plip/v13/topic-video-4.png" },
-];
+import type { UiTopicVideo } from "@/types/topic/ui";
 
 type TopicViewerSectionProps = {
   agitId: string;
   title?: string;
   meta?: string;
-  pageLabel?: string;
+  videos?: UiTopicVideo[];
   backHref?: string;
   onMenuClick?: () => void;
 };
@@ -23,8 +16,8 @@ type TopicViewerSectionProps = {
 export function TopicViewerSection({
   agitId,
   title = "오늘의 토픽",
-  meta = "8월 18일 · #7시_러닝_인증 · 7개 영상",
-  pageLabel = "1 / 2 · 다음 3개",
+  meta = "",
+  videos = [],
   backHref = ROUTES.agit.root,
   onMenuClick,
 }: TopicViewerSectionProps) {
@@ -36,7 +29,9 @@ export function TopicViewerSection({
         </TextLink>
         <div className="min-w-0 pt-[14px]">
           <h1 className="m-0 text-[22px] font-bold leading-[27px] text-[var(--dl-color-text-primary)]">{title}</h1>
-          <p className="m-[4px_0_0] text-xs leading-[16px] text-[var(--dl-color-text-secondary)]">{meta}</p>
+          {meta ? (
+            <p className="m-[4px_0_0] text-xs leading-[16px] text-[var(--dl-color-text-secondary)]">{meta}</p>
+          ) : null}
         </div>
         {onMenuClick ? (
           <button type="button" className="grid w-[44px] h-[44px] shrink-0 place-items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-surface)]" aria-label="아지트 메뉴" onClick={onMenuClick}>
@@ -47,17 +42,24 @@ export function TopicViewerSection({
         )}
       </header>
 
-      <div className="grid grid-cols-[1fr_1fr] gap-[8px]">
-        {CLIPS.map((clip) => (
-          <TextLink key={clip.id} href={ROUTES.viewer.clip(clip.id)} className="relative h-[240px] overflow-hidden border border-[var(--dl-color-border-default)] rounded-[16px] bg-[var(--dl-color-bg-surface)] no-underline">
-            <Image src={clip.src} alt="" fill className="object-cover" sizes="173px" />
-          </TextLink>
-        ))}
-      </div>
+      {videos.length === 0 ? (
+        <p className="m-0 text-[13px] text-[var(--dl-color-text-secondary)]">아직 영상이 없어요</p>
+      ) : (
+        <div className="grid grid-cols-[1fr_1fr] gap-[8px]">
+          {videos.map((video) => (
+            <TextLink
+              key={video.id}
+              href={ROUTES.viewer.clip(video.id)}
+              className="relative h-[240px] overflow-hidden border border-[var(--dl-color-border-default)] rounded-[16px] bg-[var(--dl-color-bg-surface)] no-underline"
+            >
+              <img src={video.thumbnailSrc} alt="" className="absolute inset-0 size-full object-cover" />
+            </TextLink>
+          ))}
+        </div>
+      )}
 
-      <div className="relative flex items-center justify-center min-h-[44px]">
-        <p className="m-0 inline-flex items-center p-[8px_16px] rounded-[999px] bg-[#f5f0ff] text-xs font-medium leading-[16px] text-[#6338ed]">{pageLabel}</p>
-        <TextLink href={ROUTES.agit.upload(agitId)} className="absolute right-[0] top-[50%] grid w-[44px] h-[44px] [transform:translateY(-50%)] place-items-center border border-[var(--dl-color-border-default)] rounded-[16px] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline" aria-label="영상 업로드">
+      <div className="relative flex min-h-[44px] items-center justify-end">
+        <TextLink href={ROUTES.agit.upload(agitId)} className="grid w-[44px] h-[44px] place-items-center border border-[var(--dl-color-border-default)] rounded-[16px] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline" aria-label="영상 업로드">
           <DailyIcon name="camera" size={20} />
         </TextLink>
       </div>

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -137,14 +137,17 @@ export function TopicsLayoutSection({
                       key={topic.id}
                       className="flex w-full items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]"
                     >
-                      <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                      <TextLink
+                        href={ROUTES.agit.topicDetail(agitId, topic.id)}
+                        className="flex min-w-0 flex-1 flex-col gap-[2px] !text-inherit !no-underline"
+                      >
                         <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
                           {topic.title || "제목 없음"}
                         </p>
                         <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
                           {topic.startAtLabel}
                         </p>
-                      </div>
+                      </TextLink>
                       <div className="flex shrink-0 flex-col items-end gap-1.5">
                         <span
                           className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -1,52 +1,75 @@
 "use client";
 
+import { listTopicsByStatusAction } from "@/actions/topicActions";
 import { DailyIcon, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
+import type { ApiTopicListStatus } from "@/types/topic/api";
+import type { UiTopicListItem, UiTopicListSectionKey, UiTopicListSections } from "@/types/topic/ui";
 import { useState } from "react";
 
-type TopicSectionId = "ongoing" | "upcoming" | "past";
+const INITIAL_LIMIT = 10;
+const MORE_LIMIT = 20;
 
-type MockTopic = {
-  id: string;
-  title: string;
-  meta: string;
-  clips: number;
-  section: TopicSectionId;
-};
-
-const INITIAL_TOPICS: MockTopic[] = [
-  { id: "today", title: "오늘의 한 컷", meta: "매일 · 1인 1영상", clips: 12, section: "ongoing" },
-  { id: "workout", title: "운동 인증", meta: "평일 · 릴레이", clips: 8, section: "ongoing" },
-  { id: "weekend", title: "주말 산책", meta: "주말 · 그리드", clips: 0, section: "upcoming" },
-  { id: "archive", title: "지난 챌린지", meta: "종료됨", clips: 21, section: "past" },
-];
-
-const SECTIONS: { id: TopicSectionId; label: string }[] = [
-  { id: "ongoing", label: "진행중" },
-  { id: "upcoming", label: "다가오는" },
-  { id: "past", label: "지난" },
+const SECTIONS: { id: UiTopicListSectionKey; label: string; status: ApiTopicListStatus }[] = [
+  { id: "ongoing", label: "진행중", status: "ONGOING" },
+  { id: "upcoming", label: "다가오는", status: "UPCOMING" },
+  { id: "past", label: "지난", status: "PAST" },
 ];
 
 type TopicsLayoutSectionProps = {
   agitId: string;
+  sections: UiTopicListSections;
 };
 
-export function TopicsLayoutSection({ agitId }: TopicsLayoutSectionProps) {
-  const [topics, setTopics] = useState(INITIAL_TOPICS);
-  const [openSections, setOpenSections] = useState<Record<TopicSectionId, boolean>>({
+export function TopicsLayoutSection({ agitId, sections }: TopicsLayoutSectionProps) {
+  const [openSections, setOpenSections] = useState<Record<UiTopicListSectionKey, boolean>>({
     ongoing: true,
     upcoming: true,
     past: true,
   });
+  const [itemsBySection, setItemsBySection] = useState<Record<UiTopicListSectionKey, UiTopicListItem[]>>({
+    ongoing: sections.ongoing.items,
+    upcoming: sections.upcoming.items,
+    past: sections.past.items,
+  });
+  const [errors, setErrors] = useState<Record<UiTopicListSectionKey, string | undefined>>({
+    ongoing: sections.ongoing.error,
+    upcoming: sections.upcoming.error,
+    past: sections.past.error,
+  });
+  const [expanded, setExpanded] = useState<Record<UiTopicListSectionKey, boolean>>({
+    ongoing: false,
+    upcoming: false,
+    past: false,
+  });
+  const [loadingMore, setLoadingMore] = useState<Record<UiTopicListSectionKey, boolean>>({
+    ongoing: false,
+    upcoming: false,
+    past: false,
+  });
 
-  function toggleSection(id: TopicSectionId) {
+  function toggleSection(id: UiTopicListSectionKey) {
     setOpenSections((current) => ({ ...current, [id]: !current[id] }));
+  }
+
+  async function loadMore(id: UiTopicListSectionKey, status: ApiTopicListStatus) {
+    if (loadingMore[id] || expanded[id]) return;
+    setLoadingMore((current) => ({ ...current, [id]: true }));
+    const result = await listTopicsByStatusAction(agitId, status, MORE_LIMIT);
+    setLoadingMore((current) => ({ ...current, [id]: false }));
+    if (!result.ok) {
+      setErrors((current) => ({ ...current, [id]: result.error }));
+      return;
+    }
+    setItemsBySection((current) => ({ ...current, [id]: result.data }));
+    setExpanded((current) => ({ ...current, [id]: true }));
+    setErrors((current) => ({ ...current, [id]: undefined }));
   }
 
   return (
     <section className="flex w-full flex-col gap-3.5">
       <p className="m-0 text-[13px] font-normal leading-5 text-[var(--dl-color-text-secondary)]">
-        토픽을 진행 상태별로 보고 목업으로 만들고 지울 수 있어요
+        토픽을 진행 상태별로 보고 만들 수 있어요
       </p>
 
       <TextLink
@@ -58,8 +81,11 @@ export function TopicsLayoutSection({ agitId }: TopicsLayoutSectionProps) {
       </TextLink>
 
       {SECTIONS.map((section) => {
-        const items = topics.filter((topic) => topic.section === section.id);
+        const items = itemsBySection[section.id];
         const open = openSections[section.id];
+        const error = errors[section.id];
+        const canLoadMore =
+          !error && !expanded[section.id] && items.length >= INITIAL_LIMIT;
 
         return (
           <div key={section.id} className="flex flex-col gap-2">
@@ -84,60 +110,55 @@ export function TopicsLayoutSection({ agitId }: TopicsLayoutSectionProps) {
               </span>
             </button>
 
-            {open
-              ? items.map((topic) => (
-                  <div
-                    key={topic.id}
-                    className="flex w-full items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]"
-                  >
-                    <DailyIcon name="grip" size={18} />
-                    <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                      <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
-                        {topic.title}
-                      </p>
-                      <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
-                        {topic.meta}
-                      </p>
-                    </div>
-                    <div className="flex flex-col items-end gap-1.5">
+            {open ? (
+              <>
+                {error ? (
+                  <p className="m-0 text-[13px] text-[var(--dl-color-text-danger)]">{error}</p>
+                ) : items.length === 0 ? (
+                  <p className="m-0 text-[13px] text-[var(--dl-color-text-secondary)]">
+                    아직 토픽이 없어요
+                  </p>
+                ) : (
+                  items.map((topic) => (
+                    <div
+                      key={topic.id}
+                      className="flex w-full items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]"
+                    >
+                      <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                        <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
+                          {topic.title || "제목 없음"}
+                        </p>
+                        <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
+                          {topic.startAtLabel}
+                        </p>
+                      </div>
                       <span
                         className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
-                          topic.clips === 0
+                          topic.videoCount === 0
                             ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
                             : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
                         }`}
                       >
-                        {topic.clips}개 영상
+                        {topic.videoCount}개 영상
                       </span>
-                      {topic.clips === 0 ? (
-                        <button
-                          type="button"
-                          className="text-[12px] font-semibold text-[var(--dl-color-text-danger)]"
-                          onClick={() =>
-                            setTopics((current) => current.filter((item) => item.id !== topic.id))
-                          }
-                        >
-                          삭제
-                        </button>
-                      ) : (
-                        <span className="text-[12px] font-semibold text-[var(--dl-color-text-tertiary)]">
-                          삭제 불가
-                        </span>
-                      )}
                     </div>
-                  </div>
-                ))
-              : null}
+                  ))
+                )}
+                {open && canLoadMore ? (
+                  <button
+                    type="button"
+                    className="h-[40px] rounded-[var(--dl-radius-md)] text-sm font-medium text-[var(--dl-color-text-brand)] disabled:opacity-50"
+                    disabled={loadingMore[section.id]}
+                    onClick={() => loadMore(section.id, section.status)}
+                  >
+                    {loadingMore[section.id] ? "불러오는 중..." : "더보기"}
+                  </button>
+                ) : null}
+              </>
+            ) : null}
           </div>
         );
       })}
-
-      <div className="flex w-full items-center gap-[10px] rounded-[12px] bg-[var(--dl-color-bg-warning)] p-[12px_14px]">
-        <DailyIcon name="alert" size={18} />
-        <p className="m-0 text-[12px] font-medium text-[var(--dl-color-text-primary)]">
-          영상이 등록된 토픽은 삭제할 수 없어요.
-        </p>
-      </div>
     </section>
   );
 }

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -2,6 +2,7 @@
 
 import { listTopicsByStatusAction } from "@/actions/topicActions";
 import { DailyIcon, TextLink } from "@/components/atoms";
+import { ManageListRow } from "@/components/molecules/ManageListRow";
 import { ROUTES } from "@/config/routes";
 import type { UiAgitRole } from "@/types/agit/ui";
 import type { ApiTopicListStatus } from "@/types/topic/api";
@@ -133,41 +134,43 @@ export function TopicsLayoutSection({
                       (Boolean(currentUserUuid) && topic.creatorUuid === currentUserUuid);
 
                     return (
-                    <div
+                    <ManageListRow
                       key={topic.id}
-                      className="flex w-full items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]"
-                    >
-                      <TextLink
-                        href={ROUTES.agit.topicDetail(agitId, topic.id)}
-                        className="flex min-w-0 flex-1 flex-col gap-[2px] !text-inherit !no-underline"
-                      >
-                        <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
-                          {topic.title || "제목 없음"}
-                        </p>
-                        <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
-                          {topic.startAtLabel}
-                        </p>
-                      </TextLink>
-                      <div className="flex shrink-0 flex-col items-end gap-1.5">
-                        <span
-                          className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
-                            topic.videoCount === 0
-                              ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
-                              : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
-                          }`}
+                      title={
+                        <TextLink
+                          href={ROUTES.agit.topicDetail(agitId, topic.id)}
+                          className="flex min-w-0 flex-col gap-[2px] !text-inherit !no-underline"
                         >
-                          {topic.videoCount}개 영상
-                        </span>
-                        {canEdit ? (
-                          <TextLink
-                            href={ROUTES.agit.topicEdit(agitId, topic.id)}
-                            className="text-[12px] font-semibold !text-[var(--dl-color-text-brand)] !no-underline"
+                          <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
+                            {topic.title || "제목 없음"}
+                          </p>
+                          <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
+                            {topic.startAtLabel}
+                          </p>
+                        </TextLink>
+                      }
+                      trailing={
+                        <div className="flex flex-col items-end gap-1.5">
+                          <span
+                            className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
+                              topic.videoCount === 0
+                                ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
+                                : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
+                            }`}
                           >
-                            편집
-                          </TextLink>
-                        ) : null}
-                      </div>
-                    </div>
+                            {topic.videoCount}개 영상
+                          </span>
+                          {canEdit ? (
+                            <TextLink
+                              href={ROUTES.agit.topicEdit(agitId, topic.id)}
+                              className="text-[12px] font-semibold !text-[var(--dl-color-text-brand)] !no-underline"
+                            >
+                              편집
+                            </TextLink>
+                          ) : null}
+                        </div>
+                      }
+                    />
                     );
                   })
                 )}

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -3,6 +3,7 @@
 import { listTopicsByStatusAction } from "@/actions/topicActions";
 import { DailyIcon, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
+import type { UiAgitRole } from "@/types/agit/ui";
 import type { ApiTopicListStatus } from "@/types/topic/api";
 import type { UiTopicListItem, UiTopicListSectionKey, UiTopicListSections } from "@/types/topic/ui";
 import { useState } from "react";
@@ -19,9 +20,16 @@ const SECTIONS: { id: UiTopicListSectionKey; label: string; status: ApiTopicList
 type TopicsLayoutSectionProps = {
   agitId: string;
   sections: UiTopicListSections;
+  myRole?: UiAgitRole;
+  currentUserUuid?: string;
 };
 
-export function TopicsLayoutSection({ agitId, sections }: TopicsLayoutSectionProps) {
+export function TopicsLayoutSection({
+  agitId,
+  sections,
+  myRole,
+  currentUserUuid,
+}: TopicsLayoutSectionProps) {
   const [openSections, setOpenSections] = useState<Record<UiTopicListSectionKey, boolean>>({
     ongoing: true,
     upcoming: true,
@@ -119,7 +127,12 @@ export function TopicsLayoutSection({ agitId, sections }: TopicsLayoutSectionPro
                     아직 토픽이 없어요
                   </p>
                 ) : (
-                  items.map((topic) => (
+                  items.map((topic) => {
+                    const canEdit =
+                      myRole === "HOST" ||
+                      (Boolean(currentUserUuid) && topic.creatorUuid === currentUserUuid);
+
+                    return (
                     <div
                       key={topic.id}
                       className="flex w-full items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]"
@@ -132,17 +145,28 @@ export function TopicsLayoutSection({ agitId, sections }: TopicsLayoutSectionPro
                           {topic.startAtLabel}
                         </p>
                       </div>
-                      <span
-                        className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
-                          topic.videoCount === 0
-                            ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
-                            : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
-                        }`}
-                      >
-                        {topic.videoCount}개 영상
-                      </span>
+                      <div className="flex shrink-0 flex-col items-end gap-1.5">
+                        <span
+                          className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
+                            topic.videoCount === 0
+                              ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
+                              : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
+                          }`}
+                        >
+                          {topic.videoCount}개 영상
+                        </span>
+                        {canEdit ? (
+                          <TextLink
+                            href={ROUTES.agit.topicEdit(agitId, topic.id)}
+                            className="text-[12px] font-semibold !text-[var(--dl-color-text-brand)] !no-underline"
+                          >
+                            편집
+                          </TextLink>
+                        ) : null}
+                      </div>
                     </div>
-                  ))
+                    );
+                  })
                 )}
                 {open && canLoadMore ? (
                   <button

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -4,6 +4,7 @@ export { AgitProfileEditForm } from "./AgitProfileEditForm";
 export { ChatMoreSheet } from "./ChatMoreSheet";
 export { MoveTopicSheet } from "./MoveTopicSheet";
 export { TopicCreateForm } from "./TopicCreateForm";
+export { TopicEditForm } from "./TopicEditForm";
 export { TopicGallerySection } from "./TopicGallerySection";
 export { TopicViewerSection } from "./TopicViewerSection";
 export { ViewerActionsSheet } from "./ViewerActionsSheet";

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -52,6 +52,7 @@ export {
   RoomManageHubTemplate as AgitManageTemplate,
   RoomProfileEditTemplate as AgitProfileEditTemplate,
   TopicCreateTemplate as AgitTopicCreateTemplate,
+  TopicEditTemplate as AgitTopicEditTemplate,
   TopicsLayoutTemplate as AgitTopicsTemplate,
 } from "./RoomManageTemplates";
 

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -53,6 +53,7 @@ export {
   RoomProfileEditTemplate as AgitProfileEditTemplate,
   TopicCreateTemplate as AgitTopicCreateTemplate,
   TopicEditTemplate as AgitTopicEditTemplate,
+  TopicViewerTemplate as AgitTopicViewerTemplate,
   TopicsLayoutTemplate as AgitTopicsTemplate,
 } from "./RoomManageTemplates";
 

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -6,14 +6,15 @@ import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySectio
 import { MembersPermissionsSection } from "@/components/organisms/MembersPermissionsSection";
 import { TopicCreateForm } from "@/components/organisms/TopicCreateForm";
 import { TopicEditForm } from "@/components/organisms/TopicEditForm";
+import { TopicViewerSection } from "@/components/organisms/TopicViewerSection";
 import { TopicsLayoutSection } from "@/components/organisms/TopicsLayoutSection";
-import { AgitFlowChrome } from "@/components/templates/AppChromeTemplate";
+import { AgitFlowChrome, AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
-import type { UiTopicDetail, UiTopicListSections } from "@/types/topic/ui";
+import type { UiTopicDetail, UiTopicListSections, UiTopicVideo } from "@/types/topic/ui";
 
 type AgitIdProps = { agitId: string };
 
@@ -60,6 +61,32 @@ export function TopicsLayoutTemplate({
         currentUserUuid={currentUserUuid}
       />
     </AgitFlowChrome>
+  );
+}
+
+export function TopicViewerTemplate({
+  agit,
+  topic,
+  videos,
+}: {
+  agit: UiAgit | null;
+  topic: UiTopicDetail | null;
+  videos: UiTopicVideo[];
+}) {
+  if (!agit || !topic) return <RoomMissing />;
+
+  const dateLabel = topic.startDate.replaceAll("-", ".");
+
+  return (
+    <AppChromeTemplate activeTab="agit" variant="light">
+      <TopicViewerSection
+        agitId={agit.id}
+        title={topic.title || "제목 없음"}
+        meta={`${dateLabel} · ${videos.length}개 영상`}
+        videos={videos}
+        backHref={ROUTES.agit.topics(agit.id)}
+      />
+    </AppChromeTemplate>
   );
 }
 

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -12,6 +12,7 @@ import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicListSections } from "@/types/topic/ui";
 
 type AgitIdProps = { agitId: string };
 
@@ -37,24 +38,34 @@ export function RoomManageHubTemplate({ agit }: { agit: UiAgit | null }) {
   );
 }
 
-export function TopicsLayoutTemplate({ agitId }: AgitIdProps) {
+export function TopicsLayoutTemplate({
+  agit,
+  sections,
+}: {
+  agit: UiAgit | null;
+  sections: UiTopicListSections;
+}) {
+  if (!agit) return <RoomMissing />;
+
   return (
     <AgitFlowChrome>
-      <AuthTopBar title="토픽관리" backHref={ROUTES.agit.detail(agitId)} />
-      <TopicsLayoutSection agitId={agitId} />
+      <AuthTopBar title="토픽관리" backHref={ROUTES.agit.detail(agit.id)} />
+      <TopicsLayoutSection agitId={agit.id} sections={sections} />
     </AgitFlowChrome>
   );
 }
 
-export function TopicCreateTemplate({ agitId }: AgitIdProps) {
+export function TopicCreateTemplate({ agit }: { agit: UiAgit | null }) {
+  if (!agit) return <RoomMissing />;
+
   return (
     <AgitFlowChrome>
       <AuthTopBar
         title="토픽 만들기"
-        backHref={ROUTES.agit.topics(agitId)}
-        step="토픽 진행 기간과 적용 아이템을 정합니다"
+        backHref={ROUTES.agit.topics(agit.id)}
+        step="토픽 이름과 진행 날짜를 정합니다"
       />
-      <TopicCreateForm />
+      <TopicCreateForm agitId={agit.id} />
     </AgitFlowChrome>
   );
 }

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -5,6 +5,7 @@ import { AgitProfileEditForm } from "@/components/organisms/AgitProfileEditForm"
 import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySection";
 import { MembersPermissionsSection } from "@/components/organisms/MembersPermissionsSection";
 import { TopicCreateForm } from "@/components/organisms/TopicCreateForm";
+import { TopicEditForm } from "@/components/organisms/TopicEditForm";
 import { TopicsLayoutSection } from "@/components/organisms/TopicsLayoutSection";
 import { AgitFlowChrome } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
@@ -12,7 +13,7 @@ import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
-import type { UiTopicListSections } from "@/types/topic/ui";
+import type { UiTopicDetail, UiTopicListSections } from "@/types/topic/ui";
 
 type AgitIdProps = { agitId: string };
 
@@ -41,16 +42,40 @@ export function RoomManageHubTemplate({ agit }: { agit: UiAgit | null }) {
 export function TopicsLayoutTemplate({
   agit,
   sections,
+  currentUserUuid,
 }: {
   agit: UiAgit | null;
   sections: UiTopicListSections;
+  currentUserUuid?: string;
 }) {
   if (!agit) return <RoomMissing />;
 
   return (
     <AgitFlowChrome>
       <AuthTopBar title="토픽관리" backHref={ROUTES.agit.detail(agit.id)} />
-      <TopicsLayoutSection agitId={agit.id} sections={sections} />
+      <TopicsLayoutSection
+        agitId={agit.id}
+        sections={sections}
+        myRole={agit.myRole}
+        currentUserUuid={currentUserUuid}
+      />
+    </AgitFlowChrome>
+  );
+}
+
+export function TopicEditTemplate({
+  agit,
+  topic,
+}: {
+  agit: UiAgit | null;
+  topic: UiTopicDetail | null;
+}) {
+  if (!agit || !topic) return <RoomMissing />;
+
+  return (
+    <AgitFlowChrome>
+      <AuthTopBar title="토픽 편집" backHref={ROUTES.agit.topics(agit.id)} />
+      <TopicEditForm agitId={agit.id} topic={topic} />
     </AgitFlowChrome>
   );
 }

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -14,6 +14,7 @@ export {
   AgitProfileEditTemplate,
   AgitSafetyTemplate,
   AgitTopicCreateTemplate,
+  AgitTopicEditTemplate,
 } from "./AgitTemplates";
 export { ChangePasswordTemplate } from "./ChangePasswordTemplate";
 export { CreateTemplate } from "./CreateTemplate";

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -15,6 +15,7 @@ export {
   AgitSafetyTemplate,
   AgitTopicCreateTemplate,
   AgitTopicEditTemplate,
+  AgitTopicViewerTemplate,
 } from "./AgitTemplates";
 export { ChangePasswordTemplate } from "./ChangePasswordTemplate";
 export { CreateTemplate } from "./CreateTemplate";

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -37,6 +37,7 @@ export const API_ENDPOINTS = {
   },
   topic: {
     list: gatewayPath("topic", "/api/v1/topics"),
+    listByStatus: gatewayPath("topic", "/api/v1/topics/list"),
     videos: (topicUuid: string) =>
       gatewayPath("topic", `/api/v1/topics/${topicUuid}/videos`),
   },

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -38,6 +38,7 @@ export const API_ENDPOINTS = {
   topic: {
     list: gatewayPath("topic", "/api/v1/topics"),
     listByStatus: gatewayPath("topic", "/api/v1/topics/list"),
+    detail: (topicUuid: string) => gatewayPath("topic", `/api/v1/topics/${topicUuid}`),
     videos: (topicUuid: string) =>
       gatewayPath("topic", `/api/v1/topics/${topicUuid}/videos`),
   },

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -30,6 +30,10 @@ export const ROUTES = {
     members: (agitId: string) => `/agit/${agitId}/members` as const,
     topics: (agitId: string) => `/agit/${agitId}/topics` as const,
     topicCreate: (agitId: string) => `/agit/${agitId}/topics/create` as const,
+    topicDetail: (agitId: string, topicId: string) =>
+      `/agit/${agitId}/topics/${topicId}` as const,
+    topicEdit: (agitId: string, topicId: string) =>
+      `/agit/${agitId}/topics/${topicId}/edit` as const,
     manage: (agitId: string) => `/agit/${agitId}/manage` as const,
     calendar: (agitId: string) => `/agit/${agitId}/calendar` as const,
     upload: (agitId: string) => `/agit/${agitId}/upload` as const,

--- a/lib/api/topicApi.ts
+++ b/lib/api/topicApi.ts
@@ -3,7 +3,12 @@ import { getActorUserHeaders } from "@/lib/api/actorHeaders";
 import { apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl } from "@/lib/api/env";
 import { withAuthRetry } from "@/lib/api/withAuthRetry";
-import type { ApiTopic, ApiTopicVideo } from "@/types/topic/api";
+import type {
+  ApiCreateTopicRequest,
+  ApiTopic,
+  ApiTopicListStatus,
+  ApiTopicVideo,
+} from "@/types/topic/api";
 
 function topicFetch<T>(path: string, options: Parameters<typeof apiFetch>[1] = {}): Promise<T> {
   return withAuthRetry(async () =>
@@ -19,6 +24,28 @@ export async function listTopics(agitUuid: string): Promise<ApiTopic[]> {
   return topicFetch<ApiTopic[]>(API_ENDPOINTS.topic.list, {
     method: "GET",
     searchParams: { agitUuid },
+  });
+}
+
+export async function listTopicsByStatus(
+  agitUuid: string,
+  status: ApiTopicListStatus,
+  limit?: number,
+): Promise<ApiTopic[]> {
+  return topicFetch<ApiTopic[]>(API_ENDPOINTS.topic.listByStatus, {
+    method: "GET",
+    searchParams: {
+      agitUuid,
+      status,
+      limit: limit !== undefined ? String(limit) : undefined,
+    },
+  });
+}
+
+export async function createTopic(body: ApiCreateTopicRequest): Promise<ApiTopic> {
+  return topicFetch<ApiTopic>(API_ENDPOINTS.topic.list, {
+    method: "POST",
+    body,
   });
 }
 

--- a/lib/api/topicApi.ts
+++ b/lib/api/topicApi.ts
@@ -8,6 +8,7 @@ import type {
   ApiTopic,
   ApiTopicListStatus,
   ApiTopicVideo,
+  ApiUpdateTopicRequest,
 } from "@/types/topic/api";
 
 function topicFetch<T>(path: string, options: Parameters<typeof apiFetch>[1] = {}): Promise<T> {
@@ -46,6 +47,28 @@ export async function createTopic(body: ApiCreateTopicRequest): Promise<ApiTopic
   return topicFetch<ApiTopic>(API_ENDPOINTS.topic.list, {
     method: "POST",
     body,
+  });
+}
+
+export async function getTopic(topicUuid: string): Promise<ApiTopic> {
+  return topicFetch<ApiTopic>(API_ENDPOINTS.topic.detail(topicUuid), {
+    method: "GET",
+  });
+}
+
+export async function updateTopic(
+  topicUuid: string,
+  body: ApiUpdateTopicRequest,
+): Promise<ApiTopic> {
+  return topicFetch<ApiTopic>(API_ENDPOINTS.topic.detail(topicUuid), {
+    method: "PATCH",
+    body,
+  });
+}
+
+export async function deleteTopic(topicUuid: string): Promise<void> {
+  await topicFetch<unknown>(API_ENDPOINTS.topic.detail(topicUuid), {
+    method: "DELETE",
   });
 }
 

--- a/lib/topic/selectAgitTopic.ts
+++ b/lib/topic/selectAgitTopic.ts
@@ -9,6 +9,14 @@ export function toKstDateString(value: Date): string {
   }).format(value);
 }
 
+export function formatKstDotDate(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return "";
+  }
+  return toKstDateString(parsed).replaceAll("-", ".");
+}
+
 export function isSameKstDate(iso: string, today = new Date()): boolean {
   const parsed = new Date(iso);
   if (Number.isNaN(parsed.getTime())) {

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -1,8 +1,8 @@
 import type { ApiAgitDetailMember } from "@/types/agit/api";
-import type { ApiTopic, ApiTopicVideo } from "@/types/topic/api";
-import type { UiTopicGallery, UiTopicVideo } from "@/types/topic/ui";
+import type { ApiCreateTopicRequest, ApiTopic, ApiTopicListStatus, ApiTopicVideo } from "@/types/topic/api";
+import type { UiTopicGallery, UiTopicListItem, UiTopicVideo } from "@/types/topic/ui";
 import * as topicApi from "@/lib/api/topicApi";
-import { isSameKstDate, selectAgitTopic } from "@/lib/topic/selectAgitTopic";
+import { formatKstDotDate, isSameKstDate, selectAgitTopic } from "@/lib/topic/selectAgitTopic";
 import * as videoService from "@/services/videoService";
 
 const FALLBACK_THUMBNAIL = "/plip/v13/topic-video-1.png";
@@ -60,6 +60,29 @@ async function mapTopicVideo(
       caption: "",
     };
   }
+}
+
+export function toUiTopicListItem(topic: ApiTopic): UiTopicListItem {
+  return {
+    id: topic.topicUuid,
+    title: topic.title?.trim() ?? "",
+    startAtLabel: formatKstDotDate(topic.startAt),
+    videoCount: topic.videoCount,
+    creatorUuid: topic.creatorUuid,
+  };
+}
+
+export async function listTopicsByStatus(
+  agitUuid: string,
+  status: ApiTopicListStatus,
+  limit?: number,
+): Promise<UiTopicListItem[]> {
+  const topics = await topicApi.listTopicsByStatus(agitUuid, status, limit);
+  return topics.map(toUiTopicListItem);
+}
+
+export async function createTopic(input: ApiCreateTopicRequest): Promise<ApiTopic> {
+  return topicApi.createTopic(input);
 }
 
 function mapSummary(topic: ApiTopic): UiTopicGallery["topic"] {

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -1,8 +1,8 @@
 import type { ApiAgitDetailMember } from "@/types/agit/api";
-import type { ApiCreateTopicRequest, ApiTopic, ApiTopicListStatus, ApiTopicVideo } from "@/types/topic/api";
-import type { UiTopicGallery, UiTopicListItem, UiTopicVideo } from "@/types/topic/ui";
+import type { ApiCreateTopicRequest, ApiTopic, ApiTopicListStatus, ApiTopicVideo, ApiUpdateTopicRequest } from "@/types/topic/api";
+import type { UiTopicDetail, UiTopicGallery, UiTopicListItem, UiTopicVideo } from "@/types/topic/ui";
 import * as topicApi from "@/lib/api/topicApi";
-import { formatKstDotDate, isSameKstDate, selectAgitTopic } from "@/lib/topic/selectAgitTopic";
+import { formatKstDotDate, isSameKstDate, selectAgitTopic, toKstDateString } from "@/lib/topic/selectAgitTopic";
 import * as videoService from "@/services/videoService";
 
 const FALLBACK_THUMBNAIL = "/plip/v13/topic-video-1.png";
@@ -83,6 +83,30 @@ export async function listTopicsByStatus(
 
 export async function createTopic(input: ApiCreateTopicRequest): Promise<ApiTopic> {
   return topicApi.createTopic(input);
+}
+
+export function toUiTopicDetail(topic: ApiTopic): UiTopicDetail {
+  const parsed = new Date(topic.startAt);
+  return {
+    id: topic.topicUuid,
+    title: topic.title?.trim() ?? "",
+    startDate: Number.isNaN(parsed.getTime()) ? topic.startAt.slice(0, 10) : toKstDateString(parsed),
+    videoCount: topic.videoCount,
+    creatorUuid: topic.creatorUuid,
+  };
+}
+
+export async function getTopic(topicUuid: string): Promise<UiTopicDetail> {
+  const topic = await topicApi.getTopic(topicUuid);
+  return toUiTopicDetail(topic);
+}
+
+export async function updateTopic(topicUuid: string, input: ApiUpdateTopicRequest): Promise<ApiTopic> {
+  return topicApi.updateTopic(topicUuid, input);
+}
+
+export async function deleteTopic(topicUuid: string): Promise<void> {
+  await topicApi.deleteTopic(topicUuid);
 }
 
 function mapSummary(topic: ApiTopic): UiTopicGallery["topic"] {

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -118,6 +118,19 @@ function mapSummary(topic: ApiTopic): UiTopicGallery["topic"] {
   };
 }
 
+export async function getTopicViewer(
+  topicUuid: string,
+  members: ApiAgitDetailMember[],
+): Promise<{ topic: UiTopicDetail; videos: UiTopicVideo[] }> {
+  const [topic, topicVideos] = await Promise.all([
+    topicApi.getTopic(topicUuid),
+    topicApi.listTopicVideos(topicUuid),
+  ]);
+  const profiles = memberMap(members);
+  const videos = await Promise.all(topicVideos.map((item) => mapTopicVideo(item, profiles)));
+  return { topic: toUiTopicDetail(topic), videos };
+}
+
 export async function getTopicGallery(
   agitUuid: string,
   members: ApiAgitDetailMember[],

--- a/types/topic/api.ts
+++ b/types/topic/api.ts
@@ -18,6 +18,11 @@ export type ApiCreateTopicRequest = {
   startAt?: string;
 };
 
+export type ApiUpdateTopicRequest = {
+  title?: string;
+  startAt?: string;
+};
+
 export type ApiTopicVideo = {
   videoUuid: string;
   userUuid: string;

--- a/types/topic/api.ts
+++ b/types/topic/api.ts
@@ -1,3 +1,5 @@
+export type ApiTopicListStatus = "ONGOING" | "UPCOMING" | "PAST";
+
 export type ApiTopic = {
   topicUuid: string;
   agitUuid: string;
@@ -7,6 +9,13 @@ export type ApiTopic = {
   videoCount: number;
   uploadedByMe: boolean | null;
   createdAt: string;
+};
+
+export type ApiCreateTopicRequest = {
+  agitUuid: string;
+  creatorUuid: string;
+  title: string;
+  startAt?: string;
 };
 
 export type ApiTopicVideo = {

--- a/types/topic/schema.ts
+++ b/types/topic/schema.ts
@@ -1,0 +1,34 @@
+export const TOPIC_TITLE_MAX_LENGTH = 24;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export type CreateTopicParseResult =
+  | { ok: true; title: string; startAt: string }
+  | { ok: false; error: string };
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function toTopicStartAtPayload(date: string): string {
+  return `${date}T00:00:00`;
+}
+
+export function parseCreateTopicInput(input: {
+  title: unknown;
+  startDate: unknown;
+}): CreateTopicParseResult {
+  const title = asTrimmedString(input.title);
+  if (!title) {
+    return { ok: false, error: "토픽 이름은 필수입니다." };
+  }
+  if (title.length > TOPIC_TITLE_MAX_LENGTH) {
+    return { ok: false, error: `토픽 이름은 ${TOPIC_TITLE_MAX_LENGTH}자 이하여야 합니다.` };
+  }
+
+  const startDate = asTrimmedString(input.startDate);
+  if (!DATE_PATTERN.test(startDate)) {
+    return { ok: false, error: "진행 날짜를 선택해 주세요." };
+  }
+
+  return { ok: true, title, startAt: toTopicStartAtPayload(startDate) };
+}

--- a/types/topic/schema.ts
+++ b/types/topic/schema.ts
@@ -13,6 +13,13 @@ export function toTopicStartAtPayload(date: string): string {
   return `${date}T00:00:00`;
 }
 
+export function parseUpdateTopicInput(input: {
+  title: unknown;
+  startDate: unknown;
+}): CreateTopicParseResult {
+  return parseCreateTopicInput(input);
+}
+
 export function parseCreateTopicInput(input: {
   title: unknown;
   startDate: unknown;

--- a/types/topic/ui.ts
+++ b/types/topic/ui.ts
@@ -27,6 +27,14 @@ export type UiTopicListItem = {
   creatorUuid: string;
 };
 
+export type UiTopicDetail = {
+  id: string;
+  title: string;
+  startDate: string;
+  videoCount: number;
+  creatorUuid: string;
+};
+
 export type UiTopicListSectionKey = "ongoing" | "upcoming" | "past";
 
 export type UiTopicListSection = {

--- a/types/topic/ui.ts
+++ b/types/topic/ui.ts
@@ -19,6 +19,23 @@ export type UiTopicSummary = {
   isToday: boolean;
 };
 
+export type UiTopicListItem = {
+  id: string;
+  title: string;
+  startAtLabel: string;
+  videoCount: number;
+  creatorUuid: string;
+};
+
+export type UiTopicListSectionKey = "ongoing" | "upcoming" | "past";
+
+export type UiTopicListSection = {
+  items: UiTopicListItem[];
+  error?: string;
+};
+
+export type UiTopicListSections = Record<UiTopicListSectionKey, UiTopicListSection>;
+
 export type UiTopicGallery = {
   topic: UiTopicSummary | null;
   videos: UiTopicVideo[];


### PR DESCRIPTION
## 작업 내용

아지트 멤버가 토픽 목록·만들기·편집·삭제·그리드 뷰어를 기존 OpenAPI에 붙여 쓸 수 있게 했습니다. 드로어는 열 때 진행 중 토픽 3건을 불러오고, 메뉴 패널 높이를 화면에 고정해 나가기 버튼이 보이도록 했습니다. 갤러리 `GET /topics`와 `selectAgitTopic`은 그대로입니다.

## 관련 이슈

Close #74
Close #76
Close #77
Close #78

## 변경 사항

### 1. 토픽 API·서버 액션 연동

- **파일:** `lib/api/topicApi.ts`, `actions/topicActions.ts`, `config/api-endpoints.ts`, `types/topic/api.ts`, `types/topic/schema.ts`
- **설명:** 구간 목록·생성·단건·수정·삭제를 붙이고, 세션 UUID로 생성합니다. 갤러리용 `listTopics`는 유지합니다.

```typescript
export async function listTopicsByStatus(
  agitUuid: string,
  status: ApiTopicListStatus,
  limit?: number,
): Promise<ApiTopic[]> {
  return topicFetch<ApiTopic[]>(API_ENDPOINTS.topic.listByStatus, {
    method: "GET",
    searchParams: {
      agitUuid,
      status,
      limit: limit !== undefined ? String(limit) : undefined,
    },
  });
}
```

### 2. 목록 3구간·만들기

- **파일:** `app/(agit)/agit/[agitId]/topics/page.tsx`, `TopicsLayoutSection.tsx`, `TopicCreateForm.tsx`, `config/routes.ts`
- **설명:** 멤버십 확인 후 ONGOING/UPCOMING/PAST를 병렬 조회합니다. 더보기 10→20, 빈/실패 구간 처리, 날짜 한 개로 생성 후 아지트 상세로 이동합니다.

```typescript
    topicDetail: (agitId: string, topicId: string) =>
      `/agit/${agitId}/topics/${topicId}` as const,
    topicEdit: (agitId: string, topicId: string) =>
      `/agit/${agitId}/topics/${topicId}/edit` as const,
```

### 3. 편집·삭제

- **파일:** `app/(agit)/agit/[agitId]/topics/[topicId]/edit/page.tsx`, `TopicEditForm.tsx`
- **설명:** HOST 또는 생성자만 편집합니다. PATCH와 삭제 확인 다이얼로그를 두고, 영상이 있으면 삭제를 막으며 409는 토스트로 알립니다.

```typescript
export async function deleteTopicAction(topicId: string): Promise<ActionResult<void>> {
  try {
    await topicService.deleteTopic(topicId);
    return actionSuccess(undefined);
  } catch (error) {
    if (error instanceof ApiError && error.status === 409) {
      return actionFailure("영상이 있는 토픽은 삭제할 수 없어요.");
    }
    return toActionError(error);
  }
}
```

### 4. 드로어·그리드 뷰어

- **파일:** `AgitMenuDrawer.tsx`, `AgitDetailSection.tsx`, `topics/[topicId]/page.tsx`, `TopicViewerSection.tsx`
- **설명:** 토픽관리는 멤버 전원, 열 때 ONGOING 3건. 행 탭은 그리드 뷰어입니다. 드로어는 화면 높이에 고정하고 나가기는 하단에 둡니다.

```tsx
  useEffect(() => {
    if (!open) return;
    let cancelled = false;
    listTopicsByStatusAction(agit.id, "ONGOING", 3).then((result) => {
      if (cancelled) return;
      setOngoingTopics(result.ok ? result.data : []);
    });
    return () => {
      cancelled = true;
    };
  }, [open, agit.id]);
```

### 5. 리스트 행 껍데기 통일

- **파일:** `components/molecules/ManageListRow.tsx`, `MemberManageRow.tsx`, `TopicsLayoutSection.tsx`
- **설명:** 토픽·멤버 행이 같은 카드 스타일을 씁니다.

```tsx
export const manageListRowClassName =
  "flex w-full min-h-[64px] items-center gap-[10px] rounded-[var(--dl-radius-lg)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[12px_14px]";
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] 목록 3구간·더보기·만들기 → 상세
  - [x] HOST/생성자 편집·삭제(영상 있으면 비활성)
  - [x] 드로어 진행중 3건·더보기, 나가기 버튼 위치
  - [x] 행 탭 → 그리드 뷰어

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [ ] @headdrop 승인
