### PR TITLE
[#101] Feature : 토픽 피드 pill 헤더 및 촬영 슬롯 추가, 클립 레이아웃 개선

### DIFF
--- a/components/atoms/FeedPill.tsx
+++ b/components/atoms/FeedPill.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+import type { HTMLAttributes, ReactNode } from "react";
+
+export const feedOverlayGlassClass =
+  "border-0 bg-black/40 text-white shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md";
+
+type FeedPillProps = Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {
+  children: ReactNode;
+};
+
+export function FeedPill({ children, className = "", ...props }: FeedPillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-7 max-w-full items-center gap-1.5 rounded-full px-3 text-[12px] font-semibold leading-4",
+        feedOverlayGlassClass,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -23,6 +23,7 @@ export {
 } from "./NavIcons";
 export { CursorSpark } from "./CursorSpark";
 export { DailyIcon, type DailyIconName } from "./DailyIcon";
+export { FeedPill, feedOverlayGlassClass } from "./FeedPill";
 export { Pill } from "./Pill";
 export { PageTitle } from "./PageTitle";
 export { ScreenSubtitle, ScreenTitle } from "./ScreenTitle";

--- a/components/molecules/TopicClipPage.tsx
+++ b/components/molecules/TopicClipPage.tsx
@@ -5,20 +5,18 @@ import type { UiTopicVideo } from "@/types/topic/ui";
 type TopicClipPageProps = {
   videos: UiTopicVideo[];
   captureHref: string;
+  showCaptureSlot?: boolean;
   onSelectVideo?: (videoId: string) => void;
 };
 
 export function TopicClipPage({
   videos,
   captureHref,
+  showCaptureSlot = false,
   onSelectVideo,
 }: TopicClipPageProps) {
-  if (videos.length === 0) {
-    return (
-      <div className="flex h-full min-h-0 w-full flex-col">
-        <TopicEmptySlot captureHref={captureHref} />
-      </div>
-    );
+  if (videos.length === 0 && !showCaptureSlot) {
+    return <div className="flex h-full min-h-0 w-full flex-col" />;
   }
 
   return (
@@ -26,6 +24,7 @@ export function TopicClipPage({
       {videos.map((video) => (
         <TopicVideoTile key={video.id} video={video} onSelect={onSelectVideo} />
       ))}
+      {showCaptureSlot ? <TopicEmptySlot captureHref={captureHref} /> : null}
     </div>
   );
 }

--- a/components/molecules/TopicFeedPillHeader.tsx
+++ b/components/molecules/TopicFeedPillHeader.tsx
@@ -1,0 +1,27 @@
+import { DailyIcon, TextLink } from "@/components/atoms";
+
+type TopicFeedPillHeaderProps = {
+  backHref: string;
+  title: string;
+  videoCount: number;
+};
+
+export function TopicFeedPillHeader({ backHref, title, videoCount }: TopicFeedPillHeaderProps) {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-3 z-30 flex justify-center px-4">
+      <div className="pointer-events-auto flex max-w-[min(100%,22rem)] items-center gap-1.5 rounded-full bg-black/45 py-1.5 pr-3.5 pl-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur-md">
+        <TextLink
+          href={backHref}
+          aria-label="뒤로"
+          className="grid size-8 shrink-0 place-items-center rounded-full text-white no-underline hover:no-underline"
+        >
+          <DailyIcon name="chevronLeft" size={18} className="brightness-0 invert" />
+        </TextLink>
+        <p className="m-0 min-w-0 flex-1 overflow-hidden text-[13px] font-semibold leading-4 text-white [text-overflow:ellipsis] whitespace-nowrap">
+          {title}
+        </p>
+        <p className="m-0 shrink-0 text-[13px] font-semibold leading-4 text-white/90">{videoCount}개</p>
+      </div>
+    </div>
+  );
+}

--- a/components/molecules/TopicFeedPillHeader.tsx
+++ b/components/molecules/TopicFeedPillHeader.tsx
@@ -1,27 +1,46 @@
-import { DailyIcon, TextLink } from "@/components/atoms";
+import { DailyIcon, FeedPill, IconLink } from "@/components/atoms";
+import { cn } from "@/lib/utils";
 
 type TopicFeedPillHeaderProps = {
   backHref: string;
   title: string;
   videoCount: number;
+  dateLabel: string;
 };
 
-export function TopicFeedPillHeader({ backHref, title, videoCount }: TopicFeedPillHeaderProps) {
+export function TopicFeedPillHeader({ backHref, title, videoCount, dateLabel }: TopicFeedPillHeaderProps) {
   return (
-    <div className="pointer-events-none absolute inset-x-0 top-3 z-30 flex justify-center px-4">
-      <div className="pointer-events-auto flex max-w-[min(100%,22rem)] items-center gap-1.5 rounded-full bg-black/45 py-1.5 pr-3.5 pl-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur-md">
-        <TextLink
+    <>
+      <div className="pointer-events-none absolute top-3 left-3 z-30">
+        <IconLink
           href={backHref}
-          aria-label="뒤로"
-          className="grid size-8 shrink-0 place-items-center rounded-full text-white no-underline hover:no-underline"
+          label="뒤로"
+          className={cn(
+            "pointer-events-auto size-7 rounded-full bg-transparent text-white shadow-none backdrop-blur-none no-underline hover:no-underline",
+            "hover:bg-black/40 hover:shadow-[0_4px_16px_rgba(0,0,0,0.16)] hover:backdrop-blur-md",
+            "focus-visible:bg-black/40 focus-visible:shadow-[0_4px_16px_rgba(0,0,0,0.16)] focus-visible:backdrop-blur-md",
+            "active:bg-black/40 active:shadow-[0_4px_16px_rgba(0,0,0,0.16)] active:backdrop-blur-md",
+          )}
         >
-          <DailyIcon name="chevronLeft" size={18} className="brightness-0 invert" />
-        </TextLink>
-        <p className="m-0 min-w-0 flex-1 overflow-hidden text-[13px] font-semibold leading-4 text-white [text-overflow:ellipsis] whitespace-nowrap">
-          {title}
-        </p>
-        <p className="m-0 shrink-0 text-[13px] font-semibold leading-4 text-white/90">{videoCount}개</p>
+          <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+        </IconLink>
       </div>
-    </div>
+      <div className="pointer-events-none absolute inset-x-0 top-3 z-30 flex justify-center px-14">
+        <div className="pointer-events-auto relative max-w-full">
+          <FeedPill>
+            <span className="min-w-0 overflow-hidden [text-overflow:ellipsis] whitespace-nowrap">{title}</span>
+          </FeedPill>
+          <span
+            className="absolute top-1/2 -right-5 grid h-4 min-w-4 -translate-y-1/2 place-items-center rounded-full border-0 bg-black/40 px-1 text-[10px] font-semibold leading-none text-white shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md"
+            aria-label={`${videoCount}개 영상`}
+          >
+            {videoCount}
+          </span>
+        </div>
+      </div>
+      <p className="pointer-events-none absolute top-3 right-3 z-30 m-0 flex h-7 items-center text-[11px] font-medium leading-none text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+        {dateLabel}
+      </p>
+    </>
   );
 }

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -1,4 +1,4 @@
-import { DailyIcon, UserAvatar } from "@/components/atoms";
+import { UserAvatar } from "@/components/atoms";
 import type { UiTopicVideo } from "@/types/topic/ui";
 
 type TopicVideoTileProps = {
@@ -27,20 +27,13 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
         className="absolute inset-0 size-full object-cover"
       />
       <span
-        className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.45)_0%,transparent_28%,transparent_58%,rgba(0,0,0,0.38)_100%)]"
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.28)_0%,transparent_22%,transparent_55%,rgba(0,0,0,0.48)_100%)]"
         aria-hidden
       />
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-3 top-3 flex min-w-0 items-center gap-2">
-          <UserAvatar src={video.profileImageSrc} size={28} />
-          <p className="m-0 overflow-hidden text-[13px] font-semibold leading-4 text-white [text-overflow:ellipsis] whitespace-nowrap [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-            {video.profileNickname}
-          </p>
-        </div>
         <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center">
