### PR TITLE
[#90] Feature : 테마 타임라인 pagination 및 날짜 window 연동

### DIFF
--- a/actions/diaryActions.ts
+++ b/actions/diaryActions.ts
@@ -3,8 +3,8 @@
 import { ApiError } from "@/lib/api/apiFetch";
 import * as diaryService from "@/services/diaryService";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
-import { parseThemeId, parseThemeName } from "@/types/diary/schema";
-import type { UiDiaryTheme } from "@/types/diary/ui";
+import { parseThemeId, parseThemeName, parseDiaryDateParam } from "@/types/diary/schema";
+import type { UiDiaryDateWindow, UiDiaryTheme, UiDiaryThemeTimelinePage } from "@/types/diary/ui";
 
 function toActionError(error: unknown): ActionResult<never> {
   if (error instanceof ApiError) {
@@ -61,6 +61,45 @@ export async function deleteThemeAction(themeId: unknown): Promise<ActionResult<
   try {
     await diaryService.deleteDiaryTheme(parsedId.data);
     return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function loadDiaryThemeTimelinePageAction(
+  themeId: unknown,
+  cursor: unknown,
+): Promise<ActionResult<UiDiaryThemeTimelinePage>> {
+  const parsedId = parseThemeId(themeId);
+  if (!parsedId.ok) {
+    return actionFailure(parsedId.error);
+  }
+
+  if (typeof cursor !== "string" || !cursor.trim()) {
+    return actionFailure("cursor가 올바르지 않습니다.");
+  }
+
+  try {
+    const page = await diaryService.getDiaryThemeTimelinePage(parsedId.data, cursor.trim());
+    return actionSuccess(page);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function fetchDiaryDateWindowAction(
+  date: unknown,
+  window = 1,
+): Promise<ActionResult<UiDiaryDateWindow>> {
+  const dateParam = typeof date === "string" ? date : "";
+  const parsedDate = parseDiaryDateParam(dateParam);
+  if (!parsedDate) {
+    return actionFailure("날짜 형식이 올바르지 않습니다.");
+  }
+
+  try {
+    const dateWindow = await diaryService.getDiaryDateWindow(parsedDate, window);
+    return actionSuccess(dateWindow);
   } catch (error) {
     return toActionError(error);
   }

--- a/app/(diary)/diary/[date]/page.tsx
+++ b/app/(diary)/diary/[date]/page.tsx
@@ -1,11 +1,9 @@
 import { DiaryDateTemplate } from "@/components/templates";
-import { getDiaryDateGroup } from "@/services/diaryService";
-import type { UiDiaryDateGroup } from "@/types/diary/ui";
+import { getDiaryDateWindow } from "@/services/diaryService";
+import type { UiDiaryDateWindow } from "@/types/diary/ui";
 import {
-  getTodayKstDateString,
   isFutureDiaryDate,
   parseDiaryDateParam,
-  shiftDiaryDate,
 } from "@/types/diary/schema";
 import { notFound } from "next/navigation";
 
@@ -21,26 +19,21 @@ export default async function DiaryDatePage({ params }: DiaryDatePageProps) {
     notFound();
   }
 
-  const nextDate = shiftDiaryDate(parsedDate, 1);
-  const canGoNext = !isFutureDiaryDate(nextDate, getTodayKstDateString());
-
-  let dateGroup: UiDiaryDateGroup = { date: parsedDate, themes: [] };
+  let initialWindow: UiDiaryDateWindow = {
+    focusDate: parsedDate,
+    days: { [parsedDate]: [] },
+  };
   let error: string | undefined;
 
   try {
-    dateGroup = await getDiaryDateGroup(parsedDate);
+    initialWindow = await getDiaryDateWindow(parsedDate, 1);
   } catch (caught) {
-    dateGroup = { date: parsedDate, themes: [] };
+    initialWindow = {
+      focusDate: parsedDate,
+      days: { [parsedDate]: [] },
+    };
     error = caught instanceof Error ? caught.message : "날짜 상세를 불러오지 못했습니다.";
   }
 
-  return (
-    <DiaryDateTemplate
-      dateGroup={dateGroup}
-      prevDate={shiftDiaryDate(parsedDate, -1)}
-      nextDate={nextDate}
-      canGoNext={canGoNext}
-      error={error}
-    />
-  );
+  return <DiaryDateTemplate initialWindow={initialWindow} error={error} />;
 }

--- a/app/(diary)/diary/themes/[themeId]/page.tsx
+++ b/app/(diary)/diary/themes/[themeId]/page.tsx
@@ -19,12 +19,16 @@ export default async function DiaryThemePage({ params }: DiaryThemePageProps) {
 
   let themeName = "";
   let dateGroups: UiDiaryThemeDateGroup[] = [];
+  let nextCursor: string | null = null;
+  let hasMore = false;
   let error: string | undefined;
 
   try {
     const result = await getDiaryThemeTimeline(parsedId.data);
     themeName = result.theme.name;
     dateGroups = result.dateGroups;
+    nextCursor = result.nextCursor;
+    hasMore = result.hasMore;
   } catch (caught) {
     if (caught instanceof ApiError && caught.status === 404) {
       notFound();
@@ -38,6 +42,8 @@ export default async function DiaryThemePage({ params }: DiaryThemePageProps) {
       themeId={parsedId.data}
       themeName={themeName}
       dateGroups={dateGroups}
+      initialNextCursor={nextCursor}
+      initialHasMore={hasMore}
       error={error}
     />
   );

--- a/components/molecules/DiaryThemeClipGroup.tsx
+++ b/components/molecules/DiaryThemeClipGroup.tsx
@@ -64,7 +64,7 @@ function DiaryClipThumb({ thumbnailSrc }: { thumbnailSrc?: string }) {
 }
 
 function ThumbGrid({ clips, clipCount }: { clips?: UiDiaryClip[]; clipCount: number }) {
-  const slotCount = Math.min(Math.max(clipCount, clips?.length ?? 0), 5);
+  const slotCount = Math.max(clipCount, clips?.length ?? 0);
 
   if (slotCount === 0) {
     return null;

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -1,19 +1,21 @@
 "use client";
 
+import { fetchDiaryDateWindowAction } from "@/actions/diaryActions";
 import { TextLink } from "@/components/atoms";
 import { DiaryThemeClipGroup, HeaderBackLink, ScreenHeader } from "@/components/molecules";
 import { formatDiaryDate } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
-import type { UiDiaryDateThemeGroup } from "@/types/diary/ui";
+import type { UiDiaryDateWindow } from "@/types/diary/ui";
+import {
+  getTodayKstDateString,
+  isFutureDiaryDate,
+  shiftDiaryDate,
+} from "@/types/diary/schema";
 import { useRouter } from "next/navigation";
-import { useRef, type PointerEvent } from "react";
+import { useRef, useState, type PointerEvent } from "react";
 
 type DiaryDateDetailSectionProps = {
-  date: string;
-  themes: UiDiaryDateThemeGroup[];
-  prevDate: string;
-  nextDate: string;
-  canGoNext: boolean;
+  initialWindow: UiDiaryDateWindow;
   error?: string;
 };
 
@@ -22,15 +24,20 @@ const NAV_ARROW_CLASS =
   "!grid place-items-center w-[2.25rem] h-[2.25rem] rounded-[999px] border border-[var(--dc-glass-border)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)] text-[1.35rem] font-bold leading-none !no-underline [&.is-disabled]:opacity-[0.28]";
 
 export function DiaryDateDetailSection({
-  date,
-  themes,
-  prevDate,
-  nextDate,
-  canGoNext,
-  error,
+  initialWindow,
+  error: initialError,
 }: DiaryDateDetailSectionProps) {
   const router = useRouter();
   const pointerStart = useRef<{ x: number; y: number; scrollTop: number } | null>(null);
+  const [focusDate, setFocusDate] = useState(initialWindow.focusDate);
+  const [daysCache, setDaysCache] = useState(initialWindow.days);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(initialError);
+
+  const themes = daysCache[focusDate] ?? [];
+  const prevDate = shiftDiaryDate(focusDate, -1);
+  const nextDate = shiftDiaryDate(focusDate, 1);
+  const canGoNext = !isFutureDiaryDate(nextDate, getTodayKstDateString());
 
   function isInteractiveTarget(target: EventTarget | null): boolean {
     return target instanceof Element && Boolean(target.closest("a, button, input, textarea, select"));
@@ -41,8 +48,34 @@ export function DiaryDateDetailSection({
     return (clientX - rect.left) / rect.width;
   }
 
+  async function navigateToDate(targetDate: string) {
+    if (isFutureDiaryDate(targetDate)) {
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(daysCache, targetDate)) {
+      setFocusDate(targetDate);
+      router.replace(ROUTES.diary.date(targetDate));
+      return;
+    }
+
+    setLoading(true);
+    const result = await fetchDiaryDateWindowAction(targetDate, 1);
+    setLoading(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    setDaysCache((current) => ({ ...current, ...result.data.days }));
+    setFocusDate(result.data.focusDate);
+    setError(undefined);
+    router.replace(ROUTES.diary.date(result.data.focusDate));
+  }
+
   function goPrev() {
-    router.push(ROUTES.diary.date(prevDate));
+    void navigateToDate(prevDate);
   }
 
   function goNext() {
@@ -50,7 +83,7 @@ export function DiaryDateDetailSection({
       return;
     }
 
-    router.push(ROUTES.diary.date(nextDate));
+    void navigateToDate(nextDate);
   }
 
   function handlePointerDown(event: PointerEvent<HTMLDivElement>) {
@@ -116,7 +149,7 @@ export function DiaryDateDetailSection({
           titleAlign="center"
           className="mb-[1.15rem]"
           leading={<HeaderBackLink href={ROUTES.diary.root} />}
-          title={<span className="sr-only">{formatDiaryDate(date)}</span>}
+          title={<span className="sr-only">{formatDiaryDate(focusDate)}</span>}
         />
 
         <div className="grid grid-cols-[2.25rem_1fr_2.25rem] items-center gap-[0.5rem]">
@@ -124,15 +157,23 @@ export function DiaryDateDetailSection({
             href={ROUTES.diary.date(prevDate)}
             className={NAV_ARROW_CLASS}
             aria-label="이전 날짜"
+            onClick={(event) => {
+              event.preventDefault();
+              goPrev();
+            }}
           >
             ‹
           </TextLink>
-          <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{formatDiaryDate(date)}</h2>
+          <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{formatDiaryDate(focusDate)}</h2>
           {canGoNext ? (
             <TextLink
               href={ROUTES.diary.date(nextDate)}
               className={NAV_ARROW_CLASS}
               aria-label="다음 날짜"
+              onClick={(event) => {
+                event.preventDefault();
+                goNext();
+              }}
             >
               ›
             </TextLink>
@@ -150,6 +191,9 @@ export function DiaryDateDetailSection({
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
       >
+        {loading ? (
+          <p className="m-0 text-center text-[0.85rem] font-semibold text-[rgba(0,_0,_0,_0.4)]">불러오는 중...</p>
+        ) : null}
         {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
 
         {themes.length > 0 ? (
@@ -157,16 +201,16 @@ export function DiaryDateDetailSection({
             <DiaryThemeClipGroup
               key={group.themeId}
               themeName={group.themeName}
-              date={date}
+              date={focusDate}
               clipCount={group.clipCount}
               clips={group.clips}
             />
           ))
-        ) : (
+        ) : !loading ? (
           <p className="m-[2rem_0_0] text-center text-[0.85rem] font-semibold text-[rgba(0,_0,_0,_0.4)]">
             해당 날짜의 다이어리 기록이 없습니다.
           </p>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/components/organisms/DiaryThemeDetailSection.tsx
+++ b/components/organisms/DiaryThemeDetailSection.tsx
@@ -1,22 +1,56 @@
 "use client";
 
-import { IconButton, ScreenTitle } from "@/components/atoms";
-import { DiaryThemeClipGroup, HeaderBackLink, ScreenHeader } from "@/components/molecules";
+import { loadDiaryThemeTimelinePageAction } from "@/actions/diaryActions";
+import { ScreenTitle } from "@/components/atoms";
+import { DiaryThemeClipGroup, HeaderBackLink, HeaderMenuButton, ScreenHeader } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
+import { mergeThemeDateGroups } from "@/lib/diary/mergeThemeDateGroups";
 import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
+import { useState } from "react";
 
 type DiaryThemeDetailSectionProps = {
   themeId: string;
   themeName: string;
   dateGroups: UiDiaryThemeDateGroup[];
+  initialNextCursor: string | null;
+  initialHasMore: boolean;
   error?: string;
 };
 
 export function DiaryThemeDetailSection({
+  themeId,
   themeName,
-  dateGroups,
-  error,
+  dateGroups: initialDateGroups,
+  initialNextCursor,
+  initialHasMore,
+  error: initialError,
 }: DiaryThemeDetailSectionProps) {
+  const [dateGroups, setDateGroups] = useState(initialDateGroups);
+  const [nextCursor, setNextCursor] = useState(initialNextCursor);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(initialError);
+
+  async function loadMore() {
+    if (!hasMore || !nextCursor || loadingMore) {
+      return;
+    }
+
+    setLoadingMore(true);
+    const result = await loadDiaryThemeTimelinePageAction(themeId, nextCursor);
+    setLoadingMore(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    setDateGroups((current) => mergeThemeDateGroups(current, result.data.dateGroups));
+    setNextCursor(result.data.nextCursor);
+    setHasMore(result.data.hasMore);
+    setError(undefined);
+  }
+
   return (
     <div className="flex flex-col gap-[1.15rem] p-[0.9rem_1rem_1.75rem]">
       <ScreenHeader
@@ -24,6 +58,7 @@ export function DiaryThemeDetailSection({
         titleAlign="center"
         leading={<HeaderBackLink href={ROUTES.diary.themes.root} />}
         title={<ScreenTitle className="text-[1rem] font-extrabold text-[#111]">{themeName}</ScreenTitle>}
+        trailing={<HeaderMenuButton label="테마 옵션" onClick={() => undefined} />}
       />
 
       {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
@@ -40,14 +75,24 @@ export function DiaryThemeDetailSection({
           />
         ))
       ) : (
-        <p className="m-[2rem_0_0] text-center text-[0.85rem] font-semibold text-[rgba(0,_0,_0,_0.4)]">해당 테마의 클립이 없습니다.</p>
+        <p className="m-[2rem_0_0] text-center text-[0.85rem] font-semibold text-[rgba(0,_0,_0,_0.4)]">
+          해당 테마의 클립이 없습니다.
+        </p>
       )}
 
-      <div className="flex justify-center pt-[0.25rem]">
-        <IconButton label="테마 옵션" className="!border-[var(--dc-glass-border)] !bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] !text-[var(--dc-fg-primary)]">
-          <span aria-hidden>⋮</span>
-        </IconButton>
-      </div>
+      {hasMore ? (
+        <button
+          type="button"
+          className="h-[40px] w-full rounded-[var(--dc-btn-radius)] text-sm font-medium text-[var(--dc-accent)] disabled:opacity-50"
+          disabled={loadingMore}
+          aria-label="이전 기록 더보기"
+          onClick={() => {
+            void loadMore();
+          }}
+        >
+          {loadingMore ? "불러오는 중..." : "더보기"}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/components/templates/DiaryDateTemplate.tsx
+++ b/components/templates/DiaryDateTemplate.tsx
@@ -1,32 +1,16 @@
 import { DiaryDateDetailSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
-import type { UiDiaryDateGroup } from "@/types/diary/ui";
+import type { UiDiaryDateWindow } from "@/types/diary/ui";
 
 type DiaryDateTemplateProps = {
-  dateGroup: UiDiaryDateGroup;
-  prevDate: string;
-  nextDate: string;
-  canGoNext: boolean;
+  initialWindow: UiDiaryDateWindow;
   error?: string;
 };
 
-export function DiaryDateTemplate({
-  dateGroup,
-  prevDate,
-  nextDate,
-  canGoNext,
-  error,
-}: DiaryDateTemplateProps) {
+export function DiaryDateTemplate({ initialWindow, error }: DiaryDateTemplateProps) {
   return (
     <DiaryTemplate fixedMain>
-      <DiaryDateDetailSection
-        date={dateGroup.date}
-        themes={dateGroup.themes}
-        prevDate={prevDate}
-        nextDate={nextDate}
-        canGoNext={canGoNext}
-        error={error}
-      />
+      <DiaryDateDetailSection initialWindow={initialWindow} error={error} />
     </DiaryTemplate>
   );
 }

--- a/components/templates/DiaryThemeDetailTemplate.tsx
+++ b/components/templates/DiaryThemeDetailTemplate.tsx
@@ -6,6 +6,8 @@ type DiaryThemeDetailTemplateProps = {
   themeId: string;
   themeName: string;
   dateGroups: UiDiaryThemeDateGroup[];
+  initialNextCursor: string | null;
+  initialHasMore: boolean;
   error?: string;
 };
 
@@ -13,6 +15,8 @@ export function DiaryThemeDetailTemplate({
   themeId,
   themeName,
   dateGroups,
+  initialNextCursor,
+  initialHasMore,
   error,
 }: DiaryThemeDetailTemplateProps) {
   return (
@@ -21,6 +25,8 @@ export function DiaryThemeDetailTemplate({
         themeId={themeId}
         themeName={themeName}
         dateGroups={dateGroups}
+        initialNextCursor={initialNextCursor}
+        initialHasMore={initialHasMore}
         error={error}
       />
     </DiaryTemplate>

--- a/lib/api/diaryApi.ts
+++ b/lib/api/diaryApi.ts
@@ -7,6 +7,7 @@ import type {
   ApiCreateDiaryThemeRequest,
   ApiDiaryCalendarResponse,
   ApiDiaryDateResponse,
+  ApiDiaryDateWindowResponse,
   ApiDiaryHomeResponse,
   ApiDiaryTheme,
   ApiDiaryThemesResponse,
@@ -71,13 +72,34 @@ export async function getDiaryCalendar(
   });
 }
 
-export async function getDiaryByDate(date: string): Promise<ApiDiaryDateResponse> {
-  return diaryFetch<ApiDiaryDateResponse>(API_ENDPOINTS.diary.dateDetail(date), { method: "GET" });
+export async function getDiaryByDate(date: string, window = 0): Promise<ApiDiaryDateResponse> {
+  return diaryFetch<ApiDiaryDateResponse>(API_ENDPOINTS.diary.dateDetail(date), {
+    method: "GET",
+    searchParams: window > 0 ? { window: String(window) } : undefined,
+  });
 }
 
-export async function getDiaryThemeTimeline(themeId: string): Promise<ApiDiaryTimelineResponse> {
+export async function getDiaryDateWindow(
+  date: string,
+  window = 1,
+): Promise<ApiDiaryDateWindowResponse> {
+  return diaryFetch<ApiDiaryDateWindowResponse>(API_ENDPOINTS.diary.dateDetail(date), {
+    method: "GET",
+    searchParams: { window: String(window) },
+  });
+}
+
+export async function getDiaryThemeTimeline(
+  themeId: string,
+  cursor?: string,
+  limit = 50,
+): Promise<ApiDiaryTimelineResponse> {
   return diaryFetch<ApiDiaryTimelineResponse>(API_ENDPOINTS.diary.themeTimeline(themeId), {
     method: "GET",
+    searchParams: {
+      limit: String(limit),
+      ...(cursor ? { cursor } : {}),
+    },
   });
 }
 

--- a/lib/diary/mergeThemeDateGroups.ts
+++ b/lib/diary/mergeThemeDateGroups.ts
@@ -1,0 +1,29 @@
+import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
+
+export function mergeThemeDateGroups(
+  existing: UiDiaryThemeDateGroup[],
+  incoming: UiDiaryThemeDateGroup[],
+): UiDiaryThemeDateGroup[] {
+  if (incoming.length === 0) {
+    return existing;
+  }
+
+  const merged = [...existing];
+
+  for (const group of incoming) {
+    const last = merged[merged.length - 1];
+    if (last && last.date === group.date) {
+      const clips = [...(last.clips ?? []), ...(group.clips ?? [])];
+      merged[merged.length - 1] = {
+        ...last,
+        clips,
+        clipCount: clips.length,
+      };
+      continue;
+    }
+
+    merged.push(group);
+  }
+
+  return merged;
+}

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -2,6 +2,7 @@ import * as diaryApi from "@/lib/api/diaryApi";
 import type {
   ApiDiaryDateResponse,
   ApiDiaryDateSection,
+  ApiDiaryDateWindowResponse,
   ApiDiaryHomeSection,
   ApiDiaryTheme,
   ApiDiaryTimelineSection,
@@ -12,8 +13,10 @@ import type {
   UiDiaryDateEntry,
   UiDiaryDateGroup,
   UiDiaryDateThemeGroup,
+  UiDiaryDateWindow,
   UiDiaryTheme,
   UiDiaryThemeDateGroup,
+  UiDiaryThemeTimelinePage,
 } from "@/types/diary/ui";
 
 function mapTheme(theme: ApiDiaryTheme): UiDiaryTheme {
@@ -201,18 +204,52 @@ export async function getDiaryDateGroup(date: string): Promise<UiDiaryDateGroup>
   return mapDateResponse(response);
 }
 
+export async function getDiaryDateWindow(date: string, window = 1): Promise<UiDiaryDateWindow> {
+  const response = await diaryApi.getDiaryDateWindow(date, window);
+  return mapDateWindowResponse(response);
+}
+
+function mapDateWindowResponse(response: ApiDiaryDateWindowResponse): UiDiaryDateWindow {
+  const days: Record<string, UiDiaryDateThemeGroup[]> = {};
+
+  for (const day of response.days) {
+    days[day.date] = day.sections.map((group) => mapDateThemeGroup(group, day.date));
+  }
+
+  return {
+    focusDate: response.focusDate,
+    days,
+  };
+}
+
+export async function getDiaryThemeTimelinePage(
+  themeId: string,
+  cursor?: string,
+): Promise<UiDiaryThemeTimelinePage> {
+  const timeline = await diaryApi.getDiaryThemeTimeline(themeId, cursor);
+  return {
+    dateGroups: timeline.sections.map((section) => mapTimelineSection(section, themeId)),
+    nextCursor: timeline.nextCursor ?? null,
+    hasMore: Boolean(timeline.hasMore),
+  };
+}
+
 export async function getDiaryThemeTimeline(themeId: string): Promise<{
   theme: UiDiaryTheme;
   dateGroups: UiDiaryThemeDateGroup[];
+  nextCursor: string | null;
+  hasMore: boolean;
 }> {
   const [theme, timeline] = await Promise.all([
     diaryApi.getDiaryTheme(themeId).then(mapTheme),
-    diaryApi.getDiaryThemeTimeline(themeId),
+    getDiaryThemeTimelinePage(themeId),
   ]);
 
   return {
     theme,
-    dateGroups: timeline.sections.map((section) => mapTimelineSection(section, themeId)),
+    dateGroups: timeline.dateGroups,
+    nextCursor: timeline.nextCursor,
+    hasMore: timeline.hasMore,
   };
 }
 

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -71,6 +71,18 @@ export type ApiDiaryTimelineSection = {
 
 export type ApiDiaryTimelineResponse = {
   sections: ApiDiaryTimelineSection[];
+  nextCursor?: string | null;
+  hasMore?: boolean;
+};
+
+export type ApiDiaryDateWindowDay = {
+  date: string;
+  sections: ApiDiaryDateSection[];
+};
+
+export type ApiDiaryDateWindowResponse = {
+  focusDate: string;
+  days: ApiDiaryDateWindowDay[];
 };
 
 export type ApiDiaryTopicTransferRequest = {

--- a/types/diary/ui.ts
+++ b/types/diary/ui.ts
@@ -35,3 +35,14 @@ export type UiDiaryThemeDateGroup = {
   clipCount: number;
   clips?: UiDiaryClip[];
 };
+
+export type UiDiaryThemeTimelinePage = {
+  dateGroups: UiDiaryThemeDateGroup[];
+  nextCursor: string | null;
+  hasMore: boolean;
+};
+
+export type UiDiaryDateWindow = {
+  focusDate: string;
+  days: Record<string, UiDiaryDateThemeGroup[]>;
+};


### PR DESCRIPTION
## 작업 내용

diary-service의 테마 타임라인 cursor pagination과 날짜 window API를 FE에 연동했습니다. 테마 상세는 더보기로 페이지를 이어 붙이고 날짜 섹션 경계 merge를 적용했으며, 날짜 상세는 window=1 초기 로드 후 스와이프 시 캐시된 날짜는 API 없이 전환합니다.

## 관련 이슈

Close #90

## 변경 사항

### 1. 테마 타임라인 pagination

- **파일:** `services/diaryService.ts`, `actions/diaryActions.ts`, `components/organisms/DiaryThemeDetailSection.tsx`, `lib/diary/mergeThemeDateGroups.ts`
- **설명:** nextCursor 기반 더보기, 동일 날짜 섹션 merge

### 2. 날짜 window + 스와이프 캐시

- **파일:** `components/organisms/DiaryDateDetailSection.tsx`, `app/(diary)/diary/[date]/page.tsx`
- **설명:** window=1 초기 로드, 캐시 범위 내 스와이프는 client state, URL은 replace

### 3. 썸네일 그리드

- **파일:** `components/molecules/DiaryThemeClipGroup.tsx`
- **설명:** 날짜당 썸네일 5개 cap 제거, 로드된 clip 전체 표시

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [x] develop-env 수동 E2E (로그인 → 테마 더보기 → 날짜 스와이프)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [x] @headdrop 승인