### PR TITLE
[#96] Feature : 토픽 뷰어 풀레이아웃 및 세로 피드

### DIFF
--- a/actions/topicActions.ts
+++ b/actions/topicActions.ts
@@ -7,7 +7,8 @@ import * as topicService from "@/services/topicService";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import type { ApiTopicListStatus } from "@/types/topic/api";
 import { parseCreateTopicInput, parseUpdateTopicInput } from "@/types/topic/schema";
-import type { UiTopicListItem } from "@/types/topic/ui";
+import type { UiTopicFeedWindow, UiTopicListItem, UiTopicVideo } from "@/types/topic/ui";
+import { getAgitAndMembers } from "@/services/agitService";
 
 function toActionError(error: unknown): ActionResult<never> {
   if (error instanceof ApiError) {
@@ -104,6 +105,37 @@ export async function deleteTopicAction(topicId: string): Promise<ActionResult<v
     if (error instanceof ApiError && error.status === 409) {
       return actionFailure("영상이 있는 토픽은 삭제할 수 없어요.");
     }
+    return toActionError(error);
+  }
+}
+
+export async function getTopicFeedWindowAction(
+  agitId: string,
+  input: { topicUuid?: string; date?: string; before?: number; after?: number },
+): Promise<ActionResult<UiTopicFeedWindow>> {
+  try {
+    const window = await topicService.getTopicFeedWindow({
+      agitUuid: agitId,
+      topicUuid: input.topicUuid,
+      date: input.date,
+      before: input.before,
+      after: input.after,
+    });
+    return actionSuccess(window);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function getTopicVideosAction(
+  agitId: string,
+  topicUuid: string,
+): Promise<ActionResult<UiTopicVideo[]>> {
+  try {
+    const detail = await getAgitAndMembers(agitId);
+    const videos = await topicService.getTopicVideos(topicUuid, detail.members);
+    return actionSuccess(videos);
+  } catch (error) {
     return toActionError(error);
   }
 }

--- a/app/(agit)/agit/[agitId]/feed/page.tsx
+++ b/app/(agit)/agit/[agitId]/feed/page.tsx
@@ -1,0 +1,54 @@
+import { AgitTopicFeedTemplate } from "@/components/templates";
+import { ROUTES } from "@/config/routes";
+import { toKstDateString } from "@/lib/topic/selectAgitTopic";
+import { getAgitAndMembers } from "@/services/agitService";
+import { getTopicFeedWindow, getTopicVideos } from "@/services/topicService";
+import type { UiAgit } from "@/types/agit/ui";
+import type { UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
+import { redirect } from "next/navigation";
+
+type PageProps = {
+  params: Promise<{ agitId: string }>;
+  searchParams: Promise<{ topic?: string }>;
+};
+
+export default async function AgitTopicFeedPage({ params, searchParams }: PageProps) {
+  const { agitId } = await params;
+  const { topic: topicUuid } = await searchParams;
+
+  let agit: UiAgit | null = null;
+  let initialWindow: UiTopicFeedWindow = {
+    topics: [],
+    currentId: null,
+    hasMoreBefore: false,
+    hasMoreAfter: false,
+  };
+  const initialVideos: Record<string, UiTopicVideo[]> = {};
+
+  try {
+    const detail = await getAgitAndMembers(agitId);
+    agit = detail.agit;
+    initialWindow = await getTopicFeedWindow({
+      agitUuid: agitId,
+      topicUuid,
+      date: topicUuid ? undefined : toKstDateString(new Date()),
+      before: 3,
+      after: 3,
+    });
+    const center = initialWindow.topics.findIndex((item) => item.id === initialWindow.currentId);
+    const loadIds = [initialWindow.topics[center - 1]?.id, initialWindow.topics[center]?.id, initialWindow.topics[center + 1]?.id].filter(
+      (id): id is string => Boolean(id),
+    );
+    await Promise.all(
+      loadIds.map(async (id) => {
+        initialVideos[id] = await getTopicVideos(id, detail.members);
+      }),
+    );
+  } catch {
+    redirect(ROUTES.agit.topics(agitId));
+  }
+
+  return (
+    <AgitTopicFeedTemplate agit={agit} initialWindow={initialWindow} initialVideos={initialVideos} />
+  );
+}

--- a/components/molecules/TopicClipPage.tsx
+++ b/components/molecules/TopicClipPage.tsx
@@ -22,7 +22,7 @@ export function TopicClipPage({
   }
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-2">
+    <div className="flex h-full min-h-0 w-full flex-col">
       {videos.map((video) => (
         <TopicVideoTile key={video.id} video={video} onSelect={onSelectVideo} />
       ))}

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -55,7 +55,7 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
   );
 
   const className =
-    "relative flex min-h-0 flex-1 overflow-hidden rounded-none border-0 bg-[var(--dl-color-bg-surface)] p-0 shadow-none";
+    "relative flex min-h-0 min-h-[40%] flex-1 overflow-hidden rounded-none border-0 bg-[var(--dl-color-bg-surface)] p-0 shadow-none";
 
   if (onSelect) {
     return (

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -55,7 +55,7 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
   );
 
   const className =
-    "relative flex min-h-0 flex-1 overflow-hidden rounded-[18px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] shadow-[0_8px_24px_rgba(23,23,28,0.04)]";
+    "relative flex min-h-0 flex-1 overflow-hidden rounded-none border-0 bg-[var(--dl-color-bg-surface)] p-0 shadow-none";
 
   if (onSelect) {
     return (

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -59,13 +59,20 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
 
   if (onSelect) {
     return (
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         className={`${className} cursor-pointer p-0 text-left`}
         onClick={() => onSelect(video.id)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelect(video.id);
+          }
+        }}
       >
         {body}
-      </button>
+      </div>
     );
   }
 

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -23,7 +23,7 @@ type AgitMenuDrawerProps = {
 const MENU = [
   {
     id: "topics" as const,
-    label: "토픽관리",
+    label: "토픽",
     href: (id: string) => ROUTES.agit.topics(id),
     hostOnly: false,
   },

--- a/components/organisms/RoomManageHub.tsx
+++ b/components/organisms/RoomManageHub.tsx
@@ -18,7 +18,7 @@ const TILES = [
   },
   {
     href: "topics",
-    title: "토픽 관리",
+    title: "토픽",
     description: "진행 날짜·등록 규칙",
     icon: "list" as const,
     tone: "brand" as const,

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -27,16 +27,12 @@ function sliceAroundAnchor(topics: UiTopicDetail[], anchorId: string, edge: "sta
 
 export function TopicFeedSection({ agitId, initialWindow, initialVideos }: TopicFeedSectionProps) {
   const router = useRouter();
-  const viewportRef = useRef<HTMLDivElement>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const didSyncScroll = useRef(false);
   const loadingEdge = useRef<"start" | "end" | null>(null);
-  const loadedVideoIds = useRef(new Set(Object.keys(initialVideos)));
-  const pointerStart = useRef<{ x: number; y: number } | null>(null);
-  const gestureAxis = useRef<"x" | "y" | null>(null);
-  const dragOffsetRef = useRef(0);
-  const wheelLock = useRef(false);
+  const loadingVideoIds = useRef(new Set<string>());
+  const videosRef = useRef(initialVideos);
   const [viewportHeight, setViewportHeight] = useState(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const [isDragging, setIsDragging] = useState(false);
 
   const [topics, setTopics] = useState(initialWindow.topics);
   const [index, setIndex] = useState(() => {
@@ -57,7 +53,8 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     indexRef.current = index;
     hasMoreBeforeRef.current = hasMoreBefore;
     hasMoreAfterRef.current = hasMoreAfter;
-  }, [topics, index, hasMoreBefore, hasMoreAfter]);
+    videosRef.current = videosByTopic;
+  }, [hasMoreAfter, hasMoreBefore, index, topics, videosByTopic]);
 
   const current = topics[index];
   const backHref = ROUTES.agit.topics(agitId);
@@ -69,15 +66,22 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
       );
       await Promise.all(
         ids.map(async (id) => {
-          if (loadedVideoIds.current.has(id)) {
+          const topic = list.find((item) => item.id === id);
+          const existing = videosRef.current[id];
+          const knownEmpty = (topic?.videoCount ?? 0) === 0;
+          if (existing && (existing.length > 0 || knownEmpty)) {
             return;
           }
-          loadedVideoIds.current.add(id);
+          if (loadingVideoIds.current.has(id)) {
+            return;
+          }
+          loadingVideoIds.current.add(id);
           const result = await getTopicVideosAction(agitId, id);
+          loadingVideoIds.current.delete(id);
           if (!result.ok) {
-            loadedVideoIds.current.delete(id);
             return;
           }
+          videosRef.current = { ...videosRef.current, [id]: result.data };
           setVideosByTopic((currentMap) => ({ ...currentMap, [id]: result.data }));
         }),
       );
@@ -102,19 +106,6 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
       void extendWindowRef.current("end", endId);
     }
   }, []);
-
-  const goToIndex = useCallback(
-    (nextIndex: number) => {
-      const clamped = Math.min(Math.max(nextIndex, 0), topicsRef.current.length - 1);
-      if (clamped === indexRef.current) {
-        return;
-      }
-      indexRef.current = clamped;
-      setIndex(clamped);
-      prefetchNearEdge();
-    },
-    [prefetchNearEdge],
-  );
 
   const extendWindow = useCallback(
     async (edge: "start" | "end", anchorId: string) => {
@@ -151,6 +142,12 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
           const nextIndex = indexRef.current + added;
           indexRef.current = nextIndex;
           setIndex(nextIndex);
+          requestAnimationFrame(() => {
+            const root = scrollerRef.current;
+            if (root) {
+              root.scrollTop += added * root.clientHeight;
+            }
+          });
         }
         return merged;
       });
@@ -171,7 +168,7 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
   }, [extendWindow]);
 
   useEffect(() => {
-    const root = viewportRef.current;
+    const root = scrollerRef.current;
     if (!root) {
       return;
     }
@@ -183,7 +180,16 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     const observer = new ResizeObserver(applyHeight);
     observer.observe(root);
     return () => observer.disconnect();
-  }, []);
+  }, [current]);
+
+  useEffect(() => {
+    const root = scrollerRef.current;
+    if (!root || viewportHeight === 0 || didSyncScroll.current) {
+      return;
+    }
+    didSyncScroll.current = true;
+    root.scrollTop = indexRef.current * viewportHeight;
+  }, [viewportHeight]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => prefetchNearEdge(), 0);
@@ -202,94 +208,21 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     void loadVideosAround(topics, index);
   }, [agitId, current, index, loadVideosAround, topics]);
 
