### PR TITLE
[#104] Feature : 풀페이지 비디오 뷰어 및 클라이언트 next/headers 경계 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Geist_Mono, Gothic_A1, Inter, Manrope, Montserrat, Poppins, Geist } from "next/font/google";
 import { auth } from "@/auth";
 import { AuthSessionProvider } from "@/components/providers/AuthSessionProvider";
+import { VideoViewerProvider } from "@/components/providers/VideoViewerProvider";
 import { AppRouteShell } from "@/components/templates/AppRouteShell";
 import "./globals.css";
 import { cn } from "@/lib/utils";
@@ -62,7 +63,9 @@ export default async function RootLayout({
     >
       <body className="flex h-dvh min-h-0 flex-col overflow-hidden overscroll-none">
         <AuthSessionProvider isLoggedIn={session?.isLoggedIn === true}>
-          <AppRouteShell>{children}</AppRouteShell>
+          <VideoViewerProvider>
+            <AppRouteShell>{children}</AppRouteShell>
+          </VideoViewerProvider>
         </AuthSessionProvider>
       </body>
     </html>

--- a/components/molecules/AnimatedOverlays.tsx
+++ b/components/molecules/AnimatedOverlays.tsx
@@ -7,6 +7,11 @@ import { createPortal } from "react-dom";
 
 const OverlayPortalContext = createContext<HTMLElement | null>(null);
 
+/** 기기 프레임 오버레이 호스트. 없으면 null (포탈 대신 로컬 absolute 폴백). */
+export function useOverlayPortalHost() {
+  return useContext(OverlayPortalContext);
+}
+
 /** 기기 프레임 안에서 사이드 시트가 하단 탭을 덮도록 포탈 호스트를 제공한다. */
 export function OverlayPortalProvider({ children }: { children: ReactNode }) {
   const [host, setHost] = useState<HTMLElement | null>(null);

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -4,6 +4,7 @@ export {
   AnimatedDropdown,
   AnimatedSideSheet,
   OverlayPortalProvider,
+  useOverlayPortalHost,
 } from "./AnimatedOverlays";
 export { AgitListRow } from "./AgitListRow";
 export { ManageListRow } from "./ManageListRow";

--- a/components/organisms/FullpageVideoViewer.tsx
+++ b/components/organisms/FullpageVideoViewer.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { HeaderBackLink, HeaderMenuButton, ScreenHeader } from "@/components/molecules";
+import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
+import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
+import type { VideoViewerItem } from "@/components/providers/VideoViewerProvider";
+import { getVideoDetail } from "@/services/videoService";
+import Image from "next/image";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type FullpageVideoViewerProps = {
+  initialClipId: string;
+  videoList: VideoViewerItem[];
+  onClose?: () => void;
+  isStandalone?: boolean;
+};
+
+export function FullpageVideoViewer({
+  initialClipId,
+  videoList,
+  onClose,
+}: FullpageVideoViewerProps) {
+  const list = videoList.length > 0 ? videoList : [{ clipId: initialClipId }];
+  const initialIndex = Math.max(
+    0,
+    list.findIndex((item) => item.clipId === initialClipId)
+  );
+
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [videoDetails, setVideoDetails] = useState<
+    Record<string, { playbackUrl?: string; thumbnailUrl?: string; caption?: string }>
+  >({});
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(true);
+
+  const currentItem = list[currentIndex] ?? list[0];
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  // Fetch video detail for current item if videoUuid exists
+  useEffect(() => {
+    const item = list[currentIndex];
+    if (!item) return;
+
+    const uuid = item.videoUuid || item.clipId;
+    if (uuid && !videoDetails[uuid]) {
+      getVideoDetail(uuid)
+        .then((detail) => {
+          setVideoDetails((prev) => ({
+            ...prev,
+            [uuid]: {
+              playbackUrl: detail.rawPlaybackUrl,
+              thumbnailUrl: detail.thumbnailUrl,
+              caption: detail.caption,
+            },
+          }));
+        })
+        .catch(() => {
+          // Fallback if API call fails
+        });
+    }
+  }, [currentIndex, list, videoDetails]);
+
+  const touchStartY = useRef<number | null>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0]?.clientY ?? null;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartY.current === null) return;
+    const touchEndY = e.changedTouches[0]?.clientY ?? touchStartY.current;
+    const diff = touchStartY.current - touchEndY;
+
+    if (diff > 50 && currentIndex < list.length - 1) {
+      // Swiped Up -> Next Video
+      setCurrentIndex((prev) => prev + 1);
+    } else if (diff < -50 && currentIndex > 0) {
+      // Swiped Down -> Prev Video
+      setCurrentIndex((prev) => prev - 1);
+    }
+    touchStartY.current = null;
+  };
+
+  const activeUuid = currentItem.videoUuid || currentItem.clipId;
+  const currentDetail = videoDetails[activeUuid];
+  const playbackUrl = currentItem.rawPlaybackUrl || currentDetail?.playbackUrl;
+  const coverSrc =
+    currentItem.thumbnailUrl ||
+    currentDetail?.thumbnailUrl ||
+    "/plip/v13/runner-preview.png";
+
+  const togglePlay = useCallback(() => {
+    if (videoRef.current) {
+      if (isPlaying) {
+        videoRef.current.pause();
+      } else {
+        videoRef.current.play().catch(() => {});
+      }
+      setIsPlaying(!isPlaying);
+    }
+  }, [isPlaying]);
+
+  return (
+    <section
+      className="relative flex h-full w-full flex-1 flex-col overflow-hidden bg-[#09080f] select-none"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      aria-label="개별 영상 풀페이지 뷰어"
+    >
+      {/* Background Media / Video Player */}
+      {playbackUrl ? (
+        <video
+          ref={videoRef}
+          src={playbackUrl}
+          poster={coverSrc}
+          autoPlay
+          loop
+          playsInline
+          className="absolute inset-0 h-full w-full object-cover"
+          onClick={togglePlay}
+        />
+      ) : (
+        <Image
+          src={coverSrc}
+          alt={currentItem.title || "비디오 썸네일"}
+          fill
+          className="object-cover"
+          priority
+          sizes="100vw"
+          onClick={togglePlay}
+        />
+      )}
+
+      <div className="pointer-events-none absolute inset-0 bg-black/20" aria-hidden />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/80" />
+
+      {/* Header Overlay */}
+      <ScreenHeader
+        tone="overlay"
+        leading={
+          <HeaderBackLink
+            href="#"
+            label="닫기"
+            onClick={(e) => {
+              e.preventDefault();
+              if (onClose) onClose();
+            }}
+          />
+        }
+        title={currentItem.agitName || "오늘의 영상"}
+        subtitle={currentItem.uploadedAt || "PLIP Clip"}
+        trailing={<HeaderMenuButton label="더보기" onClick={() => setActionsOpen(true)} />}
+      />
+
+      {/* Play/Pause Indicator */}
+      {!isPlaying && (
+        <div
+          className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-black/30"
+          onClick={togglePlay}
+        >
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-black/60 text-white text-2xl">
+            ▶
+          </div>
+        </div>
+      )}
+
+      {/* Side Reaction Actions */}
+      <div
+        className="absolute right-5 bottom-40 z-20 flex flex-col gap-3 rounded-2xl bg-black/30 p-3 text-white text-xs font-medium backdrop-blur-md"
+        aria-label="이모지 리액션"
+      >
+        <span>🔥 12</span>
+        <span>💜 8</span>
+        <span>👏 5</span>
+        <span>＋</span>
+      </div>
+
+      {/* Bottom Info Overlay */}
+      <div className="relative z-10 mt-auto flex flex-col gap-1 px-6 pb-12 text-white">
+        <p className="m-0 text-lg font-bold">{currentItem.title || currentDetail?.caption || "영상 클립"}</p>
+        <p className="m-0 text-sm text-white/80">
+          {currentItem.authorName || "작성자"} · {list.length > 1 ? `${currentIndex + 1} / ${list.length}` : ""}
+        </p>
+      </div>
+
+      <ViewerActionsSheet
+        open={actionsOpen}
+        onClose={() => setActionsOpen(false)}
+        onMoveTopic={() => setMoveOpen(true)}
+      />
+      <MoveTopicSheet open={moveOpen} onClose={() => setMoveOpen(false)} />
+    </section>
+  );
+}

--- a/components/organisms/FullpageVideoViewer.tsx
+++ b/components/organisms/FullpageVideoViewer.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { HeaderBackLink, HeaderMenuButton, ScreenHeader } from "@/components/molecules";
+import { getVideoAction } from "@/actions/videoActions";
+import { HeaderBackButton, HeaderMenuButton, ScreenHeader } from "@/components/molecules";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
 import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
 import type { VideoViewerItem } from "@/components/providers/VideoViewerProvider";
-import { getVideoDetail } from "@/services/videoService";
 import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -44,14 +44,15 @@ export function FullpageVideoViewer({
 
     const uuid = item.videoUuid || item.clipId;
     if (uuid && !videoDetails[uuid]) {
-      getVideoDetail(uuid)
-        .then((detail) => {
+      getVideoAction(uuid)
+        .then((result) => {
+          if (!result.ok) return;
           setVideoDetails((prev) => ({
             ...prev,
             [uuid]: {
-              playbackUrl: detail.rawPlaybackUrl,
-              thumbnailUrl: detail.thumbnailUrl,
-              caption: detail.caption,
+              playbackUrl: result.data.rawPlaybackUrl,
+              thumbnailUrl: result.data.thumbnailUrl ?? undefined,
+              caption: result.data.caption ?? undefined,
             },
           }));
         })
@@ -106,7 +107,7 @@ export function FullpageVideoViewer({
       className="relative flex h-full w-full flex-1 flex-col overflow-hidden bg-[#09080f] select-none"
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
-      aria-label="개별 영상 풀페이지 뷰어"
+      aria-label="개별 영상 뷰어"
     >
       {/* Background Media / Video Player */}
       {playbackUrl ? (
@@ -139,12 +140,10 @@ export function FullpageVideoViewer({
       <ScreenHeader
         tone="overlay"
         leading={
-          <HeaderBackLink
-            href="#"
+          <HeaderBackButton
             label="닫기"
-            onClick={(e) => {
-              e.preventDefault();
-              if (onClose) onClose();
+            onClick={() => {
+              onClose?.();
             }}
           />
         }

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -90,9 +90,9 @@ export function TopicGallerySection({
       clipId: v.id,
       videoUuid: v.id,
       title: v.caption || "토픽 클립",
-      authorName: v.authorNickname,
-      uploadedAt: v.createdAtText,
-      thumbnailUrl: v.thumbnailUrl,
+      authorName: v.profileNickname,
+      uploadedAt: v.uploadedAt,
+      thumbnailUrl: v.thumbnailSrc,
     }));
     openViewer(videoId, formattedList, "agit");
   }

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -67,6 +67,8 @@ export function TopicGallerySection({
     if (Math.abs(dx) < 48) {
       return;
     }
+    skipClick.current = true;
+    goToPage(dx < 0 ? safeIndex + 1 : safeIndex - 1);
   }
 
   function handleClickCapture(event: React.MouseEvent<HTMLElement>) {

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { FullpageVideoViewer } from "@/components/organisms/FullpageVideoViewer";
+import { FullpageViewerTemplate } from "@/components/templates/FullpageViewerTemplate";
+import { useVideoViewer } from "@/components/providers/VideoViewerProvider";
 import { TopicClipPage } from "@/components/molecules/TopicClipPage";
 import { paginateTopicVideos } from "@/lib/topic/paginateTopicVideos";
 import type { UiTopicVideo } from "@/types/topic/ui";
@@ -61,12 +64,9 @@ export function TopicGallerySection({
       return;
     }
     const dx = event.clientX - start.x;
-    const dy = event.clientY - start.y;
-    if (Math.abs(dx) < 48 || Math.abs(dx) < Math.abs(dy) * 1.25) {
+    if (Math.abs(dx) < 48) {
       return;
     }
-    skipClick.current = true;
-    goToPage(dx < 0 ? safeIndex + 1 : safeIndex - 1);
   }
 
   function handleClickCapture(event: React.MouseEvent<HTMLElement>) {
@@ -78,6 +78,23 @@ export function TopicGallerySection({
     event.stopPropagation();
   }
 
+  const { isOpen, activeClipId, videoList, openViewer, closeViewer } = useVideoViewer();
+
+  function handleSelectVideo(videoId: string) {
+    if (onSelectVideo) {
+      onSelectVideo(videoId);
+    }
+    const formattedList = videos.map((v) => ({
+      clipId: v.id,
+      videoUuid: v.id,
+      title: v.caption || "토픽 클립",
+      authorName: v.authorNickname,
+      uploadedAt: v.createdAtText,
+      thumbnailUrl: v.thumbnailUrl,
+    }));
+    openViewer(videoId, formattedList, "agit");
+  }
+
   function renderPage(pageItems: GalleryPageItem[], key: string) {
     const pageVideos = pageItems.filter((item): item is UiTopicVideo => !isCaptureSlot(item));
     return (
@@ -86,7 +103,7 @@ export function TopicGallerySection({
         videos={pageVideos}
         captureHref={captureHref}
         showCaptureSlot={pageItems.some(isCaptureSlot)}
-        onSelectVideo={onSelectVideo}
+        onSelectVideo={handleSelectVideo}
       />
     );
   }
@@ -140,6 +157,16 @@ export function TopicGallerySection({
           />
         </>
       ) : null}
+
+      {isOpen && activeClipId && (
+        <FullpageViewerTemplate isOpen={isOpen} onClose={closeViewer}>
+          <FullpageVideoViewer
+            initialClipId={activeClipId}
+            videoList={videoList}
+            onClose={closeViewer}
+          />
+        </FullpageViewerTemplate>
+      )}
     </section>
   );
 }

--- a/components/providers/VideoViewerProvider.tsx
+++ b/components/providers/VideoViewerProvider.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+export type VideoViewerItem = {
+  clipId: string;
+  videoUuid?: string;
+  title?: string;
+  authorName?: string;
+  uploadedAt?: string;
+  thumbnailUrl?: string;
+  rawPlaybackUrl?: string;
+  agitName?: string;
+};
+
+type VideoViewerContextType = {
+  isOpen: boolean;
+  activeClipId: string | null;
+  videoList: VideoViewerItem[];
+  sourceContext?: "agit" | "diary" | "direct";
+  openViewer: (clipId: string, list?: VideoViewerItem[], source?: "agit" | "diary" | "direct") => void;
+  closeViewer: () => void;
+};
+
+const VideoViewerContext = createContext<VideoViewerContextType | null>(null);
+
+export function VideoViewerProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeClipId, setActiveClipId] = useState<string | null>(null);
+  const [videoList, setVideoList] = useState<VideoViewerItem[]>([]);
+  const [sourceContext, setSourceContext] = useState<"agit" | "diary" | "direct">("direct");
+
+  const openViewer = (
+    clipId: string,
+    list: VideoViewerItem[] = [],
+    source: "agit" | "diary" | "direct" = "direct"
+  ) => {
+    setActiveClipId(clipId);
+    setVideoList(list.length > 0 ? list : [{ clipId }]);
+    setSourceContext(source);
+    setIsOpen(true);
+  };
+
+  const closeViewer = () => {
+    setIsOpen(false);
+    setActiveClipId(null);
+  };
+
+  return (
+    <VideoViewerContext.Provider
+      value={{
+        isOpen,
+        activeClipId,
+        videoList,
+        sourceContext,
+        openViewer,
+        closeViewer,
+      }}
+    >
+      {children}
+    </VideoViewerContext.Provider>
+  );
+}
+
+export function useVideoViewer() {
+  const context = useContext(VideoViewerContext);
+  if (!context) {
+    throw new Error("useVideoViewer must be used within a VideoViewerProvider");
+  }
+  return context;
+}

--- a/components/templates/DiaryTemplate.tsx
+++ b/components/templates/DiaryTemplate.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { FullpageVideoViewer } from "@/components/organisms/FullpageVideoViewer";
+import { FullpageViewerTemplate } from "@/components/templates/FullpageViewerTemplate";
+import { useVideoViewer } from "@/components/providers/VideoViewerProvider";
 import { BottomNavigation } from "@/components/molecules";
 import type { ReactNode } from "react";
 
@@ -8,6 +13,8 @@ type DiaryTemplateProps = {
 };
 
 export function DiaryTemplate({ children, fixedMain = false }: DiaryTemplateProps) {
+  const { isOpen, activeClipId, videoList, closeViewer } = useVideoViewer();
+
   return (
     <div className="relative mx-auto flex h-full min-h-0 w-full max-w-full flex-col overflow-hidden bg-[var(--dc-page-bg)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dc-fg-primary)]">
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden pb-[80px]">
@@ -22,6 +29,16 @@ export function DiaryTemplate({ children, fixedMain = false }: DiaryTemplateProp
         </main>
       </div>
       <BottomNavigation active="diary" variant="light" />
+
+      {isOpen && activeClipId && (
+        <FullpageViewerTemplate isOpen={isOpen} onClose={closeViewer}>
+          <FullpageVideoViewer
+            initialClipId={activeClipId}
+            videoList={videoList}
+            onClose={closeViewer}
+          />
+        </FullpageViewerTemplate>
+      )}
     </div>
   );
 }

--- a/components/templates/FullpageViewerTemplate.tsx
+++ b/components/templates/FullpageViewerTemplate.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+type FullpageViewerTemplateProps = {
+  children: ReactNode;
+  isOpen?: boolean;
+  onClose?: () => void;
+  isStandalone?: boolean;
+};
+
+export function FullpageViewerTemplate({
+  children,
+  isOpen = true,
+  onClose,
+  isStandalone = false,
+}: FullpageViewerTemplateProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && onClose) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const content = (
+    <div
+      className={`fixed inset-0 z-[9999] flex flex-col bg-[#09080f] text-white font-[family-name:var(--font-inter),sans-serif] ${
+        isStandalone ? "relative h-full w-full" : ""
+      }`}
+    >
+      {children}
+    </div>
+  );
+
+  if (isStandalone || typeof window === "undefined") {
+    return content;
+  }
+
+  return createPortal(content, document.body);
+}

--- a/components/templates/FullpageViewerTemplate.tsx
+++ b/components/templates/FullpageViewerTemplate.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useOverlayPortalHost } from "@/components/molecules/AnimatedOverlays";
 import { useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
@@ -10,12 +11,18 @@ type FullpageViewerTemplateProps = {
   isStandalone?: boolean;
 };
 
+/**
+ * 브라우저 전체 fixed가 아니라, 앱/데스크톱 프레임 안에서
+ * 다른 UI(하단 탭 포함)를 덮는 오버레이.
+ */
 export function FullpageViewerTemplate({
   children,
   isOpen = true,
   onClose,
   isStandalone = false,
 }: FullpageViewerTemplateProps) {
+  const host = useOverlayPortalHost();
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -31,19 +38,28 @@ export function FullpageViewerTemplate({
 
   if (!isOpen) return null;
 
+  if (isStandalone) {
+    return (
+      <div className="relative flex h-full w-full flex-col bg-[#09080f] text-white font-[family-name:var(--font-inter),sans-serif]">
+        {children}
+      </div>
+    );
+  }
+
   const content = (
     <div
-      className={`fixed inset-0 z-[9999] flex flex-col bg-[#09080f] text-white font-[family-name:var(--font-inter),sans-serif] ${
-        isStandalone ? "relative h-full w-full" : ""
-      }`}
+      className="pointer-events-auto absolute inset-0 z-[50] flex flex-col bg-[#09080f] text-white font-[family-name:var(--font-inter),sans-serif]"
+      role="dialog"
+      aria-modal
+      aria-label="영상 뷰어"
     >
       {children}
     </div>
   );
 
-  if (isStandalone || typeof window === "undefined") {
-    return content;
+  if (host) {
+    return createPortal(content, host);
   }
 
-  return createPortal(content, document.body);
+  return content;
 }

--- a/components/templates/ViewerTemplates.tsx
+++ b/components/templates/ViewerTemplates.tsx
@@ -1,11 +1,13 @@
 import { ClipViewerSection } from "@/components/organisms/ClipViewerSection";
+import { FullpageVideoViewer } from "@/components/organisms/FullpageVideoViewer";
+import { FullpageViewerTemplate } from "@/components/templates/FullpageViewerTemplate";
 import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 
 export function ClipViewerTemplate({ clipId }: { clipId: string }) {
   return (
-    <AppChromeTemplate showNav={false} variant="feed" className="bg-[var(--plip-feed-bg)] text-[var(--plip-feed-text)]">
-      <ClipViewerSection clipId={clipId} mode="view" />
-    </AppChromeTemplate>
+    <FullpageViewerTemplate isOpen isStandalone>
+      <FullpageVideoViewer initialClipId={clipId} videoList={[{ clipId }]} isStandalone />
+    </FullpageViewerTemplate>
   );
 }
 

--- a/lib/api/authApi.ts
+++ b/lib/api/authApi.ts
@@ -117,6 +117,7 @@ export async function postRestoreAccount(
     method: "POST",
     baseUrl: getApiUrl(),
     body,
+    auth: false,
     headers: buildAuthHeaders(options.bearerToken),
   });
 }

--- a/lib/api/withAuthRetry.ts
+++ b/lib/api/withAuthRetry.ts
@@ -24,6 +24,10 @@ export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
       throw error;
     }
 
+    if (typeof window !== "undefined") {
+      throw error;
+    }
+
     const jwt = await getServerAuthJwt();
     const refreshToken = jwt?.refreshToken;
     if (typeof refreshToken !== "string" || !refreshToken) {

--- a/lib/api/withAuthRetry.ts
+++ b/lib/api/withAuthRetry.ts
@@ -5,7 +5,6 @@ import {
   getRequestAccessTokenOverride,
   setRequestAccessTokenOverride,
 } from "@/lib/auth/request-token-cache";
-import { getServerAuthJwt } from "@/lib/auth/server-token";
 import * as authService from "@/services/authService";
 
 export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
@@ -28,6 +27,7 @@ export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
       throw error;
     }
 
+    const { getServerAuthJwt } = await import("@/lib/auth/server-token");
     const jwt = await getServerAuthJwt();
     const refreshToken = jwt?.refreshToken;
     if (typeof refreshToken !== "string" || !refreshToken) {

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -3,6 +3,10 @@ import { headers } from "next/headers";
 import { getToken } from "next-auth/jwt";
 
 export async function getServerAuthJwt() {
+  if (typeof window !== "undefined") {
+    return null;
+  }
+
   const headerStore = await headers();
   const cookie = headerStore.get("cookie") ?? "";
 


### PR DESCRIPTION
## 작업 내용

아지트·다이어리에서 쇼츠/틱톡 스타일로 영상을 이어 볼 수 있는 풀페이지(프레임 내 오버레이) 비디오 뷰어를 추가했습니다.  
뷰어는 브라우저 전체가 아니라 데스크톱 기기 프레임·앱 셸 안에서 하단 탭까지 덮도록 했고, Client Component가 `next/headers`/`server-token`을 끌어오지 않도록 Server Action·동적 import로 경계를 맞췄습니다.

## 관련 이슈

Close #104

## 변경 사항

### 1. 비디오 뷰어 전역 Context 및 오버레이 템플릿

- **파일:** `components/providers/VideoViewerProvider.tsx`, `components/templates/FullpageViewerTemplate.tsx`, `app/layout.tsx`, `components/molecules/AnimatedOverlays.tsx`
- **설명:** 전역으로 뷰어 open/close·클립 리스트를 관리하고, `document.body` fixed 대신 기기 프레임 `plip-overlay-root`로 포탈해 데스크톱은 프레임 안만 채웁니다.

```tsx
// components/templates/FullpageViewerTemplate.tsx
const host = useOverlayPortalHost();
const content = (
  <div
    className="pointer-events-auto absolute inset-0 z-[50] flex flex-col bg-[#09080f] ..."
    role="dialog"
    aria-modal
  >
    {children}
  </div>
);
if (host) {
  return createPortal(content, host);
}
```

### 2. Vertical Swiper 스타일 풀페이지 뷰어 UI

- **파일:** `components/organisms/FullpageVideoViewer.tsx`
- **설명:** 상·하 스와이프로 클립 이동, 재생/일시정지, 헤더·리액션·액션 시트를 포함한 뷰어 UI를 구현하고, 상세 조회는 `getVideoAction` Server Action으로 호출합니다.

```tsx
// components/organisms/FullpageVideoViewer.tsx
getVideoAction(uuid).then((result) => {
  if (!result.ok) return;
  setVideoDetails((prev) => ({
    ...prev,
    [uuid]: {
      playbackUrl: result.data.rawPlaybackUrl,
      thumbnailUrl: result.data.thumbnailUrl ?? undefined,
      caption: result.data.caption ?? undefined,
    },
  }));
});
```

### 3. 아지트 갤러리·다이어리 화면 연동

- **파일:** `components/organisms/TopicGallerySection.tsx`, `components/templates/DiaryTemplate.tsx`, `components/templates/ViewerTemplates.tsx`
- **설명:** 갤러리/다이어리에서 클립 선택 시 뷰어를 열고, 단독 `/viewer` 라우트도 동일 컴포넌트를 사용하도록 연결했습니다. `UiTopicVideo` 필드(`profileNickname`, `uploadedAt`, `thumbnailSrc`) 매핑을 맞췄습니다.

### 4. Client Bundle에서 `next/headers` 격리

- **파일:** `lib/api/withAuthRetry.ts`, `lib/auth/server-token.ts`
- **설명:** 클라이언트에서는 401 reissue를 시도하지 않고, 서버에서만 `server-token`을 동적 import해 Turbopack Build Error를 방지합니다.

```ts
// lib/api/withAuthRetry.ts
if (typeof window !== "undefined") {
  throw error;
}
const { getServerAuthJwt } = await import("@/lib/auth/server-token");
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)
  - [ ] 아지트 갤러리에서 클립 탭 → 프레임 안 뷰어, 하단 탭 가림
  - [ ] 데스크톱: 바깥 회색 배경은 유지, 폰 프레임만 풀
  - [ ] Escape/닫기로 뷰어 종료
  - [ ] `/login` 등에서 `next/headers` Build Error 없음

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
