### PR TITLE
Feature: 토픽 쓰기에서 세션 UUID body 제거 및 403 토스트

### DIFF
--- a/actions/topicActions.ts
+++ b/actions/topicActions.ts
@@ -2,6 +2,7 @@
 
 import { ApiError } from "@/lib/api/apiFetch";
 import { getServerUserUuid } from "@/lib/auth/server-token";
+import { TOPIC_FORBIDDEN, TOPIC_LOGIN_REQUIRED } from "@/lib/topic/actionErrors";
 import * as topicService from "@/services/topicService";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import type { ApiTopicListStatus } from "@/types/topic/api";
@@ -10,12 +11,20 @@ import type { UiTopicListItem } from "@/types/topic/ui";
 
 function toActionError(error: unknown): ActionResult<never> {
   if (error instanceof ApiError) {
+    if (error.status === 403) {
+      return actionFailure(TOPIC_FORBIDDEN);
+    }
     return actionFailure(`[${error.status}] ${error.message}`);
   }
   if (error instanceof Error) {
     return actionFailure(error.message);
   }
   return actionFailure("Unknown error");
+}
+
+async function requireLogin(): Promise<string | null> {
+  const userUuid = await getServerUserUuid();
+  return userUuid ? null : TOPIC_LOGIN_REQUIRED;
 }
 
 export async function listTopicsByStatusAction(
@@ -35,9 +44,9 @@ export async function createTopicAction(
   agitId: string,
   input: { title: unknown; startDate: unknown },
 ): Promise<ActionResult<void>> {
-  const creatorUuid = await getServerUserUuid();
-  if (!creatorUuid) {
-    return actionFailure("로그인이 필요합니다.");
+  const loginError = await requireLogin();
+  if (loginError) {
+    return actionFailure(loginError);
   }
 
   const parsed = parseCreateTopicInput(input);
@@ -48,7 +57,6 @@ export async function createTopicAction(
   try {
     await topicService.createTopic({
       agitUuid: agitId,
-      creatorUuid,
       title: parsed.title,
       startAt: parsed.startAt,
     });
@@ -62,6 +70,11 @@ export async function updateTopicAction(
   topicId: string,
   input: { title: unknown; startDate: unknown },
 ): Promise<ActionResult<void>> {
+  const loginError = await requireLogin();
+  if (loginError) {
+    return actionFailure(loginError);
+  }
+
   const parsed = parseUpdateTopicInput(input);
   if (!parsed.ok) {
     return actionFailure(parsed.error);
@@ -79,6 +92,11 @@ export async function updateTopicAction(
 }
 
 export async function deleteTopicAction(topicId: string): Promise<ActionResult<void>> {
+  const loginError = await requireLogin();
+  if (loginError) {
+    return actionFailure(loginError);
+  }
+
   try {
     await topicService.deleteTopic(topicId);
     return actionSuccess(undefined);

--- a/app/(agit)/agit/[agitId]/topics/create/page.tsx
+++ b/app/(agit)/agit/[agitId]/topics/create/page.tsx
@@ -1,5 +1,6 @@
 import { AgitTopicCreateTemplate } from "@/components/templates";
 import { ROUTES } from "@/config/routes";
+import { getServerUserUuid } from "@/lib/auth/server-token";
 import { getAgit } from "@/services/agitService";
 import type { UiAgit } from "@/types/agit/ui";
 import { redirect } from "next/navigation";
@@ -20,6 +21,10 @@ export default async function AgitTopicCreatePage({ params }: PageProps) {
 
   if (!agit) {
     redirect(ROUTES.agit.detail(agitId));
+  }
+
+  if (!(await getServerUserUuid())) {
+    redirect(ROUTES.login);
   }
 
   return <AgitTopicCreateTemplate agit={agit} />;

--- a/components/organisms/TopicCreateForm.tsx
+++ b/components/organisms/TopicCreateForm.tsx
@@ -6,6 +6,7 @@ import { AuthField } from "@/components/molecules";
 import { NoticeCard } from "@/components/molecules/NoticeCard";
 import { toast } from "@/components/ui/toast";
 import { ROUTES } from "@/config/routes";
+import { TOPIC_FORBIDDEN, TOPIC_LOGIN_REQUIRED } from "@/lib/topic/actionErrors";
 import { toKstDateString } from "@/lib/topic/selectAgitTopic";
 import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
 import { useRouter } from "next/navigation";
@@ -34,6 +35,10 @@ export function TopicCreateForm({ agitId }: TopicCreateFormProps) {
     setPending(false);
 
     if (!result.ok) {
+      if (result.error === TOPIC_FORBIDDEN || result.error === TOPIC_LOGIN_REQUIRED) {
+        toast.add({ type: "error", title: result.error });
+        return;
+      }
       setError(result.error);
       return;
     }

--- a/components/organisms/TopicEditForm.tsx
+++ b/components/organisms/TopicEditForm.tsx
@@ -5,6 +5,7 @@ import { SubmitButton } from "@/components/atoms";
 import { AuthField } from "@/components/molecules";
 import { toast } from "@/components/ui/toast";
 import { ROUTES } from "@/config/routes";
+import { TOPIC_FORBIDDEN, TOPIC_LOGIN_REQUIRED } from "@/lib/topic/actionErrors";
 import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
 import type { UiTopicDetail } from "@/types/topic/ui";
 import { useRouter } from "next/navigation";
@@ -36,6 +37,10 @@ export function TopicEditForm({ agitId, topic }: TopicEditFormProps) {
     setPending(false);
 
     if (!result.ok) {
+      if (result.error === TOPIC_FORBIDDEN || result.error === TOPIC_LOGIN_REQUIRED) {
+        toast.add({ type: "error", title: result.error });
+        return;
+      }
       setError(result.error);
       return;
     }
@@ -52,8 +57,14 @@ export function TopicEditForm({ agitId, topic }: TopicEditFormProps) {
     if (!result.ok) {
       toast.add({
         type: "error",
-        title: "토픽을 삭제하지 못했습니다",
-        description: result.error,
+        title:
+          result.error === TOPIC_FORBIDDEN || result.error === TOPIC_LOGIN_REQUIRED
+            ? result.error
+            : "토픽을 삭제하지 못했습니다",
+        description:
+          result.error === TOPIC_FORBIDDEN || result.error === TOPIC_LOGIN_REQUIRED
+            ? undefined
+            : result.error,
       });
       setDeleting(false);
       setConfirmDelete(false);

--- a/lib/topic/actionErrors.ts
+++ b/lib/topic/actionErrors.ts
@@ -1,0 +1,2 @@
+export const TOPIC_LOGIN_REQUIRED = "로그인이 필요합니다.";
+export const TOPIC_FORBIDDEN = "이 작업을 할 권한이 없어요.";

--- a/types/topic/api.ts
+++ b/types/topic/api.ts
@@ -13,7 +13,6 @@ export type ApiTopic = {
 
 export type ApiCreateTopicRequest = {
   agitUuid: string;
-  creatorUuid: string;
   title: string;
   startAt?: string;
 };


### PR DESCRIPTION
## 작업 내용

생성 body에서 creatorUuid를 빼고 actor 헤더만 쓰도록 맞췄습니다. 생성·수정·삭제는 세션이 없으면 막고, 403은 토스트로 구분합니다. 목록/편집의 HOST·생성자 숨김은 그대로입니다. 앱에 topic attach/detach 호출은 없어서 그 부분은 손대지 않았습니다.

## 관련 이슈

Close #81

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