-  function resetDrag() {
-    dragOffsetRef.current = 0;
-    setDragOffset(0);
-    setIsDragging(false);
-    pointerStart.current = null;
-    gestureAxis.current = null;
-  }
-
-  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
-    pointerStart.current = { x: event.clientX, y: event.clientY };
-    gestureAxis.current = null;
-    dragOffsetRef.current = 0;
-  }
-
-  function handlePointerMove(event: React.PointerEvent<HTMLDivElement>) {
-    const start = pointerStart.current;
-    if (!start) {
+  function handleScroll() {
+    const root = scrollerRef.current;
+    if (!root || root.clientHeight === 0 || topics.length === 0) {
       return;
     }
-    const dx = event.clientX - start.x;
-    const dy = event.clientY - start.y;
-    if (!gestureAxis.current) {
-      if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
-        return;
-      }
-      gestureAxis.current = Math.abs(dy) >= Math.abs(dx) ? "y" : "x";
+    const nextIndex = Math.min(
+      topics.length - 1,
+      Math.max(0, Math.round(root.scrollTop / root.clientHeight)),
+    );
+    if (nextIndex !== indexRef.current) {
+      indexRef.current = nextIndex;
+      setIndex(nextIndex);
     }
-    if (gestureAxis.current !== "y") {
-      return;
-    }
-    event.preventDefault();
-    setIsDragging(true);
-    const atStart = indexRef.current === 0;
-    const atEnd = indexRef.current >= topicsRef.current.length - 1;
-    let nextOffset = dy;
-    if ((atStart && nextOffset > 0) || (atEnd && nextOffset < 0)) {
-      nextOffset *= 0.28;
-    }
-    dragOffsetRef.current = nextOffset;
-    setDragOffset(nextOffset);
+    prefetchNearEdge();
   }
-
-  function handlePointerUp() {
-    if (gestureAxis.current === "y") {
-      const height = viewportHeight || viewportRef.current?.clientHeight || 1;
-      const threshold = Math.max(48, height * 0.18);
-      const offset = dragOffsetRef.current;
-      if (offset < -threshold) {
-        goToIndex(indexRef.current + 1);
-      } else if (offset > threshold) {
-        goToIndex(indexRef.current - 1);
-      }
-    }
-    resetDrag();
-  }
-
-  useEffect(() => {
-    const root = viewportRef.current;
-    if (!root) {
-      return;
-    }
-    const onWheel = (event: WheelEvent) => {
-      event.preventDefault();
-      if (wheelLock.current || Math.abs(event.deltaY) < 20) {
-        return;
-      }
-      wheelLock.current = true;
-      window.setTimeout(() => {
-        wheelLock.current = false;
-      }, 420);
-      if (event.deltaY > 0) {
-        goToIndex(indexRef.current + 1);
-      } else {
-        goToIndex(indexRef.current - 1);
-      }
-    };
-    const onTouchMove = (event: TouchEvent) => {
-      if (gestureAxis.current === "y") {
-        event.preventDefault();
-      }
-    };
-    root.addEventListener("wheel", onWheel, { passive: false });
-    root.addEventListener("touchmove", onTouchMove, { passive: false });
-    return () => {
-      root.removeEventListener("wheel", onWheel);
-      root.removeEventListener("touchmove", onTouchMove);
-    };
-  }, [current, goToIndex]);
 
   if (!current) {
     return (
@@ -304,40 +237,34 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     );
   }
 
-  const dateLabel = current.startDate.replaceAll("-", ".");
-  const videoCount = videosByTopic[current.id]?.length ?? current.videoCount;
-  const slideHeight = viewportHeight;
+  const loadedVideos = videosByTopic[current.id];
+  const videoCount = loadedVideos && loadedVideos.length > 0 ? loadedVideos.length : current.videoCount;
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
         leading={<HeaderBackLink href={backHref} />}
         title={current.title || "제목 없음"}
-        subtitle={`${dateLabel} · ${videoCount}개 영상`}
+        subtitle={`${current.startDate.replaceAll("-", ".")} · ${videoCount}개 영상`}
       />
       <div
-        ref={viewportRef}
-        className="relative min-h-0 flex-1 touch-none overflow-hidden"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={resetDrag}
+        ref={scrollerRef}
+        onScroll={handleScroll}
+        className="min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {topics.map((topic, topicIndex) => (
           <div
             key={topic.id}
-            className="absolute inset-x-0 top-0 flex flex-col"
-            style={{
-              height: slideHeight > 0 ? slideHeight : "100%",
-              transform: `translate3d(0, calc(${(topicIndex - index) * 100}% + ${dragOffset}px), 0)`,
-              transition: isDragging ? "none" : "transform 240ms ease-out",
-            }}
+            className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col"
+            style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
           >
-            <TopicGallerySection
-              videos={videosByTopic[topic.id] ?? []}
-              captureHref={ROUTES.agit.upload(agitId)}
-              onSelectVideo={(videoId) => router.push(ROUTES.viewer.clip(videoId))}
-            />
+            {Math.abs(topicIndex - index) <= 1 ? (
+              <TopicGallerySection
+                videos={videosByTopic[topic.id] ?? []}
+                captureHref={ROUTES.agit.upload(agitId)}
+                onSelectVideo={(videoId) => router.push(ROUTES.viewer.clip(videoId))}
+              />
+            ) : null}
           </div>
         ))}
       </div>

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -41,6 +41,18 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
   const [hasMoreBefore, setHasMoreBefore] = useState(initialWindow.hasMoreBefore);
   const [hasMoreAfter, setHasMoreAfter] = useState(initialWindow.hasMoreAfter);
 
