### PR TITLE
[#114] Feature: 아지트 최근 토픽 자동 탐색 Fallback 및 빈 피드 커버 UI 구현

### DIFF
--- a/components/organisms/AgitDetailSection.tsx
+++ b/components/organisms/AgitDetailSection.tsx
@@ -19,17 +19,17 @@ type AgitDetailSectionProps = {
 function formatTopicMeta(gallery: UiTopicGallery): string {
   const topic = gallery.topic;
   if (!topic) {
-    return "아직 토픽이 없습니다";
+    return "아직 토픽이 없어요";
   }
 
   const parsed = new Date(topic.startAt);
   const date = Number.isNaN(parsed.getTime())
     ? ""
     : new Intl.DateTimeFormat("ko-KR", {
-        timeZone: "Asia/Seoul",
-        month: "long",
-        day: "numeric",
-      }).format(parsed);
+      timeZone: "Asia/Seoul",
+      month: "long",
+      day: "numeric",
+    }).format(parsed);
   const title = topic.title ? `#${topic.title}` : "";
   const count = `${gallery.videos.length}개 영상`;
   return [date, title, count].filter(Boolean).join(" · ");

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -167,7 +167,7 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
           backHref={backHref}
           title={current.title || "제목 없음"}
           videoCount={videoCount}
-          onMenuClick={() => setActionsOpen(true)}
+          onMenuClick={() => setMenuOpen(true)}
         />
         <div
           ref={scrollerRef}
@@ -197,6 +197,9 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
         </div>
       </div>
 
+      {resolvedAgit && (
+        <AgitMenuDrawer agit={resolvedAgit} open={menuOpen} onClose={() => setMenuOpen(false)} />
+      )}
       <ViewerActionsSheet
         open={actionsOpen}
         onClose={() => setActionsOpen(false)}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -37,13 +37,21 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
   const [menuOpen, setMenuOpen] = useState(false);
 
   const [topics, setTopics] = useState(initialWindow.topics);
-  const [index, setIndex] = useState(() => {
-    const found = initialWindow.topics.findIndex((topic) => topic.id === initialWindow.currentId);
-    return found >= 0 ? found : 0;
-  });
   const [videosByTopic, setVideosByTopic] = useState<Record<string, UiTopicVideo[]>>(initialVideos);
   const [hasMoreBefore, setHasMoreBefore] = useState(initialWindow.hasMoreBefore);
   const [hasMoreAfter, setHasMoreAfter] = useState(initialWindow.hasMoreAfter);
+
+  // 오늘 진행 중인 토픽 존재 여부 확인
+  const hasActiveTopic = topics.some((t) => isSameKstDate(t.startDate, new Date()));
+  const showCoverSlide = !hasActiveTopic && topics.length > 0;
+
+  const [index, setIndex] = useState(() => {
+    if (showCoverSlide) {
+      return 0; // 진행 중인 토픽이 없을 때는 무조건 0 (커버 화면)에서 시작!
+    }
+    const found = initialWindow.topics.findIndex((topic) => topic.id === initialWindow.currentId);
+    return found >= 0 ? found : 0;
+  });
 
   const topicsRef = useRef(topics);
   const indexRef = useRef(index);
@@ -71,10 +79,6 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
 
   const resolvedAgit = agit ?? getAgitById(agitId) ?? null;
   const backHref = ROUTES.agit.topics(agitId);
-
-  // 오늘 진행 중인 토픽 존재 여부 확인
-  const hasActiveTopic = topics.some((t) => isSameKstDate(t.startDate, new Date()));
-  const showCoverSlide = !hasActiveTopic && topics.length > 0;
 
   const loadVideosAround = useCallback(
     async (list: UiTopicDetail[], center: number) => {

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getTopicVideosAction } from "@/actions/topicActions";
+import { DailyIcon } from "@/components/atoms";
 import { HeaderBackLink, HeaderMenuButton, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
@@ -8,7 +9,7 @@ import { TopicGallerySection } from "@/components/organisms/TopicGallerySection"
 import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
-import { shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgitTopic";
+import { isSameKstDate, shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgitTopic";
 import { extractDate } from "@/lib/video/formatOverlayClock";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicDetail, UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
@@ -68,9 +69,12 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
     return () => window.removeEventListener("resize", updateHeight);
   }, []);
 
-  const current = topics[index];
-  const backHref = ROUTES.agit.topics(agitId);
   const resolvedAgit = agit ?? getAgitById(agitId) ?? null;
+  const backHref = ROUTES.agit.topics(agitId);
+
+  // 오늘 진행 중인 토픽 존재 여부 확인
+  const hasActiveTopic = topics.some((t) => isSameKstDate(t.startDate, new Date()));
+  const showCoverSlide = !hasActiveTopic && topics.length > 0;
 
   const loadVideosAround = useCallback(
     async (list: UiTopicDetail[], center: number) => {
@@ -104,9 +108,9 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
 
   const prefetchNearEdge = useCallback(() => {
     const list = topicsRef.current;
-    const currentIndex = indexRef.current;
+    const currentIndex = showCoverSlide ? Math.max(0, indexRef.current - 1) : indexRef.current;
     loadVideosAround(list, currentIndex);
-  }, [loadVideosAround]);
+  }, [loadVideosAround, showCoverSlide]);
 
   function handleScroll() {
     const el = scrollerRef.current;
@@ -114,13 +118,14 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
     const h = el.clientHeight;
     if (h <= 0) return;
     const newIndex = Math.round(el.scrollTop / h);
-    if (newIndex !== indexRef.current && newIndex >= 0 && newIndex < topicsRef.current.length) {
+    if (newIndex !== indexRef.current && newIndex >= 0) {
       setIndex(newIndex);
     }
     prefetchNearEdge();
   }
 
-  if (!current) {
+  // 토픽이 아예 0개인 경우
+  if (topics.length === 0) {
     return (
       <>
         <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dl-color-bg-surface-default)]">
@@ -157,30 +162,87 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
     );
   }
 
-  const loadedVideos = videosByTopic[current.id];
-  const videoCount = loadedVideos && loadedVideos.length > 0 ? loadedVideos.length : current.videoCount;
+  // 진행 중 토픽 부재 시 커버 슬라이드 포함 피드 목록 계산
+  const effectiveIndex = showCoverSlide ? Math.max(0, index - 1) : index;
+  const currentTopic = topics[effectiveIndex] ?? topics[0];
+  const isAtCoverSlide = showCoverSlide && index === 0;
+
+  const loadedVideos = videosByTopic[currentTopic.id];
+  const videoCount = loadedVideos && loadedVideos.length > 0 ? loadedVideos.length : currentTopic.videoCount;
 
   return (
     <>
       <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-        <TopicFeedPillHeader
-          backHref={backHref}
-          title={current.title || "제목 없음"}
-          videoCount={videoCount}
-          onMenuClick={() => setMenuOpen(true)}
-        />
+        {/* 상단 헤더: 커버 슬라이드 일 때는 ScreenHeader, 피드 진입 시 TopicFeedPillHeader로 동적 전환 */}
+        {isAtCoverSlide ? (
+          <ScreenHeader
+            leading={<HeaderBackLink href={ROUTES.agit.root} />}
+            title={resolvedAgit?.name || "아지트"}
+            subtitle="오늘 진행 중인 토픽 없음"
+            trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
+          />
+        ) : (
+          <TopicFeedPillHeader
+            backHref={backHref}
+            title={currentTopic.title || "제목 없음"}
+            videoCount={videoCount}
+            onMenuClick={() => setMenuOpen(true)}
+          />
+        )}
+
         <div
           ref={scrollerRef}
           onScroll={handleScroll}
           className="min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
+          {/* 커버 슬라이드 (진행 중인 토픽이 없을 때 슬라이드 0) */}
+          {showCoverSlide && (
+            <div
+              className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 text-center bg-[var(--dl-color-bg-surface-default)]"
+              style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
+            >
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4 text-2xl">
+                💬
+              </div>
+              <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
+                오늘 진행 중인 토픽이 없습니다.
+              </p>
+              <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
+                새로운 토픽을 생성하거나, 아래로 끌어 이전 기록을 확인하세요.
+              </p>
+              <button
+                type="button"
+                onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
+                className="flex items-center justify-center rounded-xl bg-[#09080f] px-5 py-3 text-sm font-semibold text-white transition-opacity active:opacity-80 shadow-md"
+              >
+                ＋ 토픽 생성하기
+              </button>
+
+              {/* 아래로 끌어서 피드 시작하도록 안내하는 바운스 화살표 힌트 */}
+              <button
+                type="button"
+                onClick={() => {
+                  scrollerRef.current?.scrollTo({
+                    top: viewportHeight > 0 ? viewportHeight : 500,
+                    behavior: "smooth",
+                  });
+                }}
+                className="mt-8 flex flex-col items-center gap-1.5 text-xs font-semibold text-[var(--dl-color-text-secondary)] animate-bounce cursor-pointer border-0 bg-transparent"
+              >
+                <span>이전 기록 피드 보기</span>
+                <DailyIcon name="chevronLeft" size={16} className="-rotate-90 brightness-0 opacity-60" />
+              </button>
+            </div>
+          )}
+
+          {/* 과거/진행 토픽 피드 슬라이드 목록 */}
           {topics.map((topic, topicIndex) => (
             <div
               key={topic.id}
               className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col"
               style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
             >
-              {Math.abs(topicIndex - index) <= 1 ? (
+              {Math.abs(topicIndex - effectiveIndex) <= 1 ? (
                 <TopicGallerySection
                   videos={videosByTopic[topic.id] ?? EMPTY_TOPIC_VIDEOS}
                   captureHref={ROUTES.capture.videoWith({ agitUuid: agitId, topicUuid: topic.id })}
@@ -190,11 +252,15 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
             </div>
           ))}
         </div>
-        <div className="pointer-events-none absolute bottom-4 right-4 z-30 flex items-center">
-          <span className="text-xs font-medium text-white/80 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
-            {extractDate(current.startDate)}
-          </span>
-        </div>
+
+        {/* 피드 슬라이드 노출 시 하단 우측 고정 날짜 */}
+        {!isAtCoverSlide && (
+          <div className="pointer-events-none absolute bottom-4 right-4 z-30 flex items-center">
+            <span className="text-xs font-medium text-white/80 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+              {extractDate(currentTopic.startDate)}
+            </span>
+          </div>
+        )}
       </div>
 
       {resolvedAgit && (

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getTopicVideosAction } from "@/actions/topicActions";
-import { HeaderBackLink, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
+import { TopicFeedPillHeader } from "@/components/molecules";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
 import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
 import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
@@ -12,7 +12,6 @@ import type { UiTopicDetail, UiTopicFeedWindow, UiTopicVideo } from "@/types/top
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const NEIGHBOR_LIMIT = 3;
 const EMPTY_TOPIC_VIDEOS: UiTopicVideo[] = [];
 
 type TopicFeedSectionProps = {
@@ -117,14 +116,41 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
 
   if (!current) {
     return (
-      <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-        <ScreenHeader leading={<HeaderBackLink href={backHref} />} title="토픽" />
-        <div className="min-h-0 flex-1 px-[23px] pb-6">
-          <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">
-            피드에 보여줄 토픽이 없습니다.
-          </p>
+      <>
+        <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dl-color-bg-surface-default)]">
+          <TopicFeedPillHeader
+            backHref={backHref}
+            title="토픽 피드"
+            videoCount={0}
+            onMenuClick={() => setActionsOpen(true)}
+          />
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center p-6 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4 text-2xl">
+              💬
+            </div>
+            <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
+              등록된 토픽이 없습니다.
+            </p>
+            <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
+              새로운 토픽을 생성하고 영상 기록을 시작해 보세요.
+            </p>
+            <button
+              type="button"
+              onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
+              className="flex items-center justify-center rounded-xl bg-[#09080f] px-5 py-3 text-sm font-semibold text-white transition-opacity active:opacity-80 shadow-md"
+            >
+              ＋ 토픽 생성하기
+            </button>
+          </div>
         </div>
-      </div>
+
+        <ViewerActionsSheet
+          open={actionsOpen}
+          onClose={() => setActionsOpen(false)}
+          onMoveTopic={() => setMoveOpen(true)}
+        />
+        <MoveTopicSheet open={moveOpen} onClose={() => setMoveOpen(false)} />
+      </>
     );
   }
 

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getTopicVideosAction } from "@/actions/topicActions";
-import { DailyIcon } from "@/components/atoms";
+import { DailyIcon, SubmitButton } from "@/components/atoms";
 import { HeaderBackLink, HeaderMenuButton, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
@@ -149,13 +149,14 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
             <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
               새로운 토픽을 생성하고 영상 기록을 시작해 보세요.
             </p>
-            <button
+            <SubmitButton
               type="button"
+              variant="brand"
+              className="w-auto px-6 py-3 font-semibold shadow-md"
               onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
-              className="flex items-center justify-center rounded-xl bg-[#09080f] px-5 py-3 text-sm font-semibold text-white transition-opacity active:opacity-80 shadow-md"
             >
               ＋ 토픽 생성하기
-            </button>
+            </SubmitButton>
           </div>
         </div>
 
@@ -209,18 +210,19 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
                 💬
               </div>
               <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
-                오늘 진행 중인 토픽이 없습니다.
+                진행 중인 토픽이 없습니다.
               </p>
               <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
                 새로운 토픽을 생성하거나, 아래로 끌어 이전 기록을 확인하세요.
               </p>
-              <button
+              <SubmitButton
                 type="button"
+                variant="brand"
+                className="w-auto px-6 py-3 font-semibold shadow-md"
                 onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
-                className="flex items-center justify-center rounded-xl bg-[#09080f] px-5 py-3 text-sm font-semibold text-white transition-opacity active:opacity-80 shadow-md"
               >
-                ＋ 토픽 생성하기
-              </button>
+                토픽 생성하기
+              </SubmitButton>
 
               {/* 아래로 끌어서 피드 시작하도록 안내하는 바운스 화살표 힌트 */}
               <button

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -25,6 +25,59 @@ type TopicFeedSectionProps = {
   initialVideos: Record<string, UiTopicVideo[]>;
 };
 
+type TopicFeedEmptyCoverProps = {
+  isFullyEmpty: boolean;
+  onTopicCreate: () => void;
+  onScrollToFeed?: () => void;
+  style?: React.CSSProperties;
+};
+
+function TopicFeedEmptyCover({
+  isFullyEmpty,
+  onTopicCreate,
+  onScrollToFeed,
+  style,
+}: TopicFeedEmptyCoverProps) {
+  return (
+    <div
+      className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 text-center bg-[var(--dl-color-bg-surface-default)]"
+      style={style}
+    >
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)]">
+        <DailyIcon name="messageBrand" size={28} />
+      </div>
+      <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
+        {isFullyEmpty ? "등록된 토픽이 없습니다." : "진행 중인 토픽이 없습니다."}
+      </p>
+      <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
+        {isFullyEmpty
+          ? "새로운 토픽을 생성하고 영상 기록을 시작해 보세요."
+          : "새로운 토픽을 생성하거나, 아래로 끌어 이전 기록을 확인하세요."}
+      </p>
+      <SubmitButton
+        type="button"
+        variant="brand"
+        className="flex items-center gap-1.5 w-auto px-6 py-3 font-semibold shadow-md"
+        onClick={onTopicCreate}
+      >
+        <DailyIcon name="plus" size={16} className="brightness-0 invert" />
+        <span>토픽 생성하기</span>
+      </SubmitButton>
+
+      {!isFullyEmpty && onScrollToFeed && (
+        <button
+          type="button"
+          onClick={onScrollToFeed}
+          className="mt-8 flex flex-col items-center gap-1.5 text-xs font-semibold text-[var(--dl-color-text-secondary)] animate-bounce cursor-pointer border-0 bg-transparent"
+        >
+          <span>이전 기록 피드 보기</span>
+          <DailyIcon name="chevronLeft" size={16} className="-rotate-90 brightness-0 opacity-60" />
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }: TopicFeedSectionProps) {
   const router = useRouter();
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -139,26 +192,10 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
             subtitle="아직 토픽이 없습니다"
             trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
           />
-          <div className="flex min-h-0 flex-1 flex-col items-center justify-center p-6 text-center">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4">
-              <DailyIcon name="messageBrand" size={28} />
-            </div>
-            <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
-              등록된 토픽이 없습니다.
-            </p>
-            <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
-              새로운 토픽을 생성하고 영상 기록을 시작해 보세요.
-            </p>
-            <SubmitButton
-              type="button"
-              variant="brand"
-              className="flex items-center gap-1.5 w-auto px-6 py-3 font-semibold shadow-md"
-              onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
-            >
-              <DailyIcon name="plus" size={16} className="brightness-0 invert" />
-              <span>토픽 생성하기</span>
-            </SubmitButton>
-          </div>
+          <TopicFeedEmptyCover
+            isFullyEmpty={true}
+            onTopicCreate={() => router.push(ROUTES.agit.topicCreate(agitId))}
+          />
         </div>
 
         {resolvedAgit && (
@@ -203,44 +240,17 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
         >
           {/* 커버 슬라이드 (진행 중인 토픽이 없을 때 슬라이드 0) */}
           {showCoverSlide && (
-            <div
-              className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 text-center bg-[var(--dl-color-bg-surface-default)]"
+            <TopicFeedEmptyCover
+              isFullyEmpty={false}
+              onTopicCreate={() => router.push(ROUTES.agit.topicCreate(agitId))}
+              onScrollToFeed={() => {
+                scrollerRef.current?.scrollTo({
+                  top: viewportHeight > 0 ? viewportHeight : 500,
+                  behavior: "smooth",
+                });
+              }}
               style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
-            >
-              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4">
-                <DailyIcon name="messageBrand" size={28} />
-              </div>
-              <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
-                진행 중인 토픽이 없습니다.
-              </p>
-              <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
-                새로운 토픽을 생성하거나, 아래로 끌어 이전 기록을 확인하세요.
-              </p>
-              <SubmitButton
-                type="button"
-                variant="brand"
-                className="flex items-center gap-1.5 w-auto px-6 py-3 font-semibold shadow-md"
-                onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
-              >
-                <DailyIcon name="plus" size={16} className="brightness-0 invert" />
-                <span>토픽 생성하기</span>
-              </SubmitButton>
-
-              {/* 아래로 끌어서 피드 시작하도록 안내하는 바운스 화살표 힌트 */}
-              <button
-                type="button"
-                onClick={() => {
-                  scrollerRef.current?.scrollTo({
-                    top: viewportHeight > 0 ? viewportHeight : 500,
-                    behavior: "smooth",
-                  });
-                }}
-                className="mt-8 flex flex-col items-center gap-1.5 text-xs font-semibold text-[var(--dl-color-text-secondary)] animate-bounce cursor-pointer border-0 bg-transparent"
-              >
-                <span>이전 기록 피드 보기</span>
-                <DailyIcon name="chevronLeft" size={16} className="-rotate-90 brightness-0 opacity-60" />
-              </button>
-            </div>
+            />
           )}
 
           {/* 과거/진행 토픽 피드 슬라이드 목록 */}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { getTopicVideosAction } from "@/actions/topicActions";
-import { TopicFeedPillHeader } from "@/components/molecules";
+import { HeaderBackLink, HeaderMenuButton, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
+import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
 import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
 import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
+import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import { shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgitTopic";
 import { extractDate } from "@/lib/video/formatOverlayClock";
+import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicDetail, UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -16,11 +19,12 @@ const EMPTY_TOPIC_VIDEOS: UiTopicVideo[] = [];
 
 type TopicFeedSectionProps = {
   agitId: string;
+  agit?: UiAgit | null;
   initialWindow: UiTopicFeedWindow;
   initialVideos: Record<string, UiTopicVideo[]>;
 };
 
-export function TopicFeedSection({ agitId, initialWindow, initialVideos }: TopicFeedSectionProps) {
+export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }: TopicFeedSectionProps) {
   const router = useRouter();
   const scrollerRef = useRef<HTMLDivElement>(null);
   const loadingVideoIds = useRef(new Set<string>());
@@ -29,6 +33,7 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
 
   const [actionsOpen, setActionsOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const [topics, setTopics] = useState(initialWindow.topics);
   const [index, setIndex] = useState(() => {
@@ -65,6 +70,7 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
 
   const current = topics[index];
   const backHref = ROUTES.agit.topics(agitId);
+  const resolvedAgit = agit ?? getAgitById(agitId) ?? null;
 
   const loadVideosAround = useCallback(
     async (list: UiTopicDetail[], center: number) => {
@@ -118,11 +124,11 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
     return (
       <>
         <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dl-color-bg-surface-default)]">
-          <TopicFeedPillHeader
-            backHref={backHref}
-            title="토픽 피드"
-            videoCount={0}
-            onMenuClick={() => setActionsOpen(true)}
+          <ScreenHeader
+            leading={<HeaderBackLink href={ROUTES.agit.root} />}
+            title={resolvedAgit?.name || "아지트"}
+            subtitle="아직 토픽이 없습니다"
+            trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
           />
           <div className="flex min-h-0 flex-1 flex-col items-center justify-center p-6 text-center">
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4 text-2xl">
@@ -144,12 +150,9 @@ export function TopicFeedSection({ agitId, initialWindow, initialVideos }: Topic
           </div>
         </div>
 
-        <ViewerActionsSheet
-          open={actionsOpen}
-          onClose={() => setActionsOpen(false)}
-          onMoveTopic={() => setMoveOpen(true)}
-        />
-        <MoveTopicSheet open={moveOpen} onClose={() => setMoveOpen(false)} />
+        {resolvedAgit && (
+          <AgitMenuDrawer agit={resolvedAgit} open={menuOpen} onClose={() => setMenuOpen(false)} />
+        )}
       </>
     );
   }

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -140,8 +140,8 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
             trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
           />
           <div className="flex min-h-0 flex-1 flex-col items-center justify-center p-6 text-center">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4 text-2xl">
-              💬
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4">
+              <DailyIcon name="messageBrand" size={28} />
             </div>
             <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
               등록된 토픽이 없습니다.
@@ -206,8 +206,8 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
               className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 text-center bg-[var(--dl-color-bg-surface-default)]"
               style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
             >
-              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4 text-2xl">
-                💬
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)] mb-4">
+                <DailyIcon name="messageBrand" size={28} />
               </div>
               <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
                 진행 중인 토픽이 없습니다.
@@ -221,7 +221,7 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
                 className="w-auto px-6 py-3 font-semibold shadow-md"
                 onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
               >
-                토픽 생성하기
+                ＋ 토픽 생성하기
               </SubmitButton>
 
               {/* 아래로 끌어서 피드 시작하도록 안내하는 바운스 화살표 힌트 */}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -46,7 +46,7 @@ function TopicFeedEmptyCover({
       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)]">
         <DailyIcon name="messageBrand" size={28} />
       </div>
-      <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
+      <p className="m-0 mt-4 text-base font-semibold text-[var(--dl-color-text-primary)]">
         {isFullyEmpty ? "등록된 토픽이 없습니다." : "진행 중인 토픽이 없습니다."}
       </p>
       <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
@@ -189,7 +189,6 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
           <ScreenHeader
             leading={<HeaderBackLink href={ROUTES.agit.root} />}
             title={resolvedAgit?.name || "아지트"}
-            subtitle="아직 토픽이 없습니다"
             trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
           />
           <TopicFeedEmptyCover
@@ -221,7 +220,6 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
           <ScreenHeader
             leading={<HeaderBackLink href={ROUTES.agit.root} />}
             title={resolvedAgit?.name || "아지트"}
-            subtitle="오늘 진행 중인 토픽 없음"
             trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
           />
         ) : (

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -152,10 +152,11 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
             <SubmitButton
               type="button"
               variant="brand"
-              className="w-auto px-6 py-3 font-semibold shadow-md"
+              className="flex items-center gap-1.5 w-auto px-6 py-3 font-semibold shadow-md"
               onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
             >
-              ＋ 토픽 생성하기
+              <DailyIcon name="plus" size={16} className="brightness-0 invert" />
+              <span>토픽 생성하기</span>
             </SubmitButton>
           </div>
         </div>
@@ -218,10 +219,11 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
               <SubmitButton
                 type="button"
                 variant="brand"
-                className="w-auto px-6 py-3 font-semibold shadow-md"
+                className="flex items-center gap-1.5 w-auto px-6 py-3 font-semibold shadow-md"
                 onClick={() => router.push(ROUTES.agit.topicCreate(agitId))}
               >
-                ＋ 토픽 생성하기
+                <DailyIcon name="plus" size={16} className="brightness-0 invert" />
+                <span>토픽 생성하기</span>
               </SubmitButton>
 
               {/* 아래로 끌어서 피드 시작하도록 안내하는 바운스 화살표 힌트 */}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -40,7 +40,7 @@ function TopicFeedEmptyCover({
 }: TopicFeedEmptyCoverProps) {
   return (
     <div
-      className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 text-center bg-[var(--dl-color-bg-surface-default)]"
+      className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 pt-16 text-center bg-[var(--dl-color-bg-surface-default)]"
       style={style}
     >
       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)]">
@@ -215,13 +215,15 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
   return (
     <>
       <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-        {/* 상단 헤더: 커버 슬라이드 일 때는 ScreenHeader, 피드 진입 시 TopicFeedPillHeader로 동적 전환 */}
+        {/* 상단 헤더: ScreenHeader와 TopicFeedPillHeader 모두 absolute 오버레이로 상단에 올려서 스크롤러 높이가 변하지 않도록 보장 */}
         {isAtCoverSlide ? (
-          <ScreenHeader
-            leading={<HeaderBackLink href={ROUTES.agit.root} />}
-            title={resolvedAgit?.name || "아지트"}
-            trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
-          />
+          <div className="pointer-events-none absolute top-0 inset-x-0 z-30">
+            <ScreenHeader
+              leading={<HeaderBackLink href={ROUTES.agit.root} />}
+              title={resolvedAgit?.name || "아지트"}
+              trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
+            />
+          </div>
         ) : (
           <TopicFeedPillHeader
             backHref={backHref}
@@ -234,21 +236,22 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
         <div
           ref={scrollerRef}
           onScroll={handleScroll}
-          className="min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="h-full min-h-0 flex-1 snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
           {/* 커버 슬라이드 (진행 중인 토픽이 없을 때 슬라이드 0) */}
           {showCoverSlide && (
-            <TopicFeedEmptyCover
-              isFullyEmpty={false}
-              onTopicCreate={() => router.push(ROUTES.agit.topicCreate(agitId))}
-              onScrollToFeed={() => {
-                scrollerRef.current?.scrollTo({
-                  top: viewportHeight > 0 ? viewportHeight : 500,
-                  behavior: "smooth",
-                });
-              }}
-              style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
-            />
+            <div className="h-full w-full shrink-0 snap-start snap-always">
+              <TopicFeedEmptyCover
+                isFullyEmpty={false}
+                onTopicCreate={() => router.push(ROUTES.agit.topicCreate(agitId))}
+                onScrollToFeed={() => {
+                  scrollerRef.current?.scrollTo({
+                    top: scrollerRef.current?.clientHeight || 500,
+                    behavior: "smooth",
+                  });
+                }}
+              />
+            </div>
           )}
 
           {/* 과거/진행 토픽 피드 슬라이드 목록 */}
@@ -256,7 +259,6 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
             <div
               key={topic.id}
               className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col"
-              style={{ height: viewportHeight > 0 ? viewportHeight : "100%" }}
             >
               {Math.abs(topicIndex - effectiveIndex) <= 1 ? (
                 <TopicGallerySection

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -134,43 +134,42 @@ export function TopicsLayoutSection({
                       (Boolean(currentUserUuid) && topic.creatorUuid === currentUserUuid);
 
                     return (
-                    <ManageListRow
-                      key={topic.id}
-                      title={
-                        <TextLink
-                          href={ROUTES.agit.topicFeed(agitId, topic.id)}
-                          className="flex min-w-0 flex-col gap-[2px] !text-inherit !no-underline"
-                        >
-                          <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
-                            {topic.title || "제목 없음"}
-                          </p>
-                          <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
-                            {topic.startAtLabel}
-                          </p>
-                        </TextLink>
-                      }
-                      trailing={
-                        <div className="flex flex-col items-end gap-1.5">
-                          <span
-                            className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${
-                              topic.videoCount === 0
-                                ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
-                                : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
-                            }`}
+                      <ManageListRow
+                        key={topic.id}
+                        title={
+                          <TextLink
+                            href={ROUTES.agit.topicFeed(agitId, topic.id)}
+                            className="flex min-w-0 flex-col gap-[2px] !text-inherit !no-underline"
                           >
-                            {topic.videoCount}개 영상
-                          </span>
-                          {canEdit ? (
-                            <TextLink
-                              href={ROUTES.agit.topicEdit(agitId, topic.id)}
-                              className="text-[12px] font-semibold !text-[var(--dl-color-text-brand)] !no-underline"
+                            <p className="m-0 text-sm font-semibold leading-5 text-[var(--dl-color-text-primary)]">
+                              {topic.title || "제목 없음"}
+                            </p>
+                            <p className="m-0 text-xs font-normal leading-[17px] text-[var(--dl-color-text-secondary)]">
+                              {topic.startAtLabel}
+                            </p>
+                          </TextLink>
+                        }
+                        trailing={
+                          <div className="flex flex-col items-end gap-1.5">
+                            <span
+                              className={`inline-flex h-[28px] items-center justify-center rounded-[14px] p-[0_12px] text-xs font-semibold leading-none ${topic.videoCount === 0
+                                  ? "m-dlBadgeSuccess bg-[var(--dl-color-bg-success)] text-[var(--dl-color-text-success)]"
+                                  : "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
+                                }`}
                             >
-                              편집
-                            </TextLink>
-                          ) : null}
-                        </div>
-                      }
-                    />
+                              {topic.videoCount}개 영상
+                            </span>
+                            {canEdit ? (
+                              <TextLink
+                                href={ROUTES.agit.topicEdit(agitId, topic.id)}
+                                className="text-[12px] font-semibold !text-[var(--dl-color-text-brand)] !no-underline"
+                              >
+                                편집
+                              </TextLink>
+                            ) : null}
+                          </div>
+                        }
+                      />
                     );
                   })
                 )}

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -116,6 +116,7 @@ export function TopicFeedTemplate({
     <AppChromeTemplate activeTab="agit" variant="light" mainOverflow="hidden">
       <TopicFeedSection
         agitId={agit.id}
+        agit={agit}
         initialWindow={initialWindow}
         initialVideos={initialVideos}
       />

--- a/lib/topic/selectAgitTopic.ts
+++ b/lib/topic/selectAgitTopic.ts
@@ -10,7 +10,9 @@ export function toKstDateString(value: Date): string {
 }
 
 export function formatKstDotDate(iso: string): string {
-  const parsed = new Date(iso);
+  if (!iso) return "";
+  const normalized = iso.replaceAll(".", "-");
+  const parsed = new Date(normalized);
   if (Number.isNaN(parsed.getTime())) {
     return "";
   }
@@ -18,16 +20,21 @@ export function formatKstDotDate(iso: string): string {
 }
 
 export function isSameKstDate(iso: string, today = new Date()): boolean {
-  const parsed = new Date(iso);
+  if (!iso) return false;
+  const normalized = iso.trim().replaceAll(".", "-");
+  const datePart = normalized.split(/[T\s]+/)[0] ?? normalized;
+  
+  const parsed = new Date(datePart);
   if (Number.isNaN(parsed.getTime())) {
-    return false;
+    const todayStr = toKstDateString(today);
+    return datePart.slice(0, 10) === todayStr;
   }
   return toKstDateString(parsed) === toKstDateString(today);
 }
 
 /** startDate는 KST `YYYY-MM-DD`. 오늘이면 목록 상태 ONGOING과 같다. */
 export function isOngoingStartDate(startDate: string, today = new Date()): boolean {
-  return Boolean(startDate) && startDate === toKstDateString(today);
+  return Boolean(startDate) && isSameKstDate(startDate, today);
 }
 
 export function shouldShowTopicCaptureSlot(topic: {

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -165,13 +165,31 @@ export async function getTopicFeedWindow(params: {
 }): Promise<UiTopicFeedWindow> {
   const before = params.before ?? FEED_NEIGHBOR_LIMIT;
   const after = params.after ?? FEED_NEIGHBOR_LIMIT;
-  const feed = await topicApi.getTopicFeed({
+  let feed = await topicApi.getTopicFeed({
     agitUuid: params.agitUuid,
     topicUuid: params.topicUuid,
     date: params.date,
     before,
     after,
   });
+
+  if (!feed.current) {
+    try {
+      const allTopics = await topicApi.listTopics(params.agitUuid);
+      const selected = selectAgitTopic(allTopics);
+      if (selected) {
+        feed = await topicApi.getTopicFeed({
+          agitUuid: params.agitUuid,
+          topicUuid: selected.topicUuid,
+          before,
+          after,
+        });
+      }
+    } catch {
+      // ignore fallback error
+    }
+  }
+
   if (!feed.current) {
     return { topics: [], currentId: null, hasMoreBefore: false, hasMoreAfter: false };
   }


### PR DESCRIPTION
## 📌 개요
아지트 메인 진입 시 오늘 날짜 기준 토픽이 없더라도 아지트 내에 존재하는 가장 최근 토픽을 자동 탐색하여 피드를 띄워주는 Fallback 시스템을 구축하고, 진행 중인 토픽이 없거나 토픽이 0개인 상황에 대한 커버 화면 및 이전 기록 피드 스크롤 전환 UX를 개선합니다.

---

## 🛠️ 주요 변경 사항

### 1. 최근 토픽 자동 탐색 Fallback 로직 연동 (`services/topicService.ts`)
- 오늘 날짜 기준 토픽 조회가 `current: null`을 돌려줄 때, 아지트 내 존재하는 가장 최근 토픽(`topics[0]`)을 자동으로 찾아 피드를 띄워주는 Fallback 시스템을 연결하여 끊김 없는 피드 진입 보장.

### 2. 진행 중 토픽 부재 시 커버 화면 & 이전 피드 스크롤 전환 (`TopicFeedSection.tsx`)
- 오늘 토픽이 없지만 과거 기록이 있는 경우, 첫 슬라이드(Index 0)로 "진행 중인 토픽이 없습니다" 커버 카드 렌더링.
- 커버 슬라이드 렌더링 시 기존 아지트 헤더(`ScreenHeader`)를 사용하여 뒤로가기(`ROUTES.agit.root`) 및 햄버거 메뉴(`AgitMenuDrawer`) 접근성 통일.
- 하단 바운스 화살표 버튼 또는 아래로 스크롤 제스처 시 부드럽게 과거 피드로 연결되며 상단 헤더가 `TopicFeedPillHeader`로 동적 전환.

### 3. 공통 빈 커버 컴포넌트(`TopicFeedEmptyCover`) 및 UI 정돈
- 토픽 0개 아지트와 진행 중 토픽 부재 아지트의 커버 UI를 `TopicFeedEmptyCover` 공통 서브 컴포넌트로 통합.
- 이모지 ➔ `DailyIcon name="messageBrand"` 및 플러스 기호 ➔ `DailyIcon name="plus"` 프로젝트 아이콘으로 교체.
- 토픽 생성 버튼을 브랜드 디자인 시스템 컬러가 적용된 `SubmitButton` (`variant="brand"`)으로 교체.
- 뷰포트 높이 100% 정밀 핏으로 스크롤러 및 헤더 레이아웃 오차 완전히 조절.

---

## 🔗 관련 이슈
- Close #114
