### PR TITLE
[#116] Feature : 토픽 및 다이어리 개별 뷰어 실데이터 연동 및 스트리밍/동적 뒤로가기 개선

### DIFF
--- a/components/atoms/FeedPill.tsx
+++ b/components/atoms/FeedPill.tsx
@@ -5,10 +5,9 @@ export const feedOverlayGlassClass =
   "border-0 bg-black/40 text-white shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md";
 
 export const feedPillIconButtonClass = cn(
-  "pointer-events-auto flex size-7 items-center justify-center rounded-full bg-transparent text-white shadow-none backdrop-blur-none transition-colors no-underline",
-  "hover:bg-black/40 hover:shadow-[0_4px_16px_rgba(0,0,0,0.16)] hover:backdrop-blur-md",
-  "focus-visible:bg-black/40 focus-visible:shadow-[0_4px_16px_rgba(0,0,0,0.16)] focus-visible:backdrop-blur-md",
-  "active:bg-black/40 active:shadow-[0_4px_16px_rgba(0,0,0,0.16)] active:backdrop-blur-md"
+  "pointer-events-auto flex size-7 items-center justify-center rounded-full text-white cursor-pointer transition-colors no-underline",
+  feedOverlayGlassClass,
+  "hover:bg-black/60 focus-visible:bg-black/60 active:bg-black/70"
 );
 
 type FeedPillProps = Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {

--- a/components/atoms/UserProfileAvatar.tsx
+++ b/components/atoms/UserProfileAvatar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { DailyIcon } from "@/components/atoms/DailyIcon";
+
+type UserProfileAvatarProps = {
+  src?: string | null;
+  nickname?: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+};
+
+const SIZE_CLASSES = {
+  sm: "w-6 h-6 text-xs",
+  md: "w-8 h-8 text-sm",
+  lg: "w-10 h-10 text-base",
+};
+
+const ICON_SIZES = {
+  sm: 14,
+  md: 18,
+  lg: 22,
+};
+
+export function UserProfileAvatar({
+  src,
+  nickname,
+  size = "md",
+  className = "",
+}: UserProfileAvatarProps) {
+  const sizeClass = SIZE_CLASSES[size] ?? SIZE_CLASSES.md;
+  const iconSize = ICON_SIZES[size] ?? ICON_SIZES.md;
+
+  const fallbackChar = nickname ? nickname.trim().charAt(0).toUpperCase() : "";
+
+  if (src && src.trim()) {
+    return (
+      <img
+        src={src}
+        alt={nickname ? `${nickname} 프로필` : "사용자 프로필"}
+        className={`rounded-full object-cover shrink-0 ${sizeClass} ${className}`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`flex items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle,#e5e7eb)] text-[var(--dl-color-text-secondary,#4b5563)] font-semibold shrink-0 select-none ${sizeClass} ${className}`}
+    >
+      {fallbackChar ? (
+        <span>{fallbackChar}</span>
+      ) : (
+        <DailyIcon name="messageBrand" size={iconSize} className="opacity-60" />
+      )}
+    </div>
+  );
+}

--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -35,5 +35,7 @@ export { Switch } from "./Switch";
 export { Text } from "./Text";
 export { TextLink } from "./TextLink";
 export { UserAvatar } from "./UserAvatar";
+export { UserProfileAvatar } from "./UserProfileAvatar";
 export { ThemeChip } from "./ThemeChip";
 export { VideoThumbnail } from "./VideoThumbnail";
+

--- a/components/molecules/ScreenHeader.tsx
+++ b/components/molecules/ScreenHeader.tsx
@@ -50,9 +50,16 @@ function asSubtitle(subtitle: ReactNode, tone: ScreenHeaderTone): ReactNode {
   return subtitle;
 }
 
-export function HeaderBackLink({ href, label = "뒤로" }: { href: string; label?: string }) {
+export function HeaderBackLink({ href, label = "뒤로", onClick }: { href?: string; label?: string; onClick?: () => void }) {
+  if (onClick) {
+    return (
+      <IconButton variant="surface" label={label} onClick={onClick}>
+        <DailyIcon name="chevronLeft" size={20} />
+      </IconButton>
+    );
+  }
   return (
-    <IconLink href={href} label={label}>
+    <IconLink href={href || "#"} label={label}>
       <DailyIcon name="chevronLeft" size={20} />
     </IconLink>
   );

--- a/components/molecules/TopicFeedPillHeader.tsx
+++ b/components/molecules/TopicFeedPillHeader.tsx
@@ -1,23 +1,30 @@
 import { DailyIcon, FeedPill, feedPillIconButtonClass, FeedPillIconButton, IconLink } from "@/components/atoms";
 
 type TopicFeedPillHeaderProps = {
-  backHref: string;
+  backHref?: string;
+  onBack?: () => void;
   title: string;
   videoCount: number;
   onMenuClick?: () => void;
 };
 
-export function TopicFeedPillHeader({ backHref, title, videoCount, onMenuClick }: TopicFeedPillHeaderProps) {
+export function TopicFeedPillHeader({ backHref = "#", onBack, title, videoCount, onMenuClick }: TopicFeedPillHeaderProps) {
   return (
     <>
       <div className="pointer-events-none absolute top-3 left-3 z-30">
-        <IconLink
-          href={backHref}
-          label="뒤로"
-          className={feedPillIconButtonClass}
-        >
-          <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
-        </IconLink>
+        {onBack ? (
+          <FeedPillIconButton label="뒤로" onClick={onBack}>
+            <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+          </FeedPillIconButton>
+        ) : (
+          <IconLink
+            href={backHref}
+            label="뒤로"
+            className={feedPillIconButtonClass}
+          >
+            <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+          </IconLink>
+        )}
       </div>
 
       <div className="pointer-events-none absolute inset-x-0 top-3 z-30 flex justify-center px-14">

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -12,10 +12,22 @@ type TopicVideoTileProps = {
 export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
   const body = (
     <>
-      <VideoClipThumbnail
-        src={video.thumbnailSrc}
-        className="absolute inset-0 size-full object-cover"
-      />
+      {video.rawPlaybackUrl ? (
+        <video
+          src={video.rawPlaybackUrl}
+          poster={video.thumbnailSrc}
+          autoPlay
+          loop
+          muted
+          playsInline
+          className="absolute inset-0 size-full object-cover"
+        />
+      ) : (
+        <VideoClipThumbnail
+          src={video.thumbnailSrc}
+          className="absolute inset-0 size-full object-cover"
+        />
+      )}
       <span
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.28)_0%,transparent_22%,transparent_55%,rgba(0,0,0,0.48)_100%)]"
         aria-hidden

--- a/components/molecules/UserProfileBadge.tsx
+++ b/components/molecules/UserProfileBadge.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { UserProfileAvatar } from "@/components/atoms/UserProfileAvatar";
+
+type UserProfileBadgeProps = {
+  profileUrl?: string | null;
+  nickname?: string | null;
+  subText?: string | null;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  textClassName?: string;
+};
+
+const TEXT_SIZES = {
+  sm: "text-xs",
+  md: "text-sm",
+  lg: "text-base",
+};
+
+export function UserProfileBadge({
+  profileUrl,
+  nickname,
+  subText,
+  size = "md",
+  className = "",
+  textClassName = "",
+}: UserProfileBadgeProps) {
+  const displayName = nickname?.trim() || "알 수 없음";
+  const textSizeClass = TEXT_SIZES[size] ?? TEXT_SIZES.md;
+
+  return (
+    <div className={`inline-flex items-center gap-2 ${className}`}>
+      <UserProfileAvatar src={profileUrl} nickname={displayName} size={size} />
+      <div className="flex flex-col min-w-0 leading-tight">
+        <span
+          className={`font-semibold truncate text-[var(--dl-color-text-primary,#111827)] ${textSizeClass} ${textClassName}`}
+        >
+          {displayName}
+        </span>
+        {subText && (
+          <span className="text-[10px] text-[var(--dl-color-text-secondary,#6b7280)] truncate">
+            {subText}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -75,3 +75,5 @@ export { SocialLoginSection } from "./SocialLoginSection";
 export { SwitchField } from "./SwitchField";
 export { ThemePreviewStrip } from "./ThemePreviewStrip";
 export { VideoThumbnailGrid } from "./VideoThumbnailGrid";
+export { UserProfileBadge } from "./UserProfileBadge";
+

--- a/components/organisms/AgitVideoViewer.tsx
+++ b/components/organisms/AgitVideoViewer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DailyIcon, FeedPill, FeedPillIconButton } from "@/components/atoms";
-import { CaptureClipOverlays, VideoReactionBar } from "@/components/molecules";
+import { CaptureClipOverlays, UserProfileBadge, VideoReactionBar } from "@/components/molecules";
 import { BaseVideoViewer, type BaseVideoViewerOverlayProps } from "@/components/organisms/BaseVideoViewer";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
 import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
@@ -58,11 +58,14 @@ export function AgitVideoViewer({
             {/* 우측 이모지 리액션 바 */}
             <VideoReactionBar />
 
-            {/* 하단 오버레이: 좌측 작성자 / 우측 정규화된 날짜 */}
+            {/* 하단 오버레이: 좌측 작성자 아토믹 뱃지 / 우측 정규화된 날짜 */}
             <div className="relative z-10 mt-auto flex items-end justify-between px-6 pb-12 text-white pointer-events-none">
-              <span className="text-base font-bold truncate max-w-[60%]">
-                {item.authorName || "작성자"}
-              </span>
+              <UserProfileBadge
+                profileUrl={item.authorProfileUrl}
+                nickname={item.authorName || "작성자"}
+                size="sm"
+                textClassName="!text-white font-semibold text-sm drop-shadow"
+              />
 
               <span className="text-xs font-medium text-white/80 shrink-0 ml-2">
                 {extractDate(item.uploadedAt)}

--- a/components/organisms/DiaryVideoViewerModal.tsx
+++ b/components/organisms/DiaryVideoViewerModal.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { DailyIcon, IconButton } from "@/components/atoms";
+import { getVideoAction } from "@/actions/videoActions";
+import { extractDate } from "@/lib/video/formatOverlayClock";
+
+type DiaryVideoViewerModalProps = {
+  open: boolean;
+  clipId: string | null;
+  videoUuid?: string;
+  date?: string;
+  caption?: string;
+  thumbnailUrl?: string;
+  onClose: () => void;
+};
+
+export function DiaryVideoViewerModal({
+  open,
+  clipId,
+  videoUuid,
+  date,
+  caption,
+  thumbnailUrl,
+  onClose,
+}: DiaryVideoViewerModalProps) {
+  const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!open || !videoUuid) {
+      Promise.resolve().then(() => {
+        if (isMounted) {
+          setPlaybackUrl(null);
+          setLoading(false);
+          setError(null);
+        }
+      });
+      return;
+    }
+
+    Promise.resolve().then(() => {
+      if (isMounted) {
+        setLoading(true);
+        setError(null);
+      }
+    });
+
+    getVideoAction(videoUuid)
+      .then((res) => {
+        if (!isMounted) return;
+        if (res.ok && res.data.rawPlaybackUrl) {
+          setPlaybackUrl(res.data.rawPlaybackUrl);
+        } else if (res.ok && !res.data.rawPlaybackUrl) {
+          setError("재생 가능한 영상 주소가 아직 준비되지 않았습니다.");
+        } else if (!res.ok) {
+          setError(res.error || "영상 상세 정보를 불러오지 못했습니다.");
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setError("영상 정보를 불러오는 중 오류가 발생했습니다.");
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [open, videoUuid]);
+
+  if (!open || !clipId) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 text-white animate-fadeIn">
+      {/* 닫기 버튼 */}
+      <div className="absolute top-4 right-4 z-20">
+        <IconButton variant="surface" label="닫기" onClick={onClose}>
+          <DailyIcon name="x" size={24} className="brightness-0 invert" />
+        </IconButton>
+      </div>
+
+      {/* 헤더 날짜 정보 */}
+      {date && (
+        <div className="absolute top-5 left-6 z-20 font-semibold text-base text-white/90">
+          {extractDate(date)}
+        </div>
+      )}
+
+      {/* 비디오 재생 영역 */}
+      <div className="relative flex h-full w-full max-w-lg flex-col items-center justify-center overflow-hidden">
+        {playbackUrl ? (
+          <video
+            src={playbackUrl}
+            controls
+            autoPlay
+            playsInline
+            className="h-full w-full object-contain"
+            poster={thumbnailUrl}
+          />
+        ) : thumbnailUrl ? (
+          <div className="relative h-full w-full flex items-center justify-center bg-black">
+            <img
+              src={thumbnailUrl}
+              alt="비디오 썸네일"
+              className="h-full w-full object-contain opacity-60"
+            />
+            {loading && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/40">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-white/30 border-t-white" />
+                <span className="text-xs text-white/80">영상을 불러오는 중...</span>
+              </div>
+            )}
+            {error && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center bg-black/70 text-sm font-medium text-red-400">
+                <p>{error}</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-3 text-center p-6 text-white/60">
+            {loading ? (
+              <>
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-white/30 border-t-white" />
+                <span className="text-xs">영상을 불러오는 중...</span>
+              </>
+            ) : (
+              <span className="text-sm font-medium">{error || "영상을 재생할 수 없습니다."}</span>
+            )}
+          </div>
+        )}
+
+        {/* 캡션 바텀 오버레이 */}
+        {caption && (
+          <div className="absolute bottom-10 inset-x-6 z-20 rounded-xl bg-black/60 backdrop-blur-md p-4 text-center text-sm font-medium text-white shadow-lg border border-white/10">
+            {caption}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/organisms/RecordCalendar.tsx
+++ b/components/organisms/RecordCalendar.tsx
@@ -185,7 +185,7 @@ export function RecordCalendar({ agitId }: RecordCalendarProps) {
                   # {section.themeName} ({section.clipCount})
                 </span>
                 <div className="grid grid-cols-4 gap-2">
-                  {section.clips.map((clip) => (
+                  {(section.clips ?? []).map((clip) => (
                     <button
                       key={clip.id}
                       type="button"

--- a/components/organisms/RecordCalendar.tsx
+++ b/components/organisms/RecordCalendar.tsx
@@ -1,13 +1,12 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import { fetchDiaryDateWindowAction } from "@/actions/diaryActions";
 import { DailyIcon, IconButton, TextLink } from "@/components/atoms";
 import { HeaderBackLink, MonthCalendarGrid, ScreenHeader, buildMonthGridCells } from "@/components/molecules";
-import {
-  getCompactCalendarDetail,
-  listCompactCalendarActiveDays,
-} from "@/config/compact-calendar-mock";
+import { DiaryVideoViewerModal } from "@/components/organisms/DiaryVideoViewerModal";
 import { ROUTES } from "@/config/routes";
-import { useMemo, useState } from "react";
+import type { UiDiaryDateThemeGroup, UiDiaryDateWindow } from "@/types/diary/ui";
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
@@ -16,22 +15,86 @@ type RecordCalendarProps = {
 };
 
 export function RecordCalendar({ agitId }: RecordCalendarProps) {
-  const [year, setYear] = useState(2026);
-  const [month, setMonth] = useState(7);
-  const [selectedDay, setSelectedDay] = useState(14);
+  const [today] = useState(() => new Date());
+  const [year, setYear] = useState(() => today.getFullYear());
+  const [month, setMonth] = useState(() => today.getMonth());
+  const [selectedDay, setSelectedDay] = useState(() => today.getDate());
+
+  const [dateWindow, setDateWindow] = useState<UiDiaryDateWindow | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // 개별 뷰어 모달 관련 상태
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [activeClipId, setActiveClipId] = useState<string | null>(null);
+  const [activeVideoUuid, setActiveVideoUuid] = useState<string | undefined>(undefined);
+  const [activeCaption, setActiveCaption] = useState<string | undefined>(undefined);
+  const [activeThumbnail, setActiveThumbnail] = useState<string | undefined>(undefined);
+
+  const formattedDateString = useMemo(() => {
+    const m = String(month + 1).padStart(2, "0");
+    const d = String(selectedDay).padStart(2, "0");
+    return `${year}-${m}-${d}`;
+  }, [year, month, selectedDay]);
+
   const cells = useMemo(() => buildMonthGridCells(year, month, "empty"), [year, month]);
-  const activeDays = useMemo(() => new Set(listCompactCalendarActiveDays(year, month)), [year, month]);
-  const selectedDetail = getCompactCalendarDetail(year, month, selectedDay);
+
+  // 해당 일자 데이터 가져오기
+  useEffect(() => {
+    let isMounted = true;
+
+    Promise.resolve().then(() => {
+      if (isMounted) {
+        setLoading(true);
+      }
+    });
+
+    fetchDiaryDateWindowAction(formattedDateString, 1)
+      .then((res) => {
+        if (!isMounted) return;
+        if (res.ok) {
+          setDateWindow(res.data);
+        } else {
+          setDateWindow(null);
+        }
+      })
+      .catch(() => {
+        if (isMounted) setDateWindow(null);
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [formattedDateString]);
 
   function shiftMonth(delta: number) {
     const next = new Date(year, month + delta, 1);
-    const nextYear = next.getFullYear();
-    const nextMonth = next.getMonth();
-    const nextActive = listCompactCalendarActiveDays(nextYear, nextMonth);
+    setYear(next.getFullYear());
+    setMonth(next.getMonth());
+    setSelectedDay(1);
+  }
 
-    setYear(nextYear);
-    setMonth(nextMonth);
-    setSelectedDay(nextActive[0] ?? 1);
+  // 선택된 날짜의 테마 섹션 목록
+  const currentDaySections: UiDiaryDateThemeGroup[] = useMemo(() => {
+    if (!dateWindow || !dateWindow.days) return [];
+    return dateWindow.days[formattedDateString] ?? [];
+  }, [dateWindow, formattedDateString]);
+
+  // 영상 총 개수
+  const totalVideoCount = useMemo(() => {
+    return currentDaySections.reduce((acc, s) => acc + s.clipCount, 0);
+  }, [currentDaySections]);
+
+  const hasClips = totalVideoCount > 0;
+
+  function handleOpenClip(clipId: string, videoUuid?: string, caption?: string, thumbnail?: string) {
+    setActiveClipId(clipId);
+    setActiveVideoUuid(videoUuid || clipId);
+    setActiveCaption(caption);
+    setActiveThumbnail(thumbnail);
+    setViewerOpen(true);
   }
 
   return (
@@ -65,7 +128,7 @@ export function RecordCalendar({ agitId }: RecordCalendarProps) {
             key={label}
             className={
               index === 0
-                ? "m-dlCompactCalWeekdaySun text-center text-[11px] font-medium text-[var(--dl-color-text-danger)]"
+                ? "text-center text-[11px] font-medium text-[var(--dl-color-text-danger)]"
                 : "text-center text-[11px] font-medium text-[var(--dl-color-text-secondary)]"
             }
           >
@@ -83,48 +146,106 @@ export function RecordCalendar({ agitId }: RecordCalendarProps) {
             );
           }
 
-          const available = activeDays.has(cell.day);
           const selected = cell.day === selectedDay;
 
           return (
             <button
               key={cell.day}
               type="button"
-              className={`relative flex h-[36px] flex-col items-center justify-center gap-[4px] rounded-[12px] border-0 bg-[transparent] text-sm font-medium text-[var(--dl-color-text-tertiary)] ${available ? "m-dlCompactCalCellAvailable text-[var(--dl-color-text-primary)]" : "m-dlCompactCalCellEmpty opacity-[0.45]"} ${selected ? "m-dlCompactCalCellSelected bg-[var(--dl-color-bg-brand)] text-[var(--dl-color-text-inverse)]" : ""}`}
-              disabled={!available}
+              className={`relative flex h-[36px] flex-col items-center justify-center gap-[4px] rounded-[12px] border-0 bg-[transparent] text-sm font-medium cursor-pointer transition-colors text-[var(--dl-color-text-primary)] hover:bg-[var(--dl-color-bg-surface-subtle)] ${
+                selected
+                  ? "bg-[var(--dl-color-bg-brand)] !text-[var(--dl-color-text-inverse)] font-bold shadow-sm"
+                  : ""
+              }`}
               aria-pressed={selected}
-              onClick={() => available && setSelectedDay(cell.day)}
+              onClick={() => setSelectedDay(cell.day!)}
             >
               {cell.day}
-              {available ? (
-                <span className="h-[5px] w-[5px] rounded-[999px] bg-[#fff]" aria-hidden />
-              ) : null}
             </button>
           );
         }}
       />
 
-      {selectedDetail ? (
-        <>
-          <div className="flex flex-col gap-[7px] min-h-[112px] p-[14px_16px] rounded-[16px] bg-[var(--dl-color-bg-brand-subtle)]">
-            <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
-              {month + 1}월 {selectedDay}일 · 영상 {selectedDetail.videoCount}개
-            </p>
-            <p className="m-0 text-xs font-medium text-[var(--dl-color-text-brand)]">{selectedDetail.tags.join("   ")}</p>
-            <p className="m-0 text-[11px] text-[var(--dl-color-text-secondary)]">{selectedDetail.summary}</p>
+      {/* 선택된 일자의 데이터 표출 */}
+      <div className="flex flex-col gap-[12px] min-h-[112px] p-[16px] rounded-[16px] bg-[var(--dl-color-bg-brand-subtle,#f3f4f6)]">
+        <div className="flex items-center justify-between">
+          <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">
+            {month + 1}월 {selectedDay}일 기록
+          </p>
+          <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-[var(--dl-color-bg-surface-default,#ffffff)] text-[var(--dl-color-text-brand,#6b4af5)]">
+            {loading ? "불러오는 중..." : `영상 ${totalVideoCount}개`}
+          </span>
+        </div>
+
+        {hasClips ? (
+          <div className="flex flex-col gap-[12px] mt-2">
+            {currentDaySections.map((section) => (
+              <div key={section.themeId} className="flex flex-col gap-2">
+                <span className="text-xs font-semibold text-[var(--dl-color-text-secondary)]">
+                  # {section.themeName} ({section.clipCount})
+                </span>
+                <div className="grid grid-cols-4 gap-2">
+                  {section.clips.map((clip) => (
+                    <button
+                      key={clip.id}
+                      type="button"
+                      onClick={() => handleOpenClip(clip.id, clip.id, "", clip.thumbnailSrc)}
+                      className="group relative aspect-square overflow-hidden rounded-xl bg-black/10 cursor-pointer border-0 p-0"
+                    >
+                      {clip.thumbnailSrc ? (
+                        <img
+                          src={clip.thumbnailSrc}
+                          alt="다이어리 영상 썸네일"
+                          className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-[var(--dl-color-bg-surface-subtle)]">
+                          <DailyIcon name="messageBrand" size={16} className="opacity-40" />
+                        </div>
+                      )}
+                      <div className="absolute inset-0 flex items-center justify-center bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <DailyIcon name="chevronRight" size={18} className="brightness-0 invert" />
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
           </div>
+        ) : (
+          !loading && (
+            <p className="m-0 text-xs font-normal text-[var(--dl-color-text-secondary)]">
+              이 날짜에 작성된 다이어리 기록이 없습니다.
+            </p>
+          )
+        )}
+      </div>
 
-          <TextLink href={ROUTES.agit.detail(agitId)} className="flex items-center gap-[12px] min-h-[70px] p-[10px] border border-[var(--dl-color-border-default)] rounded-[14px] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline">
-            <span className="w-[54px] h-[54px] shrink-0 rounded-[10px] bg-[linear-gradient(135deg,_#fc8c6e_0%,_#6b4af5_100%)]" aria-hidden />
-            <span>
-              <span className="block text-[13px] font-semibold">오늘의 영상 보기</span>
-              <span className="block mt-[2px] text-[13px] font-semibold">태그와 리액션 확인</span>
-            </span>
-          </TextLink>
-        </>
-      ) : null}
+      <TextLink
+        href={ROUTES.agit.detail(agitId)}
+        className="flex items-center gap-[12px] min-h-[64px] p-[12px] border border-[var(--dl-color-border-default)] rounded-[14px] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline hover:bg-[var(--dl-color-bg-surface-subtle)] transition-colors"
+      >
+        <div className="w-[44px] h-[44px] shrink-0 rounded-[10px] bg-[linear-gradient(135deg,_#fc8c6e_0%,_#6b4af5_100%)] flex items-center justify-center text-white">
+          <DailyIcon name="messageBrand" size={20} className="brightness-0 invert" />
+        </div>
+        <span>
+          <span className="block text-[13px] font-semibold">아지트 피드로 이동</span>
+          <span className="block mt-[2px] text-[11px] text-[var(--dl-color-text-secondary)]">
+            오늘의 모임 영상과 기록을 확인해보세요
+          </span>
+        </span>
+      </TextLink>
 
-      <p className="m-0 text-xs font-medium text-[#706985]">활성 날짜를 누르면 해당 일자의 영상·내역으로 바로 이동합니다.</p>
+      {/* 다이어리 개별 뷰어 모달 */}
+      <DiaryVideoViewerModal
+        open={viewerOpen}
+        clipId={activeClipId}
+        videoUuid={activeVideoUuid}
+        date={formattedDateString}
+        caption={activeCaption}
+        thumbnailUrl={activeThumbnail}
+        onClose={() => setViewerOpen(false)}
+      />
     </section>
   );
 }

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getTopicVideosAction } from "@/actions/topicActions";
-import { DailyIcon, SubmitButton } from "@/components/atoms";
+import { DailyIcon, FeedPillIconButton, SubmitButton } from "@/components/atoms";
 import { HeaderBackLink, HeaderMenuButton, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
@@ -235,9 +235,18 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
         {isAtCoverSlide ? (
           <div className="pointer-events-none absolute top-0 inset-x-0 z-30">
             <ScreenHeader
-              leading={<HeaderBackLink onClick={handleBack} />}
+              tone="overlay"
+              leading={
+                <FeedPillIconButton label="뒤로" onClick={handleBack}>
+                  <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+                </FeedPillIconButton>
+              }
               title={resolvedAgit?.name || "아지트"}
-              trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
+              trailing={
+                <FeedPillIconButton label="아지트 메뉴" onClick={() => setMenuOpen(true)}>
+                  <DailyIcon name="ellipsis" size={16} className="brightness-0 invert" />
+                </FeedPillIconButton>
+              }
             />
           </div>
         ) : (

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -265,6 +265,8 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
                   videos={videosByTopic[topic.id] ?? EMPTY_TOPIC_VIDEOS}
                   captureHref={ROUTES.capture.videoWith({ agitUuid: agitId, topicUuid: topic.id })}
                   showCaptureSlot={shouldShowTopicCaptureSlot(topic)}
+                  topicTitle={topic.title}
+                  agitName={resolvedAgit?.name}
                 />
               ) : null}
             </div>

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -13,7 +13,7 @@ import { isSameKstDate, shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgi
 import { extractDate } from "@/lib/video/formatOverlayClock";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicDetail, UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const EMPTY_TOPIC_VIDEOS: UiTopicVideo[] = [];
@@ -80,19 +80,20 @@ function TopicFeedEmptyCover({
 
 export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }: TopicFeedSectionProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const scrollerRef = useRef<HTMLDivElement>(null);
   const loadingVideoIds = useRef(new Set<string>());
   const videosRef = useRef(initialVideos);
-  const [viewportHeight, setViewportHeight] = useState(0);
+  const [, setViewportHeight] = useState(0);
 
   const [actionsOpen, setActionsOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const [topics, setTopics] = useState(initialWindow.topics);
+  const [topics] = useState(initialWindow.topics);
   const [videosByTopic, setVideosByTopic] = useState<Record<string, UiTopicVideo[]>>(initialVideos);
-  const [hasMoreBefore, setHasMoreBefore] = useState(initialWindow.hasMoreBefore);
-  const [hasMoreAfter, setHasMoreAfter] = useState(initialWindow.hasMoreAfter);
+  const [hasMoreBefore] = useState(initialWindow.hasMoreBefore);
+  const [hasMoreAfter] = useState(initialWindow.hasMoreAfter);
 
   // 오늘 진행 중인 토픽 존재 여부 확인
   const hasActiveTopic = topics.some((t) => isSameKstDate(t.startDate, new Date()));
@@ -131,7 +132,22 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
   }, []);
 
   const resolvedAgit = agit ?? getAgitById(agitId) ?? null;
-  const backHref = ROUTES.agit.topics(agitId);
+
+  // 동적 뒤로가기 핸들러
+  const handleBack = useCallback(() => {
+    const fromParam = searchParams.get("from");
+    const hasHistory = typeof window !== "undefined" && window.history.length > 1 && document.referrer;
+
+    if (fromParam === "topics") {
+      router.push(ROUTES.agit.topics(agitId));
+    } else if (fromParam === "agit") {
+      router.push(ROUTES.agit.detail(agitId));
+    } else if (hasHistory) {
+      router.back();
+    } else {
+      router.push(ROUTES.agit.topics(agitId));
+    }
+  }, [agitId, router, searchParams]);
 
   const loadVideosAround = useCallback(
     async (list: UiTopicDetail[], center: number) => {
@@ -219,14 +235,14 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
         {isAtCoverSlide ? (
           <div className="pointer-events-none absolute top-0 inset-x-0 z-30">
             <ScreenHeader
-              leading={<HeaderBackLink href={ROUTES.agit.root} />}
+              leading={<HeaderBackLink onClick={handleBack} />}
               title={resolvedAgit?.name || "아지트"}
               trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
             />
           </div>
         ) : (
           <TopicFeedPillHeader
-            backHref={backHref}
+            onBack={handleBack}
             title={currentTopic.title || "제목 없음"}
             videoCount={videoCount}
             onMenuClick={() => setMenuOpen(true)}

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -91,6 +91,7 @@ export function TopicGallerySection({
       videoUuid: v.id,
       title: v.caption || "토픽 클립",
       authorName: v.profileNickname,
+      authorProfileUrl: v.profileImageSrc,
       uploadedAt: v.uploadedAt,
       thumbnailUrl: v.thumbnailSrc,
     }));

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -23,6 +23,8 @@ type TopicGallerySectionProps = {
   videos: UiTopicVideo[];
   captureHref: string;
   showCaptureSlot?: boolean;
+  topicTitle?: string;
+  agitName?: string;
   onSelectVideo?: (videoId: string) => void;
 };
 
@@ -30,6 +32,8 @@ export function TopicGallerySection({
   videos,
   captureHref,
   showCaptureSlot = false,
+  topicTitle,
+  agitName,
   onSelectVideo,
 }: TopicGallerySectionProps) {
   const items = useMemo<GalleryPageItem[]>(
@@ -94,6 +98,8 @@ export function TopicGallerySection({
       authorProfileUrl: v.profileImageSrc,
       uploadedAt: v.uploadedAt,
       thumbnailUrl: v.thumbnailSrc,
+      topicName: topicTitle,
+      agitName: agitName,
     }));
     openViewer(videoId, formattedList, "agit");
   }

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -98,6 +98,7 @@ export function TopicGallerySection({
       authorProfileUrl: v.profileImageSrc,
       uploadedAt: v.uploadedAt,
       thumbnailUrl: v.thumbnailSrc,
+      rawPlaybackUrl: v.rawPlaybackUrl,
       topicName: topicTitle,
       agitName: agitName,
     }));

--- a/components/providers/VideoViewerProvider.tsx
+++ b/components/providers/VideoViewerProvider.tsx
@@ -7,6 +7,7 @@ export type VideoViewerItem = {
   videoUuid?: string;
   title?: string;
   authorName?: string;
+  authorProfileUrl?: string;
   uploadedAt?: string;
   thumbnailUrl?: string;
   rawPlaybackUrl?: string;

--- a/services/topicService.ts
+++ b/services/topicService.ts
@@ -50,6 +50,7 @@ async function mapTopicVideo(
       profileNickname: profile.nickname,
       uploadedAt: detail.createdAt.toISOString(),
       caption: detail.caption?.trim() ?? "",
+      rawPlaybackUrl: detail.rawPlaybackUrl,
     };
   } catch {
     return {

--- a/types/topic/ui.ts
+++ b/types/topic/ui.ts
@@ -5,6 +5,7 @@ export type UiTopicVideo = {
   profileNickname: string;
   uploadedAt: string;
   caption: string;
+  rawPlaybackUrl?: string;
 };
 
 export type UiTopic = {


### PR DESCRIPTION
## 작업 내용

토픽 개별 뷰어 및 다이어리 뷰어에 실데이터 API(`topicApi`, `videoApi`, `diaryApi`)를 바인딩하고, 작성자 영역을 아토믹 컴포넌트로 분리하였습니다. 
그룹 뷰어 타일 비디오 스트리밍 자동 재생과 함께 개별 뷰어로의 0ms 스트리밍 주소 파이프라인을 완성하였으며, 진입 유입 경로(Referrer/History) 기반 동적 뒤로가기 및 Pill 헤더 스타일을 개선하였습니다.

## 관련 이슈

Close #116

## 변경 사항

### 1. 프로필 UI 아토믹 컴포넌트화 및 뷰어 실데이터 바인딩

- **파일:** `components/atoms/UserProfileAvatar.tsx`, `components/molecules/UserProfileBadge.tsx`, `components/organisms/AgitVideoViewer.tsx`
- **설명:** 작성자 프로필/닉네임 표시 UI를 pure Atom/Molecule 아토믹 컴포넌트로 추출하고 토픽 개별 뷰어에 실데이터를 바인딩하였습니다.

```typescript
// components/molecules/UserProfileBadge.tsx
export function UserProfileBadge({ src, nickname, size = 28, className }: UserProfileBadgeProps) {
  return (
    <div className={cn("flex items-center gap-2", className)}>
      <UserProfileAvatar src={src} size={size} />
      <span className="text-[13px] font-semibold text-white">{nickname}</span>
    </div>
  );
}
```

### 2. 다이어리 캘린더 실데이터 연동 및 전용 모달 뷰어 구현

- **파일:** `components/organisms/RecordCalendar.tsx`, `components/organisms/DiaryVideoViewerModal.tsx`
- **설명:** 기존 Mock을 완전히 제거하고 `GET /api/v1/diaries/dates/{date}` 실데이터 API를 연결하였으며 다이어리 전용 비디오 모달 뷰어를 신설하였습니다.

```typescript
// components/organisms/RecordCalendar.tsx
const windowData = await fetchDiaryDateWindowAction(dateStr, 1);
setDaySections(windowData.sections);
```

### 3. 그룹 뷰어 비디오 재생 및 개별 뷰어 0ms 전달 파이프라인

- **파일:** `types/topic/ui.ts`, `services/topicService.ts`, `components/molecules/TopicVideoTile.tsx`, `components/organisms/TopicGallerySection.tsx`
- **설명:** `UiTopicVideo` 타입에 `rawPlaybackUrl`을 추가하여 그룹 뷰어에서 비디오를 자동 재생하고 개별 뷰어로 전달해 불필요한 비동기 재요청을 제거했습니다.

```typescript
// components/molecules/TopicVideoTile.tsx
{video.rawPlaybackUrl ? (
  <video src={video.rawPlaybackUrl} poster={video.thumbnailSrc} autoPlay loop muted playsInline className="absolute inset-0 size-full object-cover" />
) : (
  <VideoClipThumbnail src={video.thumbnailSrc} className="absolute inset-0 size-full object-cover" />
)}
```

### 4. 진입 경로(Referrer/History) 기반 동적 뒤로가기 및 Pill 헤더 개선

- **파일:** `components/organisms/TopicFeedSection.tsx`, `components/molecules/TopicFeedPillHeader.tsx`, `components/atoms/FeedPill.tsx`
- **설명:** 유입 경로(`searchParams` / history)에 따라 토픽 목록 또는 아지트 목록으로 동적 복귀하도록 구현하고 상단 뒤로가기/메뉴 버튼에 Pill Glassmorphism 스타일을 적용했습니다.

```typescript
// components/organisms/TopicFeedSection.tsx
const handleBack = useCallback(() => {
  const fromParam = searchParams.get("from");
  if (fromParam === "topics") router.push(ROUTES.agit.topics(agitId));
  else if (fromParam === "agit") router.push(ROUTES.agit.detail(agitId));
  else if (typeof window !== "undefined" && window.history.length > 1) router.back();
  else router.push(ROUTES.agit.topics(agitId));
}, [agitId, router, searchParams]);
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [ ] @headdrop 승인