+  const topicsRef = useRef(topics);
+  const indexRef = useRef(index);
+  const hasMoreBeforeRef = useRef(hasMoreBefore);
+  const hasMoreAfterRef = useRef(hasMoreAfter);
+
+  useEffect(() => {
+    topicsRef.current = topics;
+    indexRef.current = index;
+    hasMoreBeforeRef.current = hasMoreBefore;
+    hasMoreAfterRef.current = hasMoreAfter;
+  }, [topics, index, hasMoreBefore, hasMoreAfter]);
+
   const current = topics[index];
   const backHref = ROUTES.agit.topics(agitId);
 
@@ -67,6 +79,24 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     [agitId],
   );
 
+  const extendWindowRef = useRef<(edge: "start" | "end", anchorId: string) => Promise<void>>(
+    async () => undefined,
+  );
+
+  const prefetchNearEdge = useCallback(() => {
+    const list = topicsRef.current;
+    const currentIndex = indexRef.current;
+    const startId = list[0]?.id;
+    const endId = list.at(-1)?.id;
+    if (currentIndex <= 1 && hasMoreBeforeRef.current && startId) {
+      void extendWindowRef.current("start", startId);
+      return;
+    }
+    if (currentIndex >= list.length - 2 && hasMoreAfterRef.current && endId) {
+      void extendWindowRef.current("end", endId);
+    }
+  }, []);
+
   const extendWindow = useCallback(
     async (edge: "start" | "end", anchorId: string) => {
       if (loadingEdge.current) {
@@ -85,17 +115,23 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
       const extra = sliceAroundAnchor(result.data.topics, anchorId, edge);
       if (extra.length === 0) {
         if (edge === "start") {
+          hasMoreBeforeRef.current = false;
           setHasMoreBefore(false);
         } else {
+          hasMoreAfterRef.current = false;
           setHasMoreAfter(false);
         }
+        prefetchNearEdge();
         return;
       }
       setTopics((currentTopics) => {
         const merged = mergeUniqueById(currentTopics, extra, (topic) => topic.id, edge);
         const added = merged.length - currentTopics.length;
+        topicsRef.current = merged;
         if (edge === "start" && added > 0) {
-          setIndex((currentIndex) => currentIndex + added);
+          const nextIndex = indexRef.current + added;
+          indexRef.current = nextIndex;
+          setIndex(nextIndex);
           requestAnimationFrame(() => {
             const root = scrollerRef.current;
             if (root) {
@@ -106,13 +142,20 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
         return merged;
       });
       if (edge === "start") {
+        hasMoreBeforeRef.current = result.data.hasMoreBefore;
         setHasMoreBefore(result.data.hasMoreBefore);
       } else {
+        hasMoreAfterRef.current = result.data.hasMoreAfter;
         setHasMoreAfter(result.data.hasMoreAfter);
       }
+      prefetchNearEdge();
     },
-    [agitId],
+    [agitId, prefetchNearEdge],
   );
+
+  useEffect(() => {
+    extendWindowRef.current = extendWindow;
+  }, [extendWindow]);
 
   useEffect(() => {
     const root = scrollerRef.current;
@@ -124,24 +167,17 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
   }, [index]);
 
   useEffect(() => {
+    const timer = window.setTimeout(() => prefetchNearEdge(), 0);
+    return () => window.clearTimeout(timer);
+  }, [prefetchNearEdge]);
+
+  useEffect(() => {
     if (!current) {
       return;
     }
     router.replace(ROUTES.agit.topicFeed(agitId, current.id), { scroll: false });
     void loadVideosAround(topics, index);
   }, [agitId, current, index, loadVideosAround, router, topics]);
-
-  useEffect(() => {
-    if (index <= 1 && hasMoreBefore && topics[0]) {
-      void extendWindow("start", topics[0].id);
-    }
-  }, [extendWindow, hasMoreBefore, index, topics]);
-
-  useEffect(() => {
-    if (index >= topics.length - 2 && hasMoreAfter && topics.at(-1)) {
-      void extendWindow("end", topics.at(-1)!.id);
-    }
-  }, [extendWindow, hasMoreAfter, index, topics]);
 
   function handleScroll() {
     const root = scrollerRef.current;
@@ -152,7 +188,9 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
       topics.length - 1,
       Math.max(0, Math.round(root.scrollTop / root.clientHeight)),
     );
+    indexRef.current = nextIndex;
     setIndex(nextIndex);
+    prefetchNearEdge();
   }
 
   if (!current) {

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { getTopicFeedWindowAction, getTopicVideosAction } from "@/actions/topicActions";
+import { HeaderBackLink, ScreenHeader } from "@/components/molecules";
+import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
+import { ROUTES } from "@/config/routes";
+import { mergeUniqueById } from "@/lib/topic/mergeTopicFeed";
+import type { UiTopicDetail, UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const NEIGHBOR_LIMIT = 3;
+
+type TopicFeedSectionProps = {
+  agitId: string;
+  initialWindow: UiTopicFeedWindow;
+  initialVideos: Record<string, UiTopicVideo[]>;
+};
+
+function sliceAroundAnchor(topics: UiTopicDetail[], anchorId: string, edge: "start" | "end"): UiTopicDetail[] {
+  const index = topics.findIndex((topic) => topic.id === anchorId);
+  if (index < 0) {
+    return [];
+  }
+  return edge === "start" ? topics.slice(0, index) : topics.slice(index + 1);
+}
+
+export function TopicFeedSection({ agitId, initialWindow, initialVideos }: TopicFeedSectionProps) {
+  const router = useRouter();
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const didSyncScroll = useRef(false);
+  const loadingEdge = useRef<"start" | "end" | null>(null);
+  const loadedVideoIds = useRef(new Set(Object.keys(initialVideos)));
+
+  const [topics, setTopics] = useState(initialWindow.topics);
+  const [index, setIndex] = useState(() => {
+    const found = initialWindow.topics.findIndex((topic) => topic.id === initialWindow.currentId);
+    return found >= 0 ? found : 0;
+  });
+  const [videosByTopic, setVideosByTopic] = useState<Record<string, UiTopicVideo[]>>(initialVideos);
+  const [hasMoreBefore, setHasMoreBefore] = useState(initialWindow.hasMoreBefore);
+  const [hasMoreAfter, setHasMoreAfter] = useState(initialWindow.hasMoreAfter);
+
+  const current = topics[index];
+  const backHref = ROUTES.agit.topics(agitId);
+
+  const loadVideosAround = useCallback(
+    async (list: UiTopicDetail[], center: number) => {
+      const ids = [list[center - 1]?.id, list[center]?.id, list[center + 1]?.id].filter(
+        (id): id is string => Boolean(id),
+      );
+      await Promise.all(
+        ids.map(async (id) => {
+          if (loadedVideoIds.current.has(id)) {
+            return;
+          }
+          loadedVideoIds.current.add(id);
+          const result = await getTopicVideosAction(agitId, id);
+          if (!result.ok) {
+            loadedVideoIds.current.delete(id);
+            return;
+          }
+          setVideosByTopic((currentMap) => ({ ...currentMap, [id]: result.data }));
+        }),
+      );
+    },
+    [agitId],
+  );
+
+  const extendWindow = useCallback(
+    async (edge: "start" | "end", anchorId: string) => {
+      if (loadingEdge.current) {
+        return;
+      }
+      loadingEdge.current = edge;
+      const result = await getTopicFeedWindowAction(agitId, {
+        topicUuid: anchorId,
+        before: edge === "start" ? NEIGHBOR_LIMIT : 0,
+        after: edge === "end" ? NEIGHBOR_LIMIT : 0,
+      });
+      loadingEdge.current = null;
+      if (!result.ok) {
+        return;
+      }
+      const extra = sliceAroundAnchor(result.data.topics, anchorId, edge);
+      if (extra.length === 0) {
+        if (edge === "start") {
+          setHasMoreBefore(false);
+        } else {
+          setHasMoreAfter(false);
+        }
+        return;
+      }
+      setTopics((currentTopics) => {
+        const merged = mergeUniqueById(currentTopics, extra, (topic) => topic.id, edge);
+        const added = merged.length - currentTopics.length;
+        if (edge === "start" && added > 0) {
+          setIndex((currentIndex) => currentIndex + added);
+          requestAnimationFrame(() => {
+            const root = scrollerRef.current;
+            if (root) {
+              root.scrollTop += added * root.clientHeight;
+            }
+          });
+        }
+        return merged;
+      });
+      if (edge === "start") {
+        setHasMoreBefore(result.data.hasMoreBefore);
+      } else {
+        setHasMoreAfter(result.data.hasMoreAfter);
+      }
+    },
+    [agitId],
+  );
+
+  useEffect(() => {
+    const root = scrollerRef.current;
+    if (!root || didSyncScroll.current) {
+      return;
+    }
+    didSyncScroll.current = true;
+    root.scrollTop = index * root.clientHeight;
+  }, [index]);
+
+  useEffect(() => {
+    if (!current) {
+      return;
+    }
+    router.replace(ROUTES.agit.topicFeed(agitId, current.id), { scroll: false });
+    void loadVideosAround(topics, index);
+  }, [agitId, current, index, loadVideosAround, router, topics]);
+
+  useEffect(() => {
+    if (index <= 1 && hasMoreBefore && topics[0]) {
+      void extendWindow("start", topics[0].id);
+    }
+  }, [extendWindow, hasMoreBefore, index, topics]);
+
+  useEffect(() => {
+    if (index >= topics.length - 2 && hasMoreAfter && topics.at(-1)) {
+      void extendWindow("end", topics.at(-1)!.id);
+    }
+  }, [extendWindow, hasMoreAfter, index, topics]);
+
+  function handleScroll() {
+    const root = scrollerRef.current;
+    if (!root || root.clientHeight === 0 || topics.length === 0) {
+      return;
+    }
+    const nextIndex = Math.min(
+      topics.length - 1,
+      Math.max(0, Math.round(root.scrollTop / root.clientHeight)),
+    );
+    setIndex(nextIndex);
+  }
+
+  if (!current) {
+    return (
+      <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+        <ScreenHeader leading={<HeaderBackLink href={backHref} />} title="토픽" />
+        <div className="min-h-0 flex-1 px-[23px] pb-6">
+          <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">
+            피드에 보여줄 토픽이 없습니다.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const dateLabel = current.startDate.replaceAll("-", ".");
+  const videoCount = videosByTopic[current.id]?.length ?? current.videoCount;
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ScreenHeader
+        leading={<HeaderBackLink href={backHref} />}
+        title={current.title || "제목 없음"}
+        subtitle={`${dateLabel} · ${videoCount}개 영상`}
+      />
+      <div
+        ref={scrollerRef}
+        onScroll={handleScroll}
+        className="min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain touch-pan-y [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {topics.map((topic) => (
+          <div key={topic.id} className="flex h-full min-h-full w-full shrink-0 snap-start snap-always flex-col">
+            <TopicGallerySection
+              videos={videosByTopic[topic.id] ?? []}
+              captureHref={ROUTES.agit.upload(agitId)}
+              onSelectVideo={(videoId) => router.push(ROUTES.viewer.clip(videoId))}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -27,10 +27,16 @@ function sliceAroundAnchor(topics: UiTopicDetail[], anchorId: string, edge: "sta
 
 export function TopicFeedSection({ agitId, initialWindow, initialVideos }: TopicFeedSectionProps) {
   const router = useRouter();
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  const didSyncScroll = useRef(false);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const loadingEdge = useRef<"start" | "end" | null>(null);
   const loadedVideoIds = useRef(new Set(Object.keys(initialVideos)));
+  const pointerStart = useRef<{ x: number; y: number } | null>(null);
+  const gestureAxis = useRef<"x" | "y" | null>(null);
+  const dragOffsetRef = useRef(0);
+  const wheelLock = useRef(false);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
 
   const [topics, setTopics] = useState(initialWindow.topics);
   const [index, setIndex] = useState(() => {
@@ -97,6 +103,19 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     }
   }, []);
 
+  const goToIndex = useCallback(
+    (nextIndex: number) => {
+      const clamped = Math.min(Math.max(nextIndex, 0), topicsRef.current.length - 1);
+      if (clamped === indexRef.current) {
+        return;
+      }
+      indexRef.current = clamped;
+      setIndex(clamped);
+      prefetchNearEdge();
+    },
+    [prefetchNearEdge],
+  );
+
   const extendWindow = useCallback(
     async (edge: "start" | "end", anchorId: string) => {
       if (loadingEdge.current) {
@@ -132,12 +151,6 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
           const nextIndex = indexRef.current + added;
           indexRef.current = nextIndex;
           setIndex(nextIndex);
-          requestAnimationFrame(() => {
-            const root = scrollerRef.current;
-            if (root) {
-              root.scrollTop += added * root.clientHeight;
-            }
-          });
         }
         return merged;
       });
@@ -158,13 +171,19 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
   }, [extendWindow]);
 
   useEffect(() => {
-    const root = scrollerRef.current;
-    if (!root || didSyncScroll.current) {
+    const root = viewportRef.current;
+    if (!root) {
       return;
     }
-    didSyncScroll.current = true;
-    root.scrollTop = index * root.clientHeight;
-  }, [index]);
+    const applyHeight = () => {
+      const nextHeight = root.clientHeight;
+      setViewportHeight((currentHeight) => (currentHeight === nextHeight ? currentHeight : nextHeight));
+    };
+    applyHeight();
+    const observer = new ResizeObserver(applyHeight);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     const timer = window.setTimeout(() => prefetchNearEdge(), 0);
@@ -175,23 +194,102 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     if (!current) {
       return;
     }
-    router.replace(ROUTES.agit.topicFeed(agitId, current.id), { scroll: false });
+    const nextUrl = ROUTES.agit.topicFeed(agitId, current.id);
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    if (currentUrl !== nextUrl) {
+      window.history.replaceState(window.history.state, "", nextUrl);
+    }
     void loadVideosAround(topics, index);
-  }, [agitId, current, index, loadVideosAround, router, topics]);
+  }, [agitId, current, index, loadVideosAround, topics]);
 
-  function handleScroll() {
-    const root = scrollerRef.current;
-    if (!root || root.clientHeight === 0 || topics.length === 0) {
+  function resetDrag() {
+    dragOffsetRef.current = 0;
+    setDragOffset(0);
+    setIsDragging(false);
+    pointerStart.current = null;
+    gestureAxis.current = null;
+  }
+
+  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    pointerStart.current = { x: event.clientX, y: event.clientY };
+    gestureAxis.current = null;
+    dragOffsetRef.current = 0;
+  }
+
+  function handlePointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    const start = pointerStart.current;
+    if (!start) {
       return;
     }
-    const nextIndex = Math.min(
-      topics.length - 1,
-      Math.max(0, Math.round(root.scrollTop / root.clientHeight)),
-    );
-    indexRef.current = nextIndex;
-    setIndex(nextIndex);
-    prefetchNearEdge();
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    if (!gestureAxis.current) {
+      if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
+        return;
+      }
+      gestureAxis.current = Math.abs(dy) >= Math.abs(dx) ? "y" : "x";
+    }
+    if (gestureAxis.current !== "y") {
+      return;
+    }
+    event.preventDefault();
+    setIsDragging(true);
+    const atStart = indexRef.current === 0;
+    const atEnd = indexRef.current >= topicsRef.current.length - 1;
+    let nextOffset = dy;
+    if ((atStart && nextOffset > 0) || (atEnd && nextOffset < 0)) {
+      nextOffset *= 0.28;
+    }
+    dragOffsetRef.current = nextOffset;
+    setDragOffset(nextOffset);
   }
+
+  function handlePointerUp() {
+    if (gestureAxis.current === "y") {
+      const height = viewportHeight || viewportRef.current?.clientHeight || 1;
+      const threshold = Math.max(48, height * 0.18);
+      const offset = dragOffsetRef.current;
+      if (offset < -threshold) {
+        goToIndex(indexRef.current + 1);
+      } else if (offset > threshold) {
+        goToIndex(indexRef.current - 1);
+      }
+    }
+    resetDrag();
+  }
+
+  useEffect(() => {
+    const root = viewportRef.current;
+    if (!root) {
+      return;
+    }
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      if (wheelLock.current || Math.abs(event.deltaY) < 20) {
+        return;
+      }
+      wheelLock.current = true;
+      window.setTimeout(() => {
+        wheelLock.current = false;
+      }, 420);
+      if (event.deltaY > 0) {
+        goToIndex(indexRef.current + 1);
+      } else {
+        goToIndex(indexRef.current - 1);
+      }
+    };
+    const onTouchMove = (event: TouchEvent) => {
+      if (gestureAxis.current === "y") {
+        event.preventDefault();
+      }
+    };
+    root.addEventListener("wheel", onWheel, { passive: false });
+    root.addEventListener("touchmove", onTouchMove, { passive: false });
+    return () => {
+      root.removeEventListener("wheel", onWheel);
+      root.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [current, goToIndex]);
 
   if (!current) {
     return (
@@ -208,6 +306,7 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
 
   const dateLabel = current.startDate.replaceAll("-", ".");
   const videoCount = videosByTopic[current.id]?.length ?? current.videoCount;
+  const slideHeight = viewportHeight;
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
@@ -217,12 +316,23 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
         subtitle={`${dateLabel} · ${videoCount}개 영상`}
       />
       <div
-        ref={scrollerRef}
-        onScroll={handleScroll}
-        className="min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain touch-pan-y [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        ref={viewportRef}
+        className="relative min-h-0 flex-1 touch-none overflow-hidden"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={resetDrag}
       >
-        {topics.map((topic) => (
-          <div key={topic.id} className="flex h-full min-h-full w-full shrink-0 snap-start snap-always flex-col">
+        {topics.map((topic, topicIndex) => (
+          <div
+            key={topic.id}
+            className="absolute inset-x-0 top-0 flex flex-col"
+            style={{
+              height: slideHeight > 0 ? slideHeight : "100%",
+              transform: `translate3d(0, calc(${(topicIndex - index) * 100}% + ${dragOffset}px), 0)`,
+              transition: isDragging ? "none" : "transform 240ms ease-out",
+            }}
+          >
             <TopicGallerySection
               videos={videosByTopic[topic.id] ?? []}
               captureHref={ROUTES.agit.upload(agitId)}

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -55,9 +55,20 @@ export function TopicGallerySection({
     event.stopPropagation();
   }
 
+  function renderPage(pageVideos: UiTopicVideo[], key: string) {
+    return (
+      <TopicClipPage
+        key={key}
+        videos={pageVideos}
+        captureHref={captureHref}
+        onSelectVideo={onSelectVideo}
+      />
+    );
+  }
+
   return (
     <section
-      className="relative h-full min-h-0 w-full touch-pan-y overflow-hidden"
+      className="relative h-full min-h-0 w-full overflow-hidden"
       aria-label="토픽 영상"
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
@@ -66,35 +77,37 @@ export function TopicGallerySection({
       }}
       onClickCapture={handleClickCapture}
     >
-      {pages.map((pageVideos, index) => (
+      {pageCount <= 1 ? (
         <div
-          key={`topic-page-${index}`}
           className={
-            videos.length === 0
-              ? "absolute inset-0 flex flex-col px-[23px] pb-6"
-              : "absolute inset-0 flex flex-col"
+            videos.length === 0 ? "flex h-full min-h-0 flex-col px-[23px] pb-6" : "flex h-full min-h-0 flex-col"
           }
-          style={{ transform: `translate3d(${(index - safeIndex) * 100}%, 0, 0)` }}
         >
-          <TopicClipPage
-            videos={pageVideos}
-            captureHref={captureHref}
-            onSelectVideo={onSelectVideo}
-          />
+          {renderPage(pages[0] ?? [], "topic-page-0")}
         </div>
-      ))}
+      ) : (
+        pages.map((pageVideos, index) => (
+          <div
+            key={`topic-page-${index}`}
+            className="absolute inset-0 flex flex-col"
+            style={{ transform: `translate3d(${(index - safeIndex) * 100}%, 0, 0)` }}
+          >
+            {renderPage(pageVideos, `topic-page-${index}`)}
+          </div>
+        ))
+      )}
 
       {pageCount > 1 ? (
         <>
           <button
             type="button"
-            className="absolute inset-y-0 left-0 z-10 w-[12.5%] touch-pan-y border-0 bg-transparent p-0"
+            className="absolute inset-y-0 left-0 z-10 w-[12.5%] border-0 bg-transparent p-0"
             aria-label="이전 페이지"
             onClick={() => goToPage(safeIndex - 1)}
           />
           <button
             type="button"
-            className="absolute inset-y-0 right-0 z-10 w-[12.5%] touch-pan-y border-0 bg-transparent p-0"
+            className="absolute inset-y-0 right-0 z-10 w-[12.5%] border-0 bg-transparent p-0"
             aria-label="다음 페이지"
             onClick={() => goToPage(safeIndex + 1)}
           />

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -17,65 +17,86 @@ export function TopicGallerySection({
   onSelectVideo,
 }: TopicGallerySectionProps) {
   const pages = useMemo(() => paginateTopicVideos(videos), [videos]);
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  const [pageIndex, setPageIndex] = useState(0);
   const pageCount = pages.length;
+  const [pageIndex, setPageIndex] = useState(0);
+  const pointerStart = useRef<{ x: number; y: number } | null>(null);
+  const skipClick = useRef(false);
+  const safeIndex = Math.min(pageIndex, Math.max(pageCount - 1, 0));
 
-  function scrollToPage(nextIndex: number) {
-    const root = scrollerRef.current;
-    if (!root) {
-      return;
-    }
-    const clamped = Math.min(Math.max(nextIndex, 0), pageCount - 1);
-    root.scrollTo({ left: clamped * root.clientWidth, behavior: "smooth" });
+  function goToPage(nextIndex: number) {
+    setPageIndex(Math.min(Math.max(nextIndex, 0), pageCount - 1));
   }
 
-  function handleScroll() {
-    const root = scrollerRef.current;
-    if (!root || root.clientWidth === 0) {
+  function handlePointerDown(event: React.PointerEvent<HTMLElement>) {
+    pointerStart.current = { x: event.clientX, y: event.clientY };
+  }
+
+  function handlePointerUp(event: React.PointerEvent<HTMLElement>) {
+    const start = pointerStart.current;
+    pointerStart.current = null;
+    if (!start || pageCount < 2) {
       return;
     }
-    setPageIndex(Math.round(root.scrollLeft / root.clientWidth));
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    if (Math.abs(dx) < 48 || Math.abs(dx) < Math.abs(dy) * 1.25) {
+      return;
+    }
+    skipClick.current = true;
+    goToPage(dx < 0 ? safeIndex + 1 : safeIndex - 1);
+  }
+
+  function handleClickCapture(event: React.MouseEvent<HTMLElement>) {
+    if (!skipClick.current) {
+      return;
+    }
+    skipClick.current = false;
+    event.preventDefault();
+    event.stopPropagation();
   }
 
   return (
-    <section className="relative flex min-h-0 flex-1 flex-col" aria-label="토픽 영상">
-      <div
-        ref={scrollerRef}
-        onScroll={handleScroll}
-        className="flex h-full min-h-0 flex-1 snap-x snap-mandatory items-stretch overflow-x-auto overflow-y-hidden touch-pan-x [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      >
-        {pages.map((pageVideos, index) => (
-          <div
-            key={`topic-page-${index}`}
-            className={
-              videos.length === 0
-                ? "flex min-h-0 w-full min-w-full shrink-0 snap-start snap-always flex-col self-stretch px-[23px] pb-6"
-                : "flex min-h-0 w-full min-w-full shrink-0 snap-start snap-always flex-col self-stretch"
-            }
-          >
-            <TopicClipPage
-              videos={pageVideos}
-              captureHref={captureHref}
-              onSelectVideo={onSelectVideo}
-            />
-          </div>
-        ))}
-      </div>
+    <section
+      className="relative h-full min-h-0 w-full touch-pan-y overflow-hidden"
+      aria-label="토픽 영상"
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={() => {
+        pointerStart.current = null;
+      }}
+      onClickCapture={handleClickCapture}
+    >
+      {pages.map((pageVideos, index) => (
+        <div
+          key={`topic-page-${index}`}
+          className={
+            videos.length === 0
+              ? "absolute inset-0 flex flex-col px-[23px] pb-6"
+              : "absolute inset-0 flex flex-col"
+          }
+          style={{ transform: `translate3d(${(index - safeIndex) * 100}%, 0, 0)` }}
+        >
+          <TopicClipPage
+            videos={pageVideos}
+            captureHref={captureHref}
+            onSelectVideo={onSelectVideo}
+          />
+        </div>
+      ))}
 
       {pageCount > 1 ? (
         <>
           <button
             type="button"
-            className="absolute inset-y-0 left-0 z-10 w-[12.5%] border-0 bg-transparent p-0"
+            className="absolute inset-y-0 left-0 z-10 w-[12.5%] touch-pan-y border-0 bg-transparent p-0"
             aria-label="이전 페이지"
-            onClick={() => scrollToPage(pageIndex - 1)}
+            onClick={() => goToPage(safeIndex - 1)}
           />
           <button
             type="button"
-            className="absolute inset-y-0 right-0 z-10 w-[12.5%] border-0 bg-transparent p-0"
+            className="absolute inset-y-0 right-0 z-10 w-[12.5%] touch-pan-y border-0 bg-transparent p-0"
             aria-label="다음 페이지"
-            onClick={() => scrollToPage(pageIndex + 1)}
+            onClick={() => goToPage(safeIndex + 1)}
           />
         </>
       ) : null}

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -48,7 +48,11 @@ export function TopicGallerySection({
         {pages.map((pageVideos, index) => (
           <div
             key={`topic-page-${index}`}
-            className="flex min-h-0 w-full min-w-full shrink-0 snap-start snap-always flex-col self-stretch p-2"
+            className={
+              videos.length === 0
+                ? "flex min-h-0 w-full min-w-full shrink-0 snap-start snap-always flex-col self-stretch px-[23px] pb-6"
+                : "flex min-h-0 w-full min-w-full shrink-0 snap-start snap-always flex-col self-stretch"
+            }
           >
             <TopicClipPage
               videos={pageVideos}

--- a/components/organisms/TopicViewerSection.tsx
+++ b/components/organisms/TopicViewerSection.tsx
@@ -26,7 +26,7 @@ export function TopicViewerSection({
   const router = useRouter();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden" aria-label={title}>
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden" aria-label={title}>
       <ScreenHeader
         leading={<HeaderBackLink href={backHref} />}
         title={title}

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -138,7 +138,7 @@ export function TopicsLayoutSection({
                       key={topic.id}
                       title={
                         <TextLink
-                          href={ROUTES.agit.topicDetail(agitId, topic.id)}
+                          href={ROUTES.agit.topicFeed(agitId, topic.id)}
                           className="flex min-w-0 flex-col gap-[2px] !text-inherit !no-underline"
                         >
                           <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -5,6 +5,7 @@ export { ChatMoreSheet } from "./ChatMoreSheet";
 export { MoveTopicSheet } from "./MoveTopicSheet";
 export { TopicCreateForm } from "./TopicCreateForm";
 export { TopicEditForm } from "./TopicEditForm";
+export { TopicFeedSection } from "./TopicFeedSection";
 export { TopicGallerySection } from "./TopicGallerySection";
 export { TopicViewerSection } from "./TopicViewerSection";
 export { ViewerActionsSheet } from "./ViewerActionsSheet";

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -53,6 +53,7 @@ export {
   RoomProfileEditTemplate as AgitProfileEditTemplate,
   TopicCreateTemplate as AgitTopicCreateTemplate,
   TopicEditTemplate as AgitTopicEditTemplate,
+  TopicFeedTemplate as AgitTopicFeedTemplate,
   TopicViewerTemplate as AgitTopicViewerTemplate,
   TopicsLayoutTemplate as AgitTopicsTemplate,
 } from "./RoomManageTemplates";

--- a/components/templates/AppChromeTemplate.tsx
+++ b/components/templates/AppChromeTemplate.tsx
@@ -9,6 +9,7 @@ type AppChromeTemplateProps = {
   showNav?: boolean;
   variant?: "feed" | "light" | "diary";
   className?: string;
+  mainOverflow?: "auto" | "hidden";
 };
 
 export function AppChromeTemplate({
@@ -18,6 +19,7 @@ export function AppChromeTemplate({
   showNav = true,
   variant = "feed",
   className = "",
+  mainOverflow = "auto",
 }: AppChromeTemplateProps) {
   const shellClass =
     variant === "light" || variant === "diary"
@@ -28,7 +30,11 @@ export function AppChromeTemplate({
     <div className={`${shellClass} ${className}`.trim()}>
       <div className={`flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden ${showNav ? "pb-[80px]" : ""}`}>
         {header}
-        <main className="flex min-h-0 w-full flex-1 flex-col overflow-y-auto">{children}</main>
+        <main
+          className={`flex min-h-0 w-full flex-1 flex-col ${mainOverflow === "hidden" ? "overflow-hidden" : "overflow-y-auto"}`}
+        >
+          {children}
+        </main>
       </div>
       {showNav ? <BottomNavigation active={activeTab} variant={variant} /> : null}
     </div>

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -85,7 +85,7 @@ export function TopicViewerTemplate({
   const dateLabel = topic.startDate.replaceAll("-", ".");
 
   return (
-    <AppChromeTemplate activeTab="agit" variant="light">
+    <AppChromeTemplate activeTab="agit" variant="light" mainOverflow="hidden">
       <TopicViewerSection
         agitId={agit.id}
         title={topic.title || "제목 없음"}

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -6,6 +6,7 @@ import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySectio
 import { MembersPermissionsSection } from "@/components/organisms/MembersPermissionsSection";
 import { TopicCreateForm } from "@/components/organisms/TopicCreateForm";
 import { TopicEditForm } from "@/components/organisms/TopicEditForm";
+import { TopicFeedSection } from "@/components/organisms/TopicFeedSection";
 import { TopicViewerSection } from "@/components/organisms/TopicViewerSection";
 import { TopicsLayoutSection } from "@/components/organisms/TopicsLayoutSection";
 import { AgitFlowChrome, AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
@@ -14,7 +15,7 @@ import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
-import type { UiTopicDetail, UiTopicListSections, UiTopicVideo } from "@/types/topic/ui";
+import type { UiTopicDetail, UiTopicFeedWindow, UiTopicListSections, UiTopicVideo } from "@/types/topic/ui";
 
 type AgitIdProps = { agitId: string };
 
@@ -56,7 +57,7 @@ export function TopicsLayoutTemplate({
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <ScreenHeader
           leading={<HeaderBackLink href={ROUTES.agit.detail(agit.id)} />}
-          title="토픽관리"
+          title="토픽"
         />
         <div className="min-h-0 flex-1 overflow-y-auto px-[23px] pb-6">
           <TopicsLayoutSection
@@ -92,6 +93,28 @@ export function TopicViewerTemplate({
         meta={`${dateLabel} · ${videos.length}개 영상`}
         videos={videos}
         backHref={ROUTES.agit.topics(agit.id)}
+      />
+    </AppChromeTemplate>
+  );
+}
+
+export function TopicFeedTemplate({
+  agit,
+  initialWindow,
+  initialVideos,
+}: {
+  agit: UiAgit | null;
+  initialWindow: UiTopicFeedWindow;
+  initialVideos: Record<string, UiTopicVideo[]>;
+}) {
+  if (!agit) return <RoomMissing />;
+
+  return (
+    <AppChromeTemplate activeTab="agit" variant="light" mainOverflow="hidden">
+      <TopicFeedSection
+        agitId={agit.id}
+        initialWindow={initialWindow}
+        initialVideos={initialVideos}
       />
     </AppChromeTemplate>
   );

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -15,6 +15,7 @@ export {
   AgitSafetyTemplate,
   AgitTopicCreateTemplate,
   AgitTopicEditTemplate,
+  AgitTopicFeedTemplate,
   AgitTopicViewerTemplate,
 } from "./AgitTemplates";
 export { ChangePasswordTemplate } from "./ChangePasswordTemplate";

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -44,6 +44,7 @@ export const API_ENDPOINTS = {
   topic: {
     list: gatewayPath("topic", "/api/v1/topics"),
     listByStatus: gatewayPath("topic", "/api/v1/topics/list"),
+    feed: gatewayPath("topic", "/api/v1/topics/feed"),
     detail: (topicUuid: string) => gatewayPath("topic", `/api/v1/topics/${topicUuid}`),
     videos: (topicUuid: string) =>
       gatewayPath("topic", `/api/v1/topics/${topicUuid}/videos`),

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -31,9 +31,9 @@ export const ROUTES = {
     topics: (agitId: string) => `/agit/${agitId}/topics` as const,
     topicCreate: (agitId: string) => `/agit/${agitId}/topics/create` as const,
     topicFeed: (agitId: string, topicId?: string) =>
-      (topicId
-        ? `/agit/${agitId}/feed?topic=${encodeURIComponent(topicId)}`
-        : `/agit/${agitId}/feed`) as const,
+      topicId
+        ? (`/agit/${agitId}/feed?topic=${encodeURIComponent(topicId)}` as const)
+        : (`/agit/${agitId}/feed` as const),
     topicDetail: (agitId: string, topicId: string) =>
       `/agit/${agitId}/topics/${topicId}` as const,
     topicEdit: (agitId: string, topicId: string) =>

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -30,6 +30,10 @@ export const ROUTES = {
     members: (agitId: string) => `/agit/${agitId}/members` as const,
     topics: (agitId: string) => `/agit/${agitId}/topics` as const,
     topicCreate: (agitId: string) => `/agit/${agitId}/topics/create` as const,
+    topicFeed: (agitId: string, topicId?: string) =>
+      (topicId
+        ? `/agit/${agitId}/feed?topic=${encodeURIComponent(topicId)}`
+        : `/agit/${agitId}/feed`) as const,
     topicDetail: (agitId: string, topicId: string) =>
       `/agit/${agitId}/topics/${topicId}` as const,
     topicEdit: (agitId: string, topicId: string) =>

--- a/lib/api/topicApi.ts
+++ b/lib/api/topicApi.ts
@@ -6,6 +6,7 @@ import { withAuthRetry } from "@/lib/api/withAuthRetry";
 import type {
   ApiCreateTopicRequest,
   ApiTopic,
+  ApiTopicFeed,
   ApiTopicListStatus,
   ApiTopicVideo,
   ApiUpdateTopicRequest,
@@ -75,5 +76,24 @@ export async function deleteTopic(topicUuid: string): Promise<void> {
 export async function listTopicVideos(topicUuid: string): Promise<ApiTopicVideo[]> {
   return topicFetch<ApiTopicVideo[]>(API_ENDPOINTS.topic.videos(topicUuid), {
     method: "GET",
+  });
+}
+
+export async function getTopicFeed(params: {
+  agitUuid: string;
+  topicUuid?: string;
+  date?: string;
+  before?: number;
+  after?: number;
+}): Promise<ApiTopicFeed> {
+  return topicFetch<ApiTopicFeed>(API_ENDPOINTS.topic.feed, {
+    method: "GET",
+    searchParams: {
+      agitUuid: params.agitUuid,
+      topicUuid: params.topicUuid,
+      date: params.date,
+      before: params.before !== undefined ? String(params.before) : undefined,
+      after: params.after !== undefined ? String(params.after) : undefined,
+    },
   });
 }

--- a/lib/api/topicApi.ts
+++ b/lib/api/topicApi.ts
@@ -74,9 +74,59 @@ export async function deleteTopic(topicUuid: string): Promise<void> {
 }
 
 export async function listTopicVideos(topicUuid: string): Promise<ApiTopicVideo[]> {
-  return topicFetch<ApiTopicVideo[]>(API_ENDPOINTS.topic.videos(topicUuid), {
+  const payload = await topicFetch<unknown>(API_ENDPOINTS.topic.videos(topicUuid), {
     method: "GET",
   });
+  return toTopicVideoList(payload);
+}
+
+function toTopicVideoList(payload: unknown): ApiTopicVideo[] {
+  const rows = Array.isArray(payload)
+    ? payload
+    : payload !== null &&
+        typeof payload === "object" &&
+        "data" in payload &&
+        Array.isArray((payload as { data: unknown }).data)
+      ? (payload as { data: unknown[] }).data
+      : [];
+  return rows.flatMap((row) => {
+    if (!row || typeof row !== "object") {
+      return [];
+    }
+    const record = row as Record<string, unknown>;
+    const videoUuid = readString(record, ["videoUuid", "videoId", "id"]);
+    if (!videoUuid) {
+      return [];
+    }
+    return [
+      {
+        videoUuid,
+        userUuid: readString(record, ["userUuid", "userId", "memberUuid"]) ?? "",
+        createdAt: readTimestamp(record.createdAt),
+      },
+    ];
+  });
+}
+
+function readString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readTimestamp(value: unknown): string {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  if (Array.isArray(value) && value.length >= 3 && value.every((part) => typeof part === "number")) {
+    const [year, month, day, hour = 0, minute = 0, second = 0] = value as number[];
+    return new Date(year, month - 1, day, hour, minute, second).toISOString();
+  }
+  return new Date(0).toISOString();
 }
 
 export async function getTopicFeed(params: {

--- a/lib/topic/mergeTopicFeed.ts
+++ b/lib/topic/mergeTopicFeed.ts
@@ -1,0 +1,14 @@
+export function toFeedOrder<T>(before: T[], current: T, after: T[]): T[] {
+  return [...before].reverse().concat(current, after);
+}
+
+export function mergeUniqueById<T>(
+  base: T[],
+  extra: T[],
+  getId: (item: T) => string,
+  edge: "start" | "end",
+): T[] {
+  const seen = new Set(base.map(getId));
+  const unique = extra.filter((item) => !seen.has(getId(item)));
+  return edge === "start" ? [...unique, ...base] : [...base, ...unique];
+}

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -1,7 +1,8 @@
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { ApiCreateTopicRequest, ApiTopic, ApiTopicListStatus, ApiTopicVideo, ApiUpdateTopicRequest } from "@/types/topic/api";
-import type { UiTopicDetail, UiTopicGallery, UiTopicListItem, UiTopicVideo } from "@/types/topic/ui";
+import type { UiTopicDetail, UiTopicFeedWindow, UiTopicGallery, UiTopicListItem, UiTopicVideo } from "@/types/topic/ui";
 import * as topicApi from "@/lib/api/topicApi";
+import { toFeedOrder } from "@/lib/topic/mergeTopicFeed";
 import { formatKstDotDate, isSameKstDate, selectAgitTopic, toKstDateString } from "@/lib/topic/selectAgitTopic";
 import * as videoService from "@/services/videoService";
 
@@ -145,4 +146,42 @@ export async function getTopicGallery(
   const profiles = memberMap(members);
   const videos = await Promise.all(topicVideos.map((item) => mapTopicVideo(item, profiles)));
   return { topic: mapSummary(selected), videos };
+}
+
+const FEED_NEIGHBOR_LIMIT = 3;
+
+export async function getTopicFeedWindow(params: {
+  agitUuid: string;
+  topicUuid?: string;
+  date?: string;
+  before?: number;
+  after?: number;
+}): Promise<UiTopicFeedWindow> {
+  const before = params.before ?? FEED_NEIGHBOR_LIMIT;
+  const after = params.after ?? FEED_NEIGHBOR_LIMIT;
+  const feed = await topicApi.getTopicFeed({
+    agitUuid: params.agitUuid,
+    topicUuid: params.topicUuid,
+    date: params.date,
+    before,
+    after,
+  });
+  if (!feed.current) {
+    return { topics: [], currentId: null, hasMoreBefore: false, hasMoreAfter: false };
+  }
+  const ordered = toFeedOrder(feed.before ?? [], feed.current, feed.after ?? []);
+  return {
+    topics: ordered.map(toUiTopicDetail),
+    currentId: feed.current.topicUuid,
+    hasMoreBefore: (feed.before?.length ?? 0) >= before,
+    hasMoreAfter: (feed.after?.length ?? 0) >= after,
+  };
+}
+
+export async function getTopicVideos(
+  topicUuid: string,
+  members: ApiAgitDetailMember[],
+): Promise<UiTopicVideo[]> {
+  const viewer = await getTopicViewer(topicUuid, members);
+  return viewer.videos;
 }

--- a/types/topic/api.ts
+++ b/types/topic/api.ts
@@ -27,3 +27,9 @@ export type ApiTopicVideo = {
   userUuid: string;
   createdAt: string;
 };
+
+export type ApiTopicFeed = {
+  current: ApiTopic | null;
+  before: ApiTopic[];
+  after: ApiTopic[];
+};

--- a/types/topic/ui.ts
+++ b/types/topic/ui.ts
@@ -48,3 +48,10 @@ export type UiTopicGallery = {
   topic: UiTopicSummary | null;
   videos: UiTopicVideo[];
 };
+
+export type UiTopicFeedWindow = {
+  topics: UiTopicDetail[];
+  currentId: string | null;
+  hasMoreBefore: boolean;
+  hasMoreAfter: boolean;
+};


### PR DESCRIPTION
## 작업 내용

토픽 상세가 헤더와 하단 탭 사이를 가득 채우도록 레이아웃을 맞추고, 목록에서 선택한 토픽은 세로 스냅 피드(`/agit/{id}/feed`)로 이어지게 했습니다. 피드 헤더는 스크롤러 밖에 두어 제목이 바로 바뀌고, 가로 갤러리 스냅과 이웃 토픽 윈도우(±3, 영상은 보이는 토픽 ±1)는 기존 스펙을 유지합니다. 기존 `/topics/{topicId}` 상세는 리다이렉트하지 않습니다.

## 관련 이슈

Close #96
Close #98

## 변경 사항

### 1. 토픽 뷰어 풀블리드 레이아웃

- **파일:** `components/templates/AppChromeTemplate.tsx`, `components/templates/RoomManageTemplates.tsx`, `components/organisms/TopicGallerySection.tsx`, `components/organisms/TopicViewerSection.tsx`, `components/molecules/TopicVideoTile.tsx`, `components/molecules/TopicClipPage.tsx`
- **설명:** 메인 영역을 `overflow-hidden`으로 두어 페이지 여백 스크롤을 막고, 영상이 있을 때는 타일 간격·라운드를 제거합니다. 영상 0개일 때는 목록과 같은 `px-[23px] pb-6`을 유지합니다.

```tsx
type AppChromeTemplateProps = {
  children: ReactNode;
  activeTab?: BottomNavTab;
  header?: ReactNode;
  showNav?: boolean;
  variant?: "feed" | "light" | "diary";
  className?: string;
  mainOverflow?: "auto" | "hidden";
};

<main
  className={`flex min-h-0 w-full flex-1 flex-col ${mainOverflow === "hidden" ? "overflow-hidden" : "overflow-y-auto"}`}
>
  {children}
</main>
```

### 2. 토픽 피드 API와 이웃 윈도우

- **파일:** `config/api-endpoints.ts`, `config/routes.ts`, `types/topic/api.ts`, `types/topic/ui.ts`, `lib/api/topicApi.ts`, `lib/topic/mergeTopicFeed.ts`, `services/topicService.ts`, `actions/topicActions.ts`
- **설명:** `GET /api/v1/topics/feed`를 호출해 `before`/`after` 윈도우를 만들고, `topicUuid`가 없으면 KST 오늘 날짜로 조회합니다.

```typescript
export async function getTopicFeedWindow(params: {
  agitUuid: string;
  topicUuid?: string;
  date?: string;
  before?: number;
  after?: number;
}): Promise<UiTopicFeedWindow> {
  const before = params.before ?? FEED_NEIGHBOR_LIMIT;
  const after = params.after ?? FEED_NEIGHBOR_LIMIT;
  const feed = await topicApi.getTopicFeed({
    agitUuid: params.agitUuid,
    topicUuid: params.topicUuid,
    date: params.date,
    before,
    after,
  });
  if (!feed.current) {
    return { topics: [], currentId: null, hasMoreBefore: false, hasMoreAfter: false };
  }
  const ordered = toFeedOrder(feed.before ?? [], feed.current, feed.after ?? []);
  return {
    topics: ordered.map(toUiTopicDetail),
    currentId: feed.current.topicUuid,
    hasMoreBefore: (feed.before?.length ?? 0) >= before,
    hasMoreAfter: (feed.after?.length ?? 0) >= after,
  };
}
```

### 3. 세로 스냅 피드 화면

- **파일:** `app/(agit)/agit/[agitId]/feed/page.tsx`, `components/organisms/TopicFeedSection.tsx`, `components/templates/RoomManageTemplates.tsx`
- **설명:** 헤더는 세로 스크롤러 밖에 두고, 토픽 단위 `snap-y`로 이동합니다. 끝에서 막히며, 끝에서 두 번째 근처에서 이웃을 다시 불러옵니다. URL은 `router.replace`로 `?topic=`만 갱신합니다.

```tsx
<div
  ref={scrollerRef}
  onScroll={handleScroll}
  className="min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain touch-pan-y [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
>
  {topics.map((topic) => (
    <div key={topic.id} className="flex h-full min-h-full w-full shrink-0 snap-start snap-always flex-col">
      <TopicGallerySection
        videos={videosByTopic[topic.id] ?? []}
        captureHref={ROUTES.agit.upload(agitId)}
        onSelectVideo={(videoId) => router.push(ROUTES.viewer.clip(videoId))}
      />
    </div>
  ))}
</div>
```

### 4. 목록 진입 경로와 라벨

- **파일:** `components/organisms/TopicsLayoutSection.tsx`, `components/organisms/AgitMenuDrawer.tsx`, `components/organisms/RoomManageHub.tsx`
- **설명:** 목록·메뉴 문구를 「토픽」으로 맞추고, 토픽 행은 `/agit/{id}/feed?topic=`으로 연결합니다. 목록 화면 경로는 `/topics`를 유지합니다.

```ts
topicFeed: (agitId: string, topicId?: string) =>
  (topicId
    ? `/agit/${agitId}/feed?topic=${encodeURIComponent(topicId)}`
    : `/agit/${agitId}/feed`) as const,
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [x] 영상 있는 토픽: 헤더~하단 탭 사이 풀블리드, 타일 간격/라운드 없음
  - [x] 영상 0개: 목록과 동일한 좌우·하단 패딩
  - [x] 목록에서 토픽 선택 → `/feed?topic=` 진입, 뒤로가기 시 목록
  - [x] 세로 스냅 1토픽, 내부 가로 스냅 유지, 양 끝에서 추가 스크롤 차단
  - [ ] `?topic` 없이 `/feed` 진입 시 오늘(KST) 기준 피드

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