-          <DailyIcon name="play" size={36} />
-          <div className="relative mt-1">
-            <p className="m-0 text-[28px] font-bold leading-none text-white [text-shadow:0_1px_4px_rgba(0,0,0,0.5)]">
+          <div className="relative">
+            <p className="m-0 text-[40px] font-bold leading-none text-white [text-shadow:0_1px_4px_rgba(0,0,0,0.5)]">
               {time}
             </p>
             {caption ? (
@@ -49,6 +42,12 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
               </p>
             ) : null}
           </div>
+        </div>
+        <div className="absolute bottom-3 left-3 flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-2">
+          <UserAvatar src={video.profileImageSrc} size={28} />
+          <p className="m-0 overflow-hidden text-[13px] font-semibold leading-4 text-white [text-overflow:ellipsis] whitespace-nowrap [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
+            {video.profileNickname}
+          </p>
         </div>
       </div>
     </>

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -17,6 +17,7 @@ export { CaptureClipOverlays } from "./CaptureClipOverlays";
 export { TopicChip } from "./TopicChip";
 export { TopicClipPage } from "./TopicClipPage";
 export { TopicEmptySlot } from "./TopicEmptySlot";
+export { TopicFeedPillHeader } from "./TopicFeedPillHeader";
 export { TopicVideoTile } from "./TopicVideoTile";
 export { AgreementRow } from "./AgreementRow";
 export { AuthDivider } from "./AuthDivider";

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -248,6 +248,7 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
         backHref={backHref}
         title={current.title || "제목 없음"}
         videoCount={videoCount}
