### PR TITLE
[#85] Fix : 데스크탑 쉘 토스트 위치·표시 시간 및 스크롤 수정

### DIFF
--- a/app/(agit)/agit/search/page.tsx
+++ b/app/(agit)/agit/search/page.tsx
@@ -1,5 +1,0 @@
-import { AgitSearchTemplate } from "@/components/templates";
-
-export default function AgitSearchPage() {
-  return <AgitSearchTemplate />;
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,9 +58,9 @@ export default async function RootLayout({
   return (
     <html
       lang="ko"
-      className={cn("h-full", "antialiased", poppins.variable, gothicA1.variable, montserrat.variable, manrope.variable, geistMono.variable, inter.variable, "font-sans", geist.variable)}
+      className={cn("h-dvh overflow-hidden overscroll-none", "antialiased", poppins.variable, gothicA1.variable, montserrat.variable, manrope.variable, geistMono.variable, inter.variable, "font-sans", geist.variable)}
     >
-      <body className="flex min-h-dvh flex-col">
+      <body className="flex h-dvh min-h-0 flex-col overflow-hidden overscroll-none">
         <AuthSessionProvider isLoggedIn={session?.isLoggedIn === true}>
           <AppRouteShell>{children}</AppRouteShell>
         </AuthSessionProvider>

--- a/components/atoms/styles.ts
+++ b/components/atoms/styles.ts
@@ -29,7 +29,7 @@ export const ui = {
   glass:
     "rounded-[var(--dc-radius)] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,var(--dc-glass-from),var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px]",
   authPage:
-    "min-h-dvh w-full bg-[var(--dl-color-bg-elevated)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dl-color-text-primary)]",
+    "min-h-0 h-full w-full bg-[var(--dl-color-bg-elevated)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dl-color-text-primary)]",
   authContent: "mx-auto flex w-full max-w-[390px] flex-col gap-4 px-5 pb-10 pt-6",
   topbar: "flex w-full items-center gap-3",
   topbarBack:

--- a/components/molecules/AnimatedOverlays.tsx
+++ b/components/molecules/AnimatedOverlays.tsx
@@ -13,12 +13,14 @@ export function OverlayPortalProvider({ children }: { children: ReactNode }) {
 
   return (
     <OverlayPortalContext.Provider value={host}>
-      {children}
-      <div
-        id="plip-overlay-root"
-        ref={setHost}
-        className="pointer-events-none absolute inset-0 z-[40]"
-      />
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        {children}
+        <div
+          id="plip-overlay-root"
+          ref={setHost}
+          className="pointer-events-none absolute inset-0 z-[40]"
+        />
+      </div>
     </OverlayPortalContext.Provider>
   );
 }

--- a/components/molecules/BottomNavigation.tsx
+++ b/components/molecules/BottomNavigation.tsx
@@ -61,7 +61,7 @@ export function BottomNavigation({
   active = "diary",
 }: BottomNavigationProps) {
   return (
-    <nav aria-label="주 메뉴" className="sticky bottom-[0] z-30 flex h-[80px] shrink-0 items-center justify-between p-[6px_16px] [border-top:1px_solid_var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)]">
+    <nav aria-label="주 메뉴" className="absolute inset-x-0 bottom-0 z-30 flex h-[80px] shrink-0 items-center justify-between border-t border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] p-[6px_16px]">
       {NAV_ITEMS.map((item) => {
         const isActive = active === item.id;
 

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -109,7 +109,7 @@ export function DiaryDateDetailSection({
   }
 
   return (
-    <div className="flex h-[calc(100dvh-80px)] flex-col overflow-hidden bg-[var(--dc-page-bg)]">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[var(--dc-page-bg)]">
       <div className="shrink-0 px-4 pb-[1.15rem] pt-[0.9rem]">
         <ScreenHeader
           tone="plain"

--- a/components/organisms/DiaryMainSection.tsx
+++ b/components/organisms/DiaryMainSection.tsx
@@ -15,11 +15,11 @@ export function DiaryMainSection({ entries, themes, error }: DiaryMainSectionPro
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="flex h-[calc(100dvh-80px)] flex-col overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <DiaryHeader onMenuOpen={() => setMenuOpen(true)} />
       <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
 
-      <div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-4 pt-3">
         <ThemePreviewStrip themes={themes} />
         {error ? <p className="m-0 mt-3 px-1 text-sm text-red-600">{error}</p> : null}
         <div className="mt-8 flex min-h-0 flex-1 flex-col gap-4">

--- a/components/organisms/MobileDeviceFrame.tsx
+++ b/components/organisms/MobileDeviceFrame.tsx
@@ -12,15 +12,15 @@ type MobileDeviceFrameProps = {
  */
 export function MobileDeviceFrame({ children }: MobileDeviceFrameProps) {
   return (
-    <div className="w-full min-h-dvh md:flex md:items-center md:justify-center md:min-h-dvh md:p-[2rem_1.5rem] md:bg-[#ececf1]">
-      <div className="contents md:relative md:flex md:flex-col md:w-[min(402px,_calc(100vw_-_2rem))] md:h-[min(874px,_calc(100dvh_-_2.5rem))] md:p-[2px] md:rounded-[16px] md:bg-[var(--dl-color-border-default)] md:shadow-[0_12px_40px_rgba(23,_23,_28,_0.16)]">
-        <div className="relative min-h-dvh md:flex md:flex-1 md:min-h-0 md:flex-col md:overflow-hidden md:rounded-[14px] md:bg-[var(--dl-color-bg-elevated)] md:[transform:translateZ(0)]">
+    <div className="fixed inset-0 flex flex-col overflow-hidden md:items-center md:justify-center md:p-[2rem_1.5rem] md:bg-[#ececf1]">
+      <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden md:h-[min(874px,_calc(100dvh_-_2.5rem))] md:w-[min(402px,_calc(100vw_-_2rem))] md:flex-none md:p-[2px] md:rounded-[16px] md:bg-[var(--dl-color-border-default)] md:shadow-[0_12px_40px_rgba(23,_23,_28,_0.16)]">
+        <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden md:rounded-[14px] md:bg-[var(--dl-color-bg-elevated)] md:[transform:translateZ(0)]">
           <OverlayPortalProvider>
             <div className="hidden md:flex md:h-[32px] md:shrink-0 md:items-center md:justify-between md:p-[0_22px] md:text-[11px] md:font-semibold md:text-[var(--dl-color-text-primary)] md:[&_span:last-child]:text-[10px] md:[&_span:last-child]:font-medium md:[&_span:last-child]:text-[var(--dl-color-text-secondary)] md:[&_span:last-child]:tracking-[0.02em]" aria-hidden>
               <span>9:41</span>
               <span>●●●  100%</span>
             </div>
-            <div className={`${leftoverStyles.plipDeviceApp} flex min-h-dvh flex-col md:min-h-0 md:flex-1 md:overflow-hidden`}>
+            <div className={`${leftoverStyles.plipDeviceApp} flex min-h-0 flex-1 flex-col overflow-hidden`}>
               {children}
             </div>
           </OverlayPortalProvider>

--- a/components/providers/AppToaster.tsx
+++ b/components/providers/AppToaster.tsx
@@ -2,19 +2,16 @@
 
 import { Toaster } from "@/components/ui/toast";
 import type { ReactNode } from "react";
-import { useRef } from "react";
 
 type AppToasterProps = {
   children: ReactNode;
 };
 
-/** 폰 프레임 안에 토스트를 붙인다. PC에서 body fixed로 프레임 밖으로 나가지 않게 한다. */
+/** 토스트는 포털 없이 쉘 안에서 띄운다. body로 나가면 데스크탑 프레임 밖에 붙는다. */
 export function AppToaster({ children }: AppToasterProps) {
-  const frameRef = useRef<HTMLDivElement>(null);
-
   return (
-    <div ref={frameRef} className="relative flex min-h-dvh flex-1 flex-col md:min-h-0">
-      <Toaster portalContainer={frameRef}>{children}</Toaster>
+    <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <Toaster>{children}</Toaster>
     </div>
   );
 }

--- a/components/styles/leftover.module.css
+++ b/components/styles/leftover.module.css
@@ -96,11 +96,9 @@ button.plipBottomNavItem {
   box-shadow: none;
 }
 
-@media (min-width: 768px) {
 .plipDeviceApp > * {
   flex: 1;
   min-height: 0;
-}
 }
 
 .plipTtFeedTop > * {

--- a/components/templates/AppChromeTemplate.tsx
+++ b/components/templates/AppChromeTemplate.tsx
@@ -21,14 +21,14 @@ export function AppChromeTemplate({
 }: AppChromeTemplateProps) {
   const shellClass =
     variant === "light" || variant === "diary"
-      ? "mx-auto flex min-h-dvh w-full flex-col bg-[var(--dl-color-bg-elevated)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dl-color-text-primary)] md:h-full md:min-h-0"
-      : "mx-auto flex min-h-dvh w-full flex-col bg-[var(--plip-tt-bg)] text-[var(--plip-tt-text)] md:h-full md:min-h-0";
+      ? "relative mx-auto flex h-full min-h-0 w-full flex-col overflow-hidden bg-[var(--dl-color-bg-elevated)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dl-color-text-primary)]"
+      : "relative mx-auto flex h-full min-h-0 w-full flex-col overflow-hidden bg-[var(--plip-tt-bg)] text-[var(--plip-tt-text)]";
 
   return (
     <div className={`${shellClass} ${className}`.trim()}>
-      <div className="flex flex-1 min-w-0 min-h-0 flex-col w-full">
+      <div className={`flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden ${showNav ? "pb-[80px]" : ""}`}>
         {header}
-        <main className="flex flex-1 min-h-0 flex-col w-full">{children}</main>
+        <main className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto">{children}</main>
       </div>
       {showNav ? <BottomNavigation active={activeTab} variant={variant} /> : null}
     </div>

--- a/components/templates/DiaryTemplate.tsx
+++ b/components/templates/DiaryTemplate.tsx
@@ -9,8 +9,8 @@ type DiaryTemplateProps = {
 
 export function DiaryTemplate({ children, fixedMain = false }: DiaryTemplateProps) {
   return (
-    <div className="mx-auto flex min-h-dvh w-full max-w-full flex-col bg-[var(--dc-page-bg)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dc-fg-primary)] md:h-full md:min-h-0">
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
+    <div className="relative mx-auto flex h-full min-h-0 w-full max-w-full flex-col overflow-hidden bg-[var(--dc-page-bg)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dc-fg-primary)]">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden pb-[80px]">
         <main
           className={
             fixedMain

--- a/components/templates/HomeFeedTemplate.tsx
+++ b/components/templates/HomeFeedTemplate.tsx
@@ -3,9 +3,9 @@ import { BottomNavigation } from "@/components/molecules";
 
 export function HomeFeedTemplate() {
   return (
-    <div className="md:!w-full md:!max-w-none md:h-full md:min-h-0 flex min-h-dvh w-full max-w-none mx-auto flex-col bg-[var(--plip-tt-bg)] text-[var(--plip-tt-text)]">
-      <div className="flex flex-1 min-w-0 min-h-0 flex-col w-full">
-        <main className="flex flex-1 min-h-0 flex-col w-full">
+    <div className="relative md:!w-full md:!max-w-none flex h-full min-h-0 w-full max-w-none mx-auto flex-col overflow-hidden bg-[var(--plip-tt-bg)] text-[var(--plip-tt-text)]">
+      <div className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden pb-[80px]">
+        <main className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
           <HomeFeedSection />
         </main>
       </div>

--- a/components/templates/MyPageTemplate.tsx
+++ b/components/templates/MyPageTemplate.tsx
@@ -14,11 +14,13 @@ export function MyPageTemplate({
   children,
 }: MyPageTemplateProps) {
   return (
-    <>
-      <DailyLoopAuthTemplate>
-        {children ?? <ProfileHubSection />}
-      </DailyLoopAuthTemplate>
+    <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
+      <div className={`min-h-0 flex-1 overflow-y-auto ${showBottomNav ? "pb-[80px]" : ""}`}>
+        <DailyLoopAuthTemplate>
+          {children ?? <ProfileHubSection />}
+        </DailyLoopAuthTemplate>
+      </div>
       {showBottomNav ? <BottomNavigation active="mypage" variant="light" /> : null}
-    </>
+    </div>
   );
 }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -197,22 +197,31 @@ function ToastList() {
   ))
 }
 
+const TOAST_TIMEOUT_MS = 2200
+
 function Toaster({
   children,
   toastManager = toast,
   portalContainer,
+  timeout = TOAST_TIMEOUT_MS,
   ...props
 }: ToastPrimitive.Provider.Props & {
   portalContainer?: ToastPrimitive.Portal.Props["container"]
 }) {
+  const viewport = (
+    <ToastViewport>
+      <ToastList />
+    </ToastViewport>
+  )
+
   return (
-    <ToastProvider toastManager={toastManager} {...props}>
-      {children}
-      <ToastPortal container={portalContainer}>
-        <ToastViewport>
-          <ToastList />
-        </ToastViewport>
-      </ToastPortal>
+    <ToastProvider toastManager={toastManager} timeout={timeout} {...props}>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+      {portalContainer ? (
+        <ToastPortal container={portalContainer}>{viewport}</ToastPortal>
+      ) : (
+        viewport
+      )}
     </ToastProvider>
   )
 }


### PR DESCRIPTION
## 작업 내용

데스크탑 쉘에서 토스트가 너무 오래 뜨고 프레임 밖에 붙던 문제를 줄였고, 본문만 스크롤되고 하단 주 메뉴는 고정되도록 레이아웃을 잠갔습니다. 브랜치에 포함된 커밋 기준으로 공개방 검색 라우트도 제거했습니다.

## 관련 이슈

Close #85

## 변경 사항

### 1. 토스트 표시 시간 단축 및 쉘 내부 렌더

- **파일:** `components/ui/toast.tsx`
- **설명:** 기본 timeout을 2.2초로 두고, 포털이 없으면 쉘 안에서 뷰포트를 렌더해 프레임 밖으로 나가지 않게 했습니다.

```typescript
const TOAST_TIMEOUT_MS = 2200

function Toaster({
  timeout = TOAST_TIMEOUT_MS,
  portalContainer,
  ...
}) {
  return (
    <ToastProvider toastManager={toastManager} timeout={timeout} {...props}>
      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
      {portalContainer ? (
        <ToastPortal container={portalContainer}>{viewport}</ToastPortal>
      ) : (
        viewport
      )}
    </ToastProvider>
  )
}
```

### 2. 모바일·데스크탑 쉘 높이 고정 및 하단 메뉴 고정

- **파일:** `app/layout.tsx`, `components/organisms/MobileDeviceFrame.tsx`, `components/molecules/BottomNavigation.tsx`, `components/templates/AppChromeTemplate.tsx`, `components/templates/DiaryTemplate.tsx`, `components/templates/HomeFeedTemplate.tsx`, `components/templates/MyPageTemplate.tsx`
- **설명:** html/body와 디바이스 프레임을 뷰포트에 고정하고, 주 메뉴는 쉘 하단에 절대 배치해 본문 스크롤과 분리했습니다.

```tsx
<div className="fixed inset-0 flex flex-col overflow-hidden md:items-center md:justify-center ...">
  ...
</div>

<nav aria-label="주 메뉴" className="absolute inset-x-0 bottom-0 z-30 flex h-[80px] shrink-0 ...">
```

### 3. 공개방 검색 라우트 삭제

- **파일:** `app/(agit)/agit/search/page.tsx`
- **설명:** 공개방 검색 페이지 및 라우트를 제거했습니다. (`Feat: 공개방 검색 페이지 및 라우트 삭제`)

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)
  - [ ] 토스트가 약 2초 후 사라지고 데스크탑 프레임 안에 표시됨
  - [ ] 데스크탑/모바일에서 본문만 스크롤되고 하단 주 메뉴는 고정됨

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
