### PR TITLE
[#95] Feature : 다이어리 홈 themes 중복 API 호출 제거

### DIFF
--- a/app/(diary)/diary/page.tsx
+++ b/app/(diary)/diary/page.tsx
@@ -1,5 +1,5 @@
 import { DiaryMainTemplate } from "@/components/templates";
-import { getDiaryHomeFeed, listDiaryThemes } from "@/services/diaryService";
+import { getDiaryHomePageData } from "@/services/diaryService";
 import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
 
 export default async function DiaryPage() {
@@ -8,7 +8,7 @@ export default async function DiaryPage() {
   let error: string | undefined;
 
   try {
-    [entries, themes] = await Promise.all([getDiaryHomeFeed(), listDiaryThemes()]);
+    ({ entries, themes } = await getDiaryHomePageData());
   } catch (caught) {
     entries = [];
     themes = [];

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -194,6 +194,17 @@ export async function getDiaryHomeFeed(): Promise<UiDiaryDateEntry[]> {
   return normalizeHomeFeed(entries);
 }
 
+export async function getDiaryHomePageData(): Promise<{
+  entries: UiDiaryDateEntry[];
+  themes: UiDiaryTheme[];
+}> {
+  const response = await diaryApi.getDiaryHome();
+  return {
+    entries: normalizeHomeFeed(response.sections.map(mapHomeSection)),
+    themes: (response.themes ?? []).map(mapTheme),
+  };
+}
+
 export async function getDiaryCalendarDates(year: number, month: number): Promise<string[]> {
   const response = await diaryApi.getDiaryCalendar(year, month);
   return response.writtenDates;

--- a/types/diary/api.ts
+++ b/types/diary/api.ts
@@ -45,6 +45,7 @@ export type ApiDiaryHomeSection = {
 
 export type ApiDiaryHomeResponse = {
   sections: ApiDiaryHomeSection[];
+  themes: ApiDiaryTheme[];
 };
 
 export type ApiDiaryCalendarResponse = {


### PR DESCRIPTION
## Summary
- 다이어리 홈(/diary)에서 GET /home 과 GET /themes 병렬 호출을 제거
- home API 응답의 themes 필드를 사용해 ThemePreviewStrip 데이터를 구성

## Related issue
Close #95

## Changes
- [x] ApiDiaryHomeResponse에 themes 필드 추가
- [x] getDiaryHomePageData()로 홈 entries + themes 일원화
- [x] diary/page.tsx에서 listDiaryThemes() 제거

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] /diary 진입 시 UI 정상 (테마 스트립 + 날짜 섹션)
- [ ] plip-diary #38 PR 배포 후 서버 fetch 1회 동작 확인