+        dateLabel={current.startDate.replaceAll("-", ".")}
       />
       <div
         ref={scrollerRef}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { getTopicFeedWindowAction, getTopicVideosAction } from "@/actions/topicActions";
-import { HeaderBackLink, ScreenHeader } from "@/components/molecules";
+import { HeaderBackLink, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
 import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
 import { ROUTES } from "@/config/routes";
 import { mergeUniqueById } from "@/lib/topic/mergeTopicFeed";
+import { shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgitTopic";
 import type { UiTopicDetail, UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const NEIGHBOR_LIMIT = 3;
+const EMPTY_TOPIC_VIDEOS: UiTopicVideo[] = [];
 
 type TopicFeedSectionProps = {
   agitId: string;
@@ -241,11 +243,11 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
   const videoCount = loadedVideos && loadedVideos.length > 0 ? loadedVideos.length : current.videoCount;
 
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-      <ScreenHeader
-        leading={<HeaderBackLink href={backHref} />}
+    <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <TopicFeedPillHeader
+        backHref={backHref}
         title={current.title || "제목 없음"}
-        subtitle={`${current.startDate.replaceAll("-", ".")} · ${videoCount}개 영상`}
+        videoCount={videoCount}
       />
       <div
         ref={scrollerRef}
@@ -260,8 +262,9 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
           >
             {Math.abs(topicIndex - index) <= 1 ? (
               <TopicGallerySection
-                videos={videosByTopic[topic.id] ?? []}
-                captureHref={ROUTES.agit.upload(agitId)}
+                videos={videosByTopic[topic.id] ?? EMPTY_TOPIC_VIDEOS}
+                captureHref={ROUTES.capture.videoWith({ agitUuid: agitId, topicUuid: topic.id })}
+                showCaptureSlot={shouldShowTopicCaptureSlot(topic)}
                 onSelectVideo={(videoId) => router.push(ROUTES.viewer.clip(videoId))}
               />
             ) : null}

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -3,7 +3,7 @@
 import { TopicClipPage } from "@/components/molecules/TopicClipPage";
 import { paginateTopicVideos } from "@/lib/topic/paginateTopicVideos";
 import type { UiTopicVideo } from "@/types/topic/ui";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 const CAPTURE_SLOT_ID = "__capture-slot__";
 
@@ -40,9 +40,11 @@ export function TopicGallerySection({
   const skipClick = useRef(false);
   const safeIndex = Math.min(pageIndex, Math.max(pageCount - 1, 0));
 
-  useEffect(() => {
+  const [prevKey, setPrevKey] = useState({ showCaptureSlot, len: videos.length });
+  if (prevKey.showCaptureSlot !== showCaptureSlot || prevKey.len !== videos.length) {
+    setPrevKey({ showCaptureSlot, len: videos.length });
     setPageIndex(0);
-  }, [showCaptureSlot, videos.length]);
+  }
 
   function goToPage(nextIndex: number) {
     setPageIndex(Math.min(Math.max(nextIndex, 0), pageCount - 1));

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -3,25 +3,46 @@
 import { TopicClipPage } from "@/components/molecules/TopicClipPage";
 import { paginateTopicVideos } from "@/lib/topic/paginateTopicVideos";
 import type { UiTopicVideo } from "@/types/topic/ui";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+const CAPTURE_SLOT_ID = "__capture-slot__";
+
+type CaptureSlotItem = { id: typeof CAPTURE_SLOT_ID };
+type GalleryPageItem = UiTopicVideo | CaptureSlotItem;
+
+const CAPTURE_SLOT: CaptureSlotItem = { id: CAPTURE_SLOT_ID };
+
+function isCaptureSlot(item: GalleryPageItem): item is CaptureSlotItem {
+  return item.id === CAPTURE_SLOT_ID;
+}
 
 type TopicGallerySectionProps = {
   videos: UiTopicVideo[];
   captureHref: string;
+  showCaptureSlot?: boolean;
   onSelectVideo?: (videoId: string) => void;
 };
 
 export function TopicGallerySection({
   videos,
   captureHref,
+  showCaptureSlot = false,
   onSelectVideo,
 }: TopicGallerySectionProps) {
-  const pages = useMemo(() => paginateTopicVideos(videos), [videos]);
+  const items = useMemo<GalleryPageItem[]>(
+    () => (showCaptureSlot ? [...videos, CAPTURE_SLOT] : videos),
+    [showCaptureSlot, videos],
+  );
+  const pages = useMemo(() => paginateTopicVideos(items), [items]);
   const pageCount = pages.length;
   const [pageIndex, setPageIndex] = useState(0);
   const pointerStart = useRef<{ x: number; y: number } | null>(null);
   const skipClick = useRef(false);
   const safeIndex = Math.min(pageIndex, Math.max(pageCount - 1, 0));
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [showCaptureSlot, videos.length]);
 
   function goToPage(nextIndex: number) {
     setPageIndex(Math.min(Math.max(nextIndex, 0), pageCount - 1));
@@ -55,16 +76,20 @@ export function TopicGallerySection({
     event.stopPropagation();
   }
 
-  function renderPage(pageVideos: UiTopicVideo[], key: string) {
+  function renderPage(pageItems: GalleryPageItem[], key: string) {
+    const pageVideos = pageItems.filter((item): item is UiTopicVideo => !isCaptureSlot(item));
     return (
       <TopicClipPage
         key={key}
         videos={pageVideos}
         captureHref={captureHref}
+        showCaptureSlot={pageItems.some(isCaptureSlot)}
         onSelectVideo={onSelectVideo}
       />
     );
   }
+
+  const paddedEmpty = videos.length === 0;
 
   return (
     <section
@@ -80,19 +105,19 @@ export function TopicGallerySection({
       {pageCount <= 1 ? (
         <div
           className={
-            videos.length === 0 ? "flex h-full min-h-0 flex-col px-[23px] pb-6" : "flex h-full min-h-0 flex-col"
+            paddedEmpty ? "flex h-full min-h-0 flex-col px-[23px] pb-6" : "flex h-full min-h-0 flex-col"
           }
         >
           {renderPage(pages[0] ?? [], "topic-page-0")}
         </div>
       ) : (
-        pages.map((pageVideos, index) => (
+        pages.map((pageItems, index) => (
           <div
             key={`topic-page-${index}`}
             className="absolute inset-0 flex flex-col"
             style={{ transform: `translate3d(${(index - safeIndex) * 100}%, 0, 0)` }}
           >
-            {renderPage(pageVideos, `topic-page-${index}`)}
+            {renderPage(pageItems, `topic-page-${index}`)}
           </div>
         ))
       )}

--- a/components/organisms/TopicViewerSection.tsx
+++ b/components/organisms/TopicViewerSection.tsx
@@ -12,6 +12,7 @@ type TopicViewerSectionProps = {
   title?: string;
   meta?: string;
   videos?: UiTopicVideo[];
+  showCaptureSlot?: boolean;
   backHref?: string;
   onMenuClick?: () => void;
 };
@@ -22,6 +23,7 @@ export function TopicViewerSection({
   title = "오늘의 토픽",
   meta = "",
   videos = [],
+  showCaptureSlot = false,
   backHref = ROUTES.agit.root,
   onMenuClick,
 }: TopicViewerSectionProps) {
@@ -38,6 +40,7 @@ export function TopicViewerSection({
       <TopicGallerySection
         videos={videos}
         captureHref={ROUTES.capture.videoWith({ agitUuid: agitId, topicUuid: topicId })}
+        showCaptureSlot={showCaptureSlot}
         onSelectVideo={(videoId) => router.push(ROUTES.viewer.clip(videoId))}
       />
     </div>

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -13,6 +13,7 @@ import { AgitFlowChrome, AppChromeTemplate } from "@/components/templates/AppChr
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import { shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgitTopic";
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicDetail, UiTopicFeedWindow, UiTopicListSections, UiTopicVideo } from "@/types/topic/ui";
@@ -93,6 +94,7 @@ export function TopicViewerTemplate({
         title={topic.title || "제목 없음"}
         meta={`${dateLabel} · ${videos.length}개 영상`}
         videos={videos}
+        showCaptureSlot={shouldShowTopicCaptureSlot(topic)}
         backHref={ROUTES.agit.topics(agit.id)}
       />
     </AppChromeTemplate>

--- a/lib/topic/selectAgitTopic.ts
+++ b/lib/topic/selectAgitTopic.ts
@@ -25,6 +25,18 @@ export function isSameKstDate(iso: string, today = new Date()): boolean {
   return toKstDateString(parsed) === toKstDateString(today);
 }
 
+/** startDate는 KST `YYYY-MM-DD`. 오늘이면 목록 상태 ONGOING과 같다. */
+export function isOngoingStartDate(startDate: string, today = new Date()): boolean {
+  return Boolean(startDate) && startDate === toKstDateString(today);
+}
+
+export function shouldShowTopicCaptureSlot(topic: {
+  startDate: string;
+  uploadedByMe: boolean | null;
+}): boolean {
+  return topic.uploadedByMe === false && isOngoingStartDate(topic.startDate);
+}
+
 /** 오늘(KST) startAt 토픽. 없으면 목록 첫 항목(최신). 0개면 null. */
 export function selectAgitTopic(topics: ApiTopic[], today = new Date()): ApiTopic | null {
   if (topics.length === 0) {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -99,6 +99,7 @@ export function toUiTopicDetail(topic: ApiTopic): UiTopicDetail {
     startDate: Number.isNaN(parsed.getTime()) ? topic.startAt.slice(0, 10) : toKstDateString(parsed),
     videoCount: topic.videoCount,
     creatorUuid: topic.creatorUuid,
+    uploadedByMe: topic.uploadedByMe ?? null,
   };
 }
 

--- a/types/topic/ui.ts
+++ b/types/topic/ui.ts
@@ -33,6 +33,7 @@ export type UiTopicDetail = {
   startDate: string;
   videoCount: number;
   creatorUuid: string;
+  uploadedByMe: boolean | null;
 };
 
 export type UiTopicListSectionKey = "ongoing" | "upcoming" | "past";


### PR DESCRIPTION
## 📌 개요
토픽 피드 화면의 헤더 디자인을 Pill 형태로 개선하고, 촬영 슬롯 조건 매핑 및 토픽 클립 타일 레이아웃을 개편했습니다.

## 🛠️ 변경 사항
- **토픽 피드 Pill 헤더 및 컴포넌트 추가**: `FeedPill`, `TopicFeedPillHeader` 컴포넌트 신규 구현 및 `TopicFeedSection` 적용
- **촬영 슬롯 매핑 및 조건 추가**: `uploadedByMe` 속성 추가 및 촬영 슬롯 표시 조건 연동
- **토픽 비디오 타일 UI 개선**: 비디오 타일에서 재생 버튼 제거 및 작성자 프로필/아바타 레이아웃 변경
- **TopicGallerySection 관련 개선**: 미사용 useEffect / import 정리를 통한 린트 오류 해결

## 🔗 관련 이슈
Close #101

## 🔍 리뷰 포인트
- 토픽 피드의 Pill 헤더 전환 및 비디오 카드 UI 레이아웃이 요구사항대로 정상 표시되는지 확인해 주세요.
