### PR TITLE
[#501] Feature: 인증 및 8mb 업로드 제한

### DIFF
--- a/actions/videoActions.ts
+++ b/actions/videoActions.ts
@@ -7,8 +7,10 @@ import type {
   VideoDownloadUrlActionData,
   VideoUploadUrlActionData,
 } from "@/types/video/action";
-import { getDevUserUuid, getVideoApiBaseUrl } from "@/lib/api/env";
+import { getVideoApiBaseUrl } from "@/lib/api/env";
 import { ApiError } from "@/lib/api/apiFetch";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import { VIDEO_LOGIN_REQUIRED, VIDEO_SESSION_INVALID } from "@/lib/video/actionErrors";
 import {
   toCompleteActionData,
   toDetailActionData,
@@ -22,9 +24,19 @@ const UUID_PATTERN =
 
 const ALLOWED_CONTENT_TYPES = new Set(["video/mp4", "video/quicktime"]);
 
-function resolveUserUuid(userUuid?: string): string | null {
-  const resolved = userUuid?.trim() || getDevUserUuid();
-  return UUID_PATTERN.test(resolved) ? resolved : null;
+async function requireSessionUserUuid(): Promise<
+  { ok: true; userUuid: string } | { ok: false; error: string }
+> {
+  const userUuid = await getServerUserUuid();
+  if (!userUuid) {
+    return { ok: false, error: VIDEO_LOGIN_REQUIRED };
+  }
+
+  if (!UUID_PATTERN.test(userUuid)) {
+    return { ok: false, error: VIDEO_SESSION_INVALID };
+  }
+
+  return { ok: true, userUuid };
 }
 
 function resolveVideoUuid(videoUuid: string): string | null {
@@ -62,11 +74,10 @@ function toActionError(error: unknown): ActionResult<never> {
 
 export async function issueUploadUrlAction(
   contentType?: string,
-  userUuid?: string,
 ): Promise<ActionResult<VideoUploadUrlActionData>> {
-  const resolvedUserUuid = resolveUserUuid(userUuid);
-  if (!resolvedUserUuid) {
-    return actionFailure("Invalid userUuid");
+  const session = await requireSessionUserUuid();
+  if (!session.ok) {
+    return actionFailure(session.error);
   }
 
   const resolvedContentType = resolveContentType(contentType);
@@ -75,7 +86,7 @@ export async function issueUploadUrlAction(
   }
 
   try {
-    const data = await videoService.issueUploadUrl(resolvedUserUuid, resolvedContentType);
+    const data = await videoService.issueUploadUrl(session.userUuid, resolvedContentType);
     return actionSuccess(toUploadUrlActionData(data));
   } catch (error) {
     return toActionError(error);
@@ -85,16 +96,15 @@ export async function issueUploadUrlAction(
 export async function completeVideoAction(
   videoUuid: string,
   caption?: string,
-  userUuid?: string,
 ): Promise<ActionResult<VideoCompleteActionData>> {
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);
   if (!resolvedVideoUuid) {
     return actionFailure("Invalid videoUuid");
   }
 
-  const resolvedUserUuid = resolveUserUuid(userUuid);
-  if (!resolvedUserUuid) {
-    return actionFailure("Invalid userUuid");
+  const session = await requireSessionUserUuid();
+  if (!session.ok) {
+    return actionFailure(session.error);
   }
 
   const normalizedCaption = caption?.trim() || undefined;
@@ -102,7 +112,7 @@ export async function completeVideoAction(
   try {
     const data = await videoService.completeVideo(
       resolvedVideoUuid,
-      resolvedUserUuid,
+      session.userUuid,
       normalizedCaption,
     );
     return actionSuccess(toCompleteActionData(data));
@@ -114,6 +124,11 @@ export async function completeVideoAction(
 export async function getVideoAction(
   videoUuid: string,
 ): Promise<ActionResult<VideoDetailActionData>> {
+  const session = await requireSessionUserUuid();
+  if (!session.ok) {
+    return actionFailure(session.error);
+  }
+
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);
   if (!resolvedVideoUuid) {
     return actionFailure("Invalid videoUuid");
@@ -130,6 +145,11 @@ export async function getVideoAction(
 export async function getDownloadUrlAction(
   videoUuid: string,
 ): Promise<ActionResult<VideoDownloadUrlActionData>> {
+  const session = await requireSessionUserUuid();
+  if (!session.ok) {
+    return actionFailure(session.error);
+  }
+
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);
   if (!resolvedVideoUuid) {
     return actionFailure("Invalid videoUuid");

--- a/auth.ts
+++ b/auth.ts
@@ -62,7 +62,17 @@ const NaverProvider: Provider = {
 };
 
 const GUEST_ONLY_PREFIXES = ["/login", "/signup", "/forgot-password", "/reset-password"];
-const PROTECTED_PREFIXES = ["/home", "/diary", "/agit", "/mypage", "/shop", "/create", "/viewer"];
+const PROTECTED_PREFIXES = [
+  "/home",
+  "/diary",
+  "/agit",
+  "/mypage",
+  "/shop",
+  "/create",
+  "/viewer",
+  "/video",
+  "/video-api",
+];
 
 function matchesPrefix(pathname: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));

--- a/components/organisms/CaptureCameraStage.tsx
+++ b/components/organisms/CaptureCameraStage.tsx
@@ -9,6 +9,7 @@ import type { RefCallback } from "react";
 type CaptureCameraStageProps = {
   videoRef: RefCallback<HTMLVideoElement>;
   status: RecorderStatus;
+  facingMode?: "user" | "environment";
   error: string | null;
   elapsedMs: number;
   maxDurationMs: number;
@@ -20,6 +21,7 @@ type CaptureCameraStageProps = {
 export function CaptureCameraStage({
   videoRef,
   status,
+  facingMode = "user",
   error,
   elapsedMs,
   maxDurationMs,
@@ -30,12 +32,13 @@ export function CaptureCameraStage({
   const isRecording = status === "recording";
   const isBusy = status === "requesting" || isRecording;
   const showTimer = isRecording;
+  const mirrorFrontCamera = facingMode === "user";
 
   return (
     <section className="relative min-h-[calc(100dvh_-_80px)] overflow-hidden bg-[#111] -mx-5 -mt-6" aria-label="카메라">
       <video
         ref={videoRef}
-        className="absolute inset-0 h-full w-full object-contain"
+        className={`absolute inset-0 h-full w-full object-contain ${mirrorFrontCamera ? "-scale-x-100" : ""}`}
         autoPlay
         playsInline
         muted

--- a/components/organisms/VideoApiLabSection.tsx
+++ b/components/organisms/VideoApiLabSection.tsx
@@ -9,9 +9,12 @@ import {
 } from "@/actions/videoActions";
 import {
   extractActionError,
+  extractUploadUrlFromActionResult,
   extractVideoUuidFromActionResult,
 } from "@/lib/video/actionPayload";
-import { useState } from "react";
+import { DEFAULT_UPLOAD_CONTENT_TYPE } from "@/lib/video/constants";
+import { putPresignedUpload } from "@/lib/video/putPresigned";
+import { useRef, useState } from "react";
 
 type LogEntry = {
   id: number;
@@ -27,8 +30,11 @@ type StatusMessage = {
 export function VideoApiLabSection() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [videoUuid, setVideoUuid] = useState("");
+  const [uploadUrl, setUploadUrl] = useState("");
+  const [putDone, setPutDone] = useState(false);
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<StatusMessage | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function appendLog(label: string, payload: unknown) {
     setLogs((prev) => [{ id: Date.now(), label, payload }, ...prev].slice(0, 10));
@@ -42,6 +48,12 @@ export function VideoApiLabSection() {
       setVideoUuid(nextVideoUuid);
     }
 
+    const nextUploadUrl = extractUploadUrlFromActionResult(payload);
+    if (nextUploadUrl) {
+      setUploadUrl(nextUploadUrl);
+      setPutDone(false);
+    }
+
     const error = extractActionError(payload);
     if (error) {
       setStatus({ kind: "error", text: error });
@@ -49,7 +61,10 @@ export function VideoApiLabSection() {
     }
 
     if (nextVideoUuid && label === "issueUploadUrlAction") {
-      setStatus({ kind: "success", text: `videoUuid 입력됨: ${nextVideoUuid}` });
+      setStatus({
+        kind: "success",
+        text: `videoUuid·uploadUrl 준비됨. 2. mp4 선택 후 PUT 실행`,
+      });
       return;
     }
 
@@ -77,11 +92,58 @@ export function VideoApiLabSection() {
     await run("issueUploadUrlAction", () => issueUploadUrlAction("video/mp4"));
   }
 
+  async function handlePutToS3() {
+    if (!uploadUrl.trim()) {
+      applyActionResult("putPresignedUpload", {
+        ok: false,
+        error: "uploadUrl이 비어 있습니다. 1. upload-url을 먼저 실행하세요.",
+      });
+      return;
+    }
+
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) {
+      applyActionResult("putPresignedUpload", {
+        ok: false,
+        error: "mp4/mov 파일을 선택하세요.",
+      });
+      return;
+    }
+
+    setBusy(true);
+    setStatus(null);
+
+    try {
+      const result = await putPresignedUpload(
+        uploadUrl.trim(),
+        file,
+        DEFAULT_UPLOAD_CONTENT_TYPE,
+      );
+      appendLog("putPresignedUpload", { ok: true, data: { result } });
+      setPutDone(true);
+      setStatus({ kind: "success", text: `S3 PUT 성공 (${result})` });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      appendLog("putPresignedUpload", { ok: false, error: message });
+      setStatus({ kind: "error", text: message });
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function handleComplete() {
     if (!videoUuid.trim()) {
       applyActionResult("completeVideoAction", {
         ok: false,
         error: "videoUuid가 비어 있습니다. 1. upload-url을 먼저 실행하세요.",
+      });
+      return;
+    }
+
+    if (!putDone) {
+      applyActionResult("completeVideoAction", {
+        ok: false,
+        error: "2. PUT을 먼저 실행하세요. complete는 S3에 파일이 있어야 합니다.",
       });
       return;
     }
@@ -115,18 +177,22 @@ export function VideoApiLabSection() {
     await run("getDownloadUrlAction", () => getDownloadUrlAction(videoUuid.trim()));
   }
 
+  const putDisabled = busy || uploadUrl.trim().length === 0;
+  const completeDisabled = busy || !putDone;
+
   return (
     <section className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6 font-mono text-sm">
       <header>
-        <h1 className="text-lg font-semibold">Video API Lab (Step 1–3)</h1>
+        <h1 className="text-lg font-semibold">Video API Lab (Day 1)</h1>
         <p className="text-black/60">
-          Server Actions → videoService → videoApi → plip-video (:8085)
+          로그인 필수. Server Actions는 세션 JWT의 userUuid만 사용합니다.
         </p>
         <p className="text-xs text-black/50">
-          촬영 Phase 0-F (Step 4 PR):{" "}
+          순서: upload-url → S3 PUT → complete → GET detail → GET download-url. 촬영 UI는{" "}
           <a href={ROUTES.capture.video} className="underline">
             {ROUTES.capture.video}
           </a>
+          .
         </p>
       </header>
 
@@ -151,6 +217,17 @@ export function VideoApiLabSection() {
         />
       </label>
 
+      <label className="flex flex-col gap-1">
+        <span>2. PUT용 mp4/mov</span>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="video/mp4,video/quicktime,.mp4,.mov"
+          className="text-xs"
+          disabled={putDisabled}
+        />
+      </label>
+
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
@@ -163,10 +240,18 @@ export function VideoApiLabSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={busy}
+          disabled={putDisabled}
+          onClick={handlePutToS3}
+        >
+          2. PUT S3
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={completeDisabled}
           onClick={handleComplete}
         >
-          2. complete (NoOp PUT 생략)
+          3. complete
         </button>
         <button
           type="button"
@@ -174,7 +259,7 @@ export function VideoApiLabSection() {
           disabled={busy}
           onClick={handleGetVideo}
         >
-          3. GET detail
+          4. GET detail
         </button>
         <button
           type="button"
@@ -182,12 +267,13 @@ export function VideoApiLabSection() {
           disabled={busy}
           onClick={handleGetDownloadUrl}
         >
-          4. GET download-url
+          5. GET download-url
         </button>
       </div>
 
       <p className="text-xs text-black/50">
-        순서: 1 → 2 → 3 → 4. 2번(complete) 전에 3·4번을 누르면 404/202만 나올 수 있습니다.
+        download-url은 가공 전이면 202 PROCESSING이 정상입니다. PUT stub(AWS_ENABLED=false)이면
+        skipped-stub 후 complete 가능합니다.
       </p>
 
       <ol className="list-decimal space-y-2 pl-5 text-black/70">

--- a/components/organisms/VideoCaptureSection.tsx
+++ b/components/organisms/VideoCaptureSection.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { CaptureVideoFrame } from "@/components/molecules/CaptureVideoFrame";
 import { ROUTES } from "@/config/routes";
 import { useVideoCaptureFlow } from "@/hooks/useVideoCaptureFlow";
-import { CaptureVideoFrame } from "@/components/molecules/CaptureVideoFrame";
+import { MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from "@/lib/video/constants";
 import { formatBlobSummary } from "@/lib/video/recorderMime";
+import { isWithinUploadLimit } from "@/lib/video/uploadLimits";
 import Link from "next/link";
+import { useRef } from "react";
 
 export function VideoCaptureSection() {
   const {
@@ -25,9 +28,17 @@ export function VideoCaptureSection() {
     flipCamera,
     retake,
     uploadCapture,
+    uploadFile,
+    uploadOversizeTest,
   } = useVideoCaptureFlow();
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const progressPct = Math.min(100, Math.round((elapsedMs / maxDurationMs) * 100));
+  const canUploadBlob = blob !== null && isWithinUploadLimit(blob.size);
+  const blobOverLimit = blob !== null && blob.size > MAX_UPLOAD_BYTES;
+  const isLivePreview =
+    status === "requesting" || status === "ready" || status === "recording";
+  const mirrorFrontCamera = facingMode === "user" && isLivePreview;
 
   return (
     <section className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6 font-mono text-sm">
@@ -38,19 +49,19 @@ export function VideoCaptureSection() {
           </Link>{" "}
           · Actions lab
         </p>
-        <h1 className="text-lg font-semibold">Video Capture (Phase 0-F)</h1>
+        <h1 className="text-lg font-semibold">Video Capture (Day 1)</h1>
         <p className="text-black/60">
-          5초 촬영 → upload-url → PUT → complete → GET → download-url poll
+          로그인 필수 · 5초 · 720×1280 · 최대 {MAX_UPLOAD_MB}MB → upload-url → PUT → complete
         </p>
         <p className="text-xs text-amber-700">
-          (capture) route group — user-app 본 UI(/, /create)와 분리
+          세션 JWT의 userUuid만 사용합니다. stub URL이면 put이 skipped-stub입니다.
         </p>
       </header>
 
       <CaptureVideoFrame variant="lab">
         <video
           ref={videoRef}
-          className="h-full w-full object-contain"
+          className={`h-full w-full object-contain ${mirrorFrontCamera ? "-scale-x-100" : ""}`}
           autoPlay
           playsInline
           muted={flowPhase !== "complete"}
@@ -68,6 +79,9 @@ export function VideoCaptureSection() {
         <p>camera: {facingMode}</p>
         {mimeType ? <p>mime: {mimeType}</p> : null}
         {blob ? <p>blob: {formatBlobSummary(blob)}</p> : null}
+        {blobOverLimit ? (
+          <p className="text-red-700">최대 {MAX_UPLOAD_MB}MB를 초과해 업로드할 수 없습니다.</p>
+        ) : null}
       </div>
 
       <div className="flex flex-wrap gap-2">
@@ -111,11 +125,40 @@ export function VideoCaptureSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={uploading || flowPhase !== "preview" || !blob}
+          disabled={uploading || flowPhase !== "preview" || !canUploadBlob}
           onClick={() => void uploadCapture()}
         >
           {uploading ? "업로드 중…" : "업로드 · complete"}
         </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          mp4/mov로 테스트
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-2 disabled:opacity-50"
+          disabled={uploading}
+          onClick={() => void uploadOversizeTest()}
+        >
+          8MB 초과 테스트
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="video/mp4,video/quicktime,.mp4,.mov"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            event.target.value = "";
+            if (file) {
+              void uploadFile(file);
+            }
+          }}
+        />
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
@@ -136,7 +179,12 @@ export function VideoCaptureSection() {
         <div className="space-y-2 rounded bg-green-50 px-3 py-2 text-xs text-green-900">
           <p>videoUuid: {uploadResult.videoUuid}</p>
           <p>overlayTime: {uploadResult.complete.overlayTime}</p>
-          <p>put: {uploadResult.putResult}</p>
+          <p>
+            put: {uploadResult.putResult}
+            {uploadResult.putResult === "skipped-stub"
+              ? " · S3에 파일이 올라가지 않았습니다. 백엔드 실 presign을 확인하세요."
+              : " · S3 PUT 완료"}
+          </p>
           <p>downloadReady (GET): {String(uploadResult.detail.downloadReady)}</p>
           <p>
             download-url: {uploadResult.download.status}
@@ -146,6 +194,12 @@ export function VideoCaptureSection() {
           </p>
           <p>download poll attempts: {uploadResult.downloadPollAttempts}</p>
           <p>playback: {uploadResult.playback.kind}</p>
+          {mimeType && !mimeType.toLowerCase().includes("mp4") ? (
+            <p className="text-green-800">
+              녹화 MIME은 {mimeType}입니다. raw 버킷 파일이 webm인 것은 정상입니다. mp4
+              변환은 Day 2 FFmpeg에서 합니다.
+            </p>
+          ) : null}
           {uploadResult.playback.note ? (
             <p className="text-green-800">{uploadResult.playback.note}</p>
           ) : null}

--- a/docs/video-local.env.example
+++ b/docs/video-local.env.example
@@ -1,5 +1,6 @@
 # Copy to project root as .env.local (gitignored)
 # = 앞뒤 공백 없이 작성
+# Day 1: video actions use the logged-in session userUuid (not DEV_USER_UUID).
 API_URL=http://localhost:8000
 VIDEO_API_BASE_URL=http://localhost:8085
 DEV_USER_UUID=00000000-0000-4000-8000-000000000001

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -2,6 +2,7 @@
 
 import { useVideoRecorder } from "@/hooks/useVideoRecorder";
 import { DEFAULT_CAPTURE_CAPTION } from "@/lib/video/constants";
+import { createOversizeUploadBlob } from "@/lib/video/uploadLimits";
 import { runPhase0FUpload, type Phase0FUploadResult } from "@/lib/video/uploadPipeline";
 import type { CaptureFlowPhase } from "@/types/video/ui";
 import { useCallback, useMemo, useState } from "react";
@@ -70,22 +71,20 @@ export function useVideoCaptureFlow() {
     await recorder.discardRecording();
   }, [recorder, resetFlow]);
 
-  const uploadCapture = useCallback(
-    async (caption = DEFAULT_CAPTURE_CAPTION) => {
-      if (!recorder.blob) {
-        setFlowError("Recorded blob is missing");
-        return null;
-      }
-
+  const uploadBlob = useCallback(
+    async (
+      blob: Blob,
+      options?: { caption?: string; recorderMimeType?: string; localPreviewUrl?: string | null },
+    ) => {
       setUploading(true);
       setFlowError(null);
       setUploadResult(null);
 
       try {
-        const result = await runPhase0FUpload(recorder.blob, {
-          caption,
-          recorderMimeType: recorder.mimeType,
-          localPreviewUrl: recorder.previewUrl,
+        const result = await runPhase0FUpload(blob, {
+          caption: options?.caption ?? DEFAULT_CAPTURE_CAPTION,
+          recorderMimeType: options?.recorderMimeType ?? blob.type,
+          localPreviewUrl: options?.localPreviewUrl,
         });
 
         setUploadResult(result);
@@ -98,8 +97,42 @@ export function useVideoCaptureFlow() {
         setUploading(false);
       }
     },
-    [recorder.blob, recorder.mimeType, recorder.previewUrl],
+    [],
   );
+
+  const uploadCapture = useCallback(
+    async (caption = DEFAULT_CAPTURE_CAPTION) => {
+      if (!recorder.blob) {
+        setFlowError("Recorded blob is missing");
+        return null;
+      }
+
+      return uploadBlob(recorder.blob, {
+        caption,
+        recorderMimeType: recorder.mimeType,
+        localPreviewUrl: recorder.previewUrl,
+      });
+    },
+    [recorder.blob, recorder.mimeType, recorder.previewUrl, uploadBlob],
+  );
+
+  const uploadFile = useCallback(
+    async (file: File, caption = DEFAULT_CAPTURE_CAPTION) => {
+      return uploadBlob(file, {
+        caption,
+        recorderMimeType: file.type,
+        localPreviewUrl: URL.createObjectURL(file),
+      });
+    },
+    [uploadBlob],
+  );
+
+  const uploadOversizeTest = useCallback(async () => {
+    return uploadBlob(createOversizeUploadBlob(), {
+      caption: "oversize-limit-test",
+      recorderMimeType: "video/mp4",
+    });
+  }, [uploadBlob]);
 
   return {
     ...recorder,
@@ -109,6 +142,8 @@ export function useVideoCaptureFlow() {
     uploading,
     retake,
     uploadCapture,
+    uploadFile,
+    uploadOversizeTest,
     resetFlow,
   };
 }

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -1,6 +1,11 @@
 "use client";
 
-import { MAX_RECORD_MS, RECORD_STOP_MS, RECORD_TIMESLICE_MS } from "@/lib/video/constants";
+import {
+  MAX_RECORD_MS,
+  RECORD_STOP_MS,
+  RECORD_TIMESLICE_MS,
+  RECORD_VIDEO_BITS_PER_SECOND,
+} from "@/lib/video/constants";
 import { pickRecorderMimeType, requestCameraStream } from "@/lib/video/recorderMime";
 import { isIgnorablePlayError, safeVideoPlay } from "@/lib/video/safeVideoPlay";
 import { useCallback, useEffect, useRef, useState, type RefCallback } from "react";
@@ -188,7 +193,10 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     resetPreview();
     chunksRef.current = [];
 
-    const recorder = new MediaRecorder(stream, { mimeType: selectedMimeType });
+    const recorder = new MediaRecorder(stream, {
+      mimeType: selectedMimeType,
+      videoBitsPerSecond: RECORD_VIDEO_BITS_PER_SECOND,
+    });
     recorderRef.current = recorder;
     setMimeType(selectedMimeType);
 

--- a/lib/video/actionErrors.ts
+++ b/lib/video/actionErrors.ts
@@ -1,0 +1,2 @@
+export const VIDEO_LOGIN_REQUIRED = "로그인이 필요합니다.";
+export const VIDEO_SESSION_INVALID = "세션의 userUuid가 올바르지 않습니다.";

--- a/lib/video/actionPayload.ts
+++ b/lib/video/actionPayload.ts
@@ -59,6 +59,28 @@ export function toDownloadUrlActionData(data: VideoDownloadUrlUi): VideoDownload
   };
 }
 
+export function extractUploadUrlFromActionResult(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  if (!("ok" in payload) || payload.ok !== true) {
+    return null;
+  }
+
+  if (!("data" in payload) || !payload.data || typeof payload.data !== "object") {
+    return null;
+  }
+
+  const data = payload.data as Record<string, unknown>;
+  if (typeof data.uploadUrl !== "string") {
+    return null;
+  }
+
+  const trimmed = data.uploadUrl.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export function extractVideoUuidFromActionResult(payload: unknown): string | null {
   if (!payload || typeof payload !== "object") {
     return null;

--- a/lib/video/constants.ts
+++ b/lib/video/constants.ts
@@ -15,6 +15,18 @@ export const RECORDER_MIME_CANDIDATES = [
 /** Presigned PUT Content-Type must match upload-url query param */
 export const DEFAULT_UPLOAD_CONTENT_TYPE = "video/mp4";
 
+/** Server/client reject line. 5s 720p H.264 ~2.5 Mbps is ~1.6–2MB; iOS mp4/hevc can be larger. */
+export const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
+
+export const MAX_UPLOAD_MB = MAX_UPLOAD_BYTES / (1024 * 1024);
+
+export const CAPTURE_WIDTH = 720;
+export const CAPTURE_HEIGHT = 1280;
+export const CAPTURE_FRAME_RATE = 30;
+
+/** MediaRecorder target. 2.5 Mbps × 5s ≈ 1.6MB so typical captures stay under 8MB. */
+export const RECORD_VIDEO_BITS_PER_SECOND = 2_500_000;
+
 export const DEFAULT_CAPTURE_CAPTION = "Phase 0-F capture";
 
 /**

--- a/lib/video/putPresigned.ts
+++ b/lib/video/putPresigned.ts
@@ -2,6 +2,15 @@ export function isStubPresignedPutUrl(uploadUrl: string): boolean {
   return uploadUrl.includes("/stub-presigned-put/");
 }
 
+export function isBrokenPresignedPutUrl(uploadUrl: string): boolean {
+  try {
+    const decoded = decodeURIComponent(uploadUrl);
+    return decoded.includes("${") || decoded.includes("AWS_S3_RAW_BUCKET");
+  } catch {
+    return uploadUrl.includes("${") || uploadUrl.includes("AWS_S3_RAW_BUCKET");
+  }
+}
+
 export type PresignedPutResult = "uploaded" | "skipped-stub";
 
 export async function putPresignedUpload(
@@ -14,15 +23,31 @@ export async function putPresignedUpload(
     return "skipped-stub";
   }
 
-  const response = await fetch(uploadUrl, {
-    method: "PUT",
-    body: blob,
-    headers: { "Content-Type": contentType },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Presigned PUT failed (${response.status})`);
+  if (isBrokenPresignedPutUrl(uploadUrl)) {
+    throw new Error(
+      "업로드 URL에 버킷 이름이 비어 있습니다 (${AWS_S3_RAW_BUCKET}). video 백엔드 환경변수를 확인하세요.",
+    );
   }
 
-  return "uploaded";
+  try {
+    const response = await fetch(uploadUrl, {
+      method: "PUT",
+      body: blob,
+      headers: { "Content-Type": contentType },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Presigned PUT failed (${response.status})`);
+    }
+
+    return "uploaded";
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Presigned PUT failed")) {
+      throw error;
+    }
+
+    throw new Error(
+      "S3 업로드가 브라우저 CORS에 막혔습니다. 버킷 CORS에 localhost origin, PUT, OPTIONS가 있는지 백엔드에 요청하세요.",
+    );
+  }
 }

--- a/lib/video/recorderMime.ts
+++ b/lib/video/recorderMime.ts
@@ -1,20 +1,27 @@
-import { DEFAULT_UPLOAD_CONTENT_TYPE } from "@/lib/video/constants";
+import {
+  CAPTURE_FRAME_RATE,
+  CAPTURE_HEIGHT,
+  CAPTURE_WIDTH,
+  DEFAULT_UPLOAD_CONTENT_TYPE,
+} from "@/lib/video/constants";
+import { formatByteSize } from "@/lib/video/uploadLimits";
 
 export async function requestCameraStream(
   facingMode: "user" | "environment" = "user",
 ): Promise<MediaStream> {
   const portraitVideo: MediaTrackConstraints = {
     facingMode,
-    width: { ideal: 1080 },
-    height: { ideal: 1920 },
+    width: { ideal: CAPTURE_WIDTH },
+    height: { ideal: CAPTURE_HEIGHT },
     aspectRatio: { ideal: 9 / 16 },
+    frameRate: { ideal: CAPTURE_FRAME_RATE },
   };
 
   const attempts: MediaStreamConstraints[] = [
-    { video: portraitVideo, audio: true },
-    { video: { facingMode, aspectRatio: { ideal: 9 / 16 } }, audio: true },
-    { video: { facingMode }, audio: true },
-    { video: true, audio: true },
+    { video: portraitVideo, audio: false },
+    { video: { facingMode, aspectRatio: { ideal: 9 / 16 } }, audio: false },
+    { video: { facingMode }, audio: false },
+    { video: true, audio: false },
   ];
 
   let lastError: unknown;
@@ -29,11 +36,11 @@ export async function requestCameraStream(
 
   if (lastError instanceof DOMException) {
     if (lastError.name === "NotAllowedError") {
-      throw new Error("카메라·마이크 권한이 거부되었습니다. 브라우저 설정에서 허용해 주세요.");
+      throw new Error("카메라 권한이 거부되었습니다. 브라우저 설정에서 허용해 주세요.");
     }
 
     if (lastError.name === "NotFoundError") {
-      throw new Error("카메라 또는 마이크를 찾을 수 없습니다.");
+      throw new Error("카메라를 찾을 수 없습니다.");
     }
 
     throw new Error(lastError.message);
@@ -66,6 +73,5 @@ export function resolveUploadContentType(recorderMimeType?: string): string {
 }
 
 export function formatBlobSummary(blob: Blob): string {
-  const sizeKb = Math.round(blob.size / 1024);
-  return `${blob.type || "application/octet-stream"} · ${sizeKb} KB`;
+  return `${blob.type || "application/octet-stream"} · ${formatByteSize(blob.size)}`;
 }

--- a/lib/video/uploadLimits.ts
+++ b/lib/video/uploadLimits.ts
@@ -1,0 +1,34 @@
+import { MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from "@/lib/video/constants";
+
+export function formatByteSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${Math.round(kb)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function isWithinUploadLimit(bytes: number): boolean {
+  return bytes > 0 && bytes <= MAX_UPLOAD_BYTES;
+}
+
+export function createOversizeUploadBlob(): Blob {
+  return new Blob([new Uint8Array(MAX_UPLOAD_BYTES + 1)], { type: "video/mp4" });
+}
+
+export function assertUploadSize(blob: Blob): void {
+  if (blob.size === 0) {
+    throw new Error("녹화 데이터가 비어 있습니다.");
+  }
+
+  if (blob.size > MAX_UPLOAD_BYTES) {
+    throw new Error(
+      `영상 용량이 ${MAX_UPLOAD_MB}MB를 초과합니다 (${formatByteSize(blob.size)}).`,
+    );
+  }
+}

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -8,6 +8,7 @@ import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";
 import { resolvePlaybackSource, type PlaybackSource } from "@/lib/video/playback";
 import { putPresignedUpload } from "@/lib/video/putPresigned";
 import { resolveUploadContentType } from "@/lib/video/recorderMime";
+import { assertUploadSize } from "@/lib/video/uploadLimits";
 import type {
   VideoCompleteActionData,
   VideoDetailActionData,
@@ -31,6 +32,8 @@ export async function uploadRecordedVideo(
   blob: Blob,
   options?: { caption?: string; recorderMimeType?: string },
 ): Promise<VideoUploadPipelineResult> {
+  assertUploadSize(blob);
+
   const contentType = resolveUploadContentType(options?.recorderMimeType ?? blob.type);
 
   const uploadUrlResult = await issueUploadUrlAction(contentType);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 export { auth as middleware } from "@/auth";
 
 export const config = {
-  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|plip|video|video-api).*)"],
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|plip).*)"],
 };


### PR DESCRIPTION
## 작업 내용

영상 서비스 Phase 1으로 video API Server Actions가 **세션 JWT의 userUuid만** 사용하도록 바꿨습니다. `/video`, `/video-api` 촬영·업로드 랩을 로그인 필수로 보호하고, 업로드 전 **8MB·720×1280** 제약을 프론트에 적용했습니다. 백엔드 8MB limit(iOS mp4/hevc 대응)과 맞추기 위한 선행 작업이며, FFmpeg·본 UI(`/create`)·뷰어 연동은 이후입니다.

## 관련 이슈

Close #12

## 변경 사항

### 1. video Server Actions — DEV_USER_UUID 제거, 세션 JWT 필수

- **파일:** `actions/videoActions.ts`, `lib/video/actionErrors.ts`
- **설명:** `issueUploadUrlAction` / `completeVideoAction` / `getVideoAction` / `getDownloadUrlAction`에서 클라이언트 `userUuid` 인자와 `DEV_USER_UUID` fallback을 제거했습니다. 미로그인 시 `로그인이 필요합니다.`로 실패합니다.

```typescript
// actions/videoActions.ts
async function requireSessionUserUuid(): Promise<
  { ok: true; userUuid: string } | { ok: false; error: string }
> {
  const userUuid = await getServerUserUuid();
  if (!userUuid) {
    return { ok: false, error: VIDEO_LOGIN_REQUIRED };
  }
  if (!UUID_PATTERN.test(userUuid)) {
    return { ok: false, error: VIDEO_SESSION_INVALID };
  }
  return { ok: true, userUuid };
}

export async function issueUploadUrlAction(contentType?: string) {
  const session = await requireSessionUserUuid();
  if (!session.ok) return actionFailure(session.error);
  // session.userUuid만 video API query로 전달
}
```

### 2. `/video`, `/video-api` 라우트 보호

- **파일:** `auth.ts`, `middleware.ts`
- **설명:** `PROTECTED_PREFIXES`에 `/video`, `/video-api`를 추가했습니다. middleware matcher에서 `video|video-api` 제외를 제거해 비로그인 접근 시 로그인으로 유도합니다.

```typescript
// auth.ts
const PROTECTED_PREFIXES = [
  "/home", "/diary", "/agit", "/mypage", "/shop",
  "/create", "/viewer", "/video", "/video-api",
];

// middleware.ts
matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|plip).*)"],
```

### 3. 업로드 용량 8MB 가드

- **파일:** `lib/video/constants.ts`, `lib/video/uploadLimits.ts`, `lib/video/uploadPipeline.ts`
- **설명:** 서버·백엔드와 동일하게 **최대 8MB**를 상한으로 두었습니다. presign 요청 전 `assertUploadSize`로 거절합니다. (5s 720p H.264 2.5 Mbps ≈ 1.6–2MB, iOS mp4/hevc 여유)

```typescript
// lib/video/constants.ts
export const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
export const MAX_UPLOAD_MB = MAX_UPLOAD_BYTES / (1024 * 1024);

// lib/video/uploadLimits.ts
export function assertUploadSize(blob: Blob): void {
  if (blob.size > MAX_UPLOAD_BYTES) {
    throw new Error(
      `영상 용량이 ${MAX_UPLOAD_MB}MB를 초과합니다 (${formatByteSize(blob.size)}).`,
    );
  }
}

// lib/video/uploadPipeline.ts
export async function uploadRecordedVideo(blob: Blob, ...) {
  assertUploadSize(blob);
  const uploadUrlResult = await issueUploadUrlAction(contentType);
  // ...
}
```

### 4. 촬영 해상도 720×1280 및 촬영 랩 UX

- **파일:** `lib/video/recorderMime.ts`, `hooks/useVideoRecorder.ts`, `hooks/useVideoCaptureFlow.ts`, `components/organisms/VideoCaptureSection.tsx`, `components/organisms/CaptureCameraStage.tsx`
- **설명:** 카메라 ideal을 720×1280·30fps로 낮췄습니다. `/video` 랩에 8MB 초과 안내, mp4/mov 파일 업로드 테스트, stub presign 시 `skipped-stub` 안내를 추가했습니다.

```typescript
// lib/video/recorderMime.ts
const portraitVideo: MediaTrackConstraints = {
  facingMode,
  width: { ideal: CAPTURE_WIDTH },   // 720
  height: { ideal: CAPTURE_HEIGHT }, // 1280
  aspectRatio: { ideal: 9 / 16 },
  frameRate: { ideal: CAPTURE_FRAME_RATE },
};
```

### 5. Video API Lab 보완

- **파일:** `components/organisms/VideoApiLabSection.tsx`, `lib/video/putPresigned.ts`, `lib/video/actionPayload.ts`
- **설명:** 랩 UI에 로그인 필수 안내를 추가했습니다. `/video-api`는 PUT 생략(메타 API 확인용), 실제 S3 업로드는 `/video`에서 수행합니다.

## 테스트

- [x] `npm run typecheck` (push 전 `.next` 삭제 후 통과)
- [x] `npm run lint`
- [ ] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] 비로그인 `/video` → 로그인 리다이렉트
  - [x] 로그인 후 `/video-api` → `1. upload-url` 성공
  - [x] `/video` 5초 촬영 → 업로드 → `put: uploaded` (실 presign 환경)
  - [x] 8MB 초과 파일 → 업로드 거절 메시지

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인