### PR TITLE
[#120] Fix: API 엔드포인트 구조 수정

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,26 +2,26 @@
 # 이 값을 .env.local 파일에 복사해 사용합니다.
 
 # --- API_URL ---
-# README.MD 참고해 사용할 환경변수의 주석을 해제하세요.
-# baseUrl 끝에 /api/user 등 서비스 prefix를 붙이지 않습니다. 경로는 config/api-endpoints.ts에서 정의합니다.
+# Gateway base (끝에 /api/user 등 service prefix 붙이지 않음)
 #
-# Gateway 경유 (develop 등, 기본/권장)
+# Gateway 경유 (develop/prod 권장)
 # API_URL=http://192.168.10.144:8000
-#
-# 로컬 user-service 직접 호출 (Gateway 미사용)
-# 예: http://localhost:8080/api/user
-# API_URL=http://localhost:8080/api/{service}
-# 혹은 프록시를 사용할 경우 (LOCAL_CADDY.md 참고)
+# 또는 로컬 프록시
 # API_URL=http://localhost:8000
 
-# --- plip-video (직접 호출 시) ---
-# VIDEO_API_BASE_URL=http://localhost:8085
-# destination API 미구현(404/501) 시 업로드만 성공 처리. Phase 2 연동 후 false 로 끄기.
+# --- plip-video ---
+# 로컬: video bootRun 직접 호출
+VIDEO_API_BASE_URL=http://localhost:8085
+VIDEO_USE_GATEWAY=false
+#
+# develop/prod 프론트: gateway JWT(+HMAC) 경로
+# API_URL=https://fo-api.plip.life   # 또는 develop gateway
+# VIDEO_USE_GATEWAY=true
+#
+# destination API 미연동 시 업로드만 성공 처리 (연동 후 false)
 # VIDEO_DESTINATION_NOT_WIRED_FALLBACK=true
-DEV_USER_UUID=018f3f6e-8e2a-7b3c-9d4e-5f6a7b8c9d0e
 
 # --- 통합 개발환경용 테스트 계정 로그인 ---
-# 현재 JWT 연동 전 개발용 Bearer + X-User-Uuid 사용
 # DEV_LOGIN_EMAIL=dev-test@plip.local
 # DEV_LOGIN_PASSWORD=Test1234!
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -27,12 +27,7 @@
 		reverse_proxy localhost:8084
 	}
 
-	# video — 현재 프론트는 prefix 없이 /api/videos 로 직행
-	handle /api/videos/* {
-		reverse_proxy localhost:8085
-	}
-
-	# video — 게이트웨이형 /api/video/**
+	# video
 	handle_path /api/video/* {
 		reverse_proxy localhost:8085
 	}

--- a/LOCAL_CADDY.md
+++ b/LOCAL_CADDY.md
@@ -18,7 +18,7 @@
 | chat       | 8082 | `/api/chat`                                  |
 | agit       | 8083 | `/api/agit`                                  |
 | topic      | 8084 | `/api/topic`                                 |
-| video      | 8085 | `/api/video` (현재 앱 `/api/videos`는 prefix 유지) |
+| video      | 8085 | `/api/video`                                 |
 | point      | 8086 | `/api/point`                                 |
 | shop       | 8087 | `/api/shop`                                  |
 | backoffice | 8088 | `/api/backoffice`                            |

--- a/actions/videoActions.ts
+++ b/actions/videoActions.ts
@@ -80,7 +80,8 @@ function toActionError(error: unknown): ActionResult<never> {
 }
 
 export async function issueUploadUrlAction(
-  contentType?: string,
+  contentType: string | undefined,
+  contentLengthBytes: number,
 ): Promise<ActionResult<VideoUploadUrlActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
@@ -92,8 +93,15 @@ export async function issueUploadUrlAction(
     return actionFailure("contentType must be video/mp4 or video/quicktime");
   }
 
+  if (!Number.isFinite(contentLengthBytes) || contentLengthBytes <= 0) {
+    return actionFailure("contentLengthBytes must be a positive number");
+  }
+
   try {
-    const data = await videoService.issueUploadUrl(session.userUuid, resolvedContentType);
+    const data = await videoService.issueUploadUrl(
+      resolvedContentType,
+      contentLengthBytes,
+    );
     return actionSuccess(toUploadUrlActionData(data));
   } catch (error) {
     return toActionError(error);
@@ -119,7 +127,6 @@ export async function completeVideoAction(
   try {
     const data = await videoService.completeVideo(
       resolvedVideoUuid,
-      session.userUuid,
       normalizedCaption,
     );
     return actionSuccess(toCompleteActionData(data));

--- a/components/organisms/VideoApiLabSection.tsx
+++ b/components/organisms/VideoApiLabSection.tsx
@@ -89,7 +89,18 @@ export function VideoApiLabSection() {
   }
 
   async function handleIssueUploadUrl() {
-    await run("issueUploadUrlAction", () => issueUploadUrlAction("video/mp4"));
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) {
+      applyActionResult("issueUploadUrlAction", {
+        ok: false,
+        error: "mp4/mov 파일을 먼저 선택한 뒤 upload-url을 발급하세요 (contentLength 서명).",
+      });
+      return;
+    }
+
+    await run("issueUploadUrlAction", () =>
+      issueUploadUrlAction("video/mp4", file.size),
+    );
   }
 
   async function handlePutToS3() {
@@ -188,7 +199,7 @@ export function VideoApiLabSection() {
           로그인 필수. Server Actions는 세션 JWT의 userUuid만 사용합니다.
         </p>
         <p className="text-xs text-black/50">
-          순서: upload-url → S3 PUT → complete → GET detail → GET download-url. 촬영 UI는{" "}
+          순서: 파일 선택 → upload-url(size) → S3 PUT → complete → GET detail → GET download-url. 촬영 UI는{" "}
           <a href={ROUTES.capture.video} className="underline">
             {ROUTES.capture.video}
           </a>

--- a/components/organisms/VideoCaptureSection.tsx
+++ b/components/organisms/VideoCaptureSection.tsx
@@ -51,7 +51,7 @@ export function VideoCaptureSection() {
         </p>
         <h1 className="text-lg font-semibold">Video Capture (Day 1)</h1>
         <p className="text-black/60">
-          로그인 필수 · 5초 · 720×1280 · 최대 {MAX_UPLOAD_MB}MB → upload-url → PUT → complete
+          로그인 필수 · 5초 · 720×1280 · 최대 {MAX_UPLOAD_MB}MB → upload-url(size) → PUT → complete
         </p>
         <p className="text-xs text-amber-700">
           세션 JWT의 userUuid만 사용합니다. stub URL이면 put이 skipped-stub입니다.

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -1,3 +1,5 @@
+import { resolveVideoServicePath } from "./video-path";
+
 /** Gateway `/api/{serviceId}/**` + StripPrefix=2 — Gateway 경유 시 auth/users에 적용 */
 function gatewayPath(serviceId: string, servicePath: string): string {
   const normalized = servicePath.startsWith("/") ? servicePath : `/${servicePath}`;
@@ -63,11 +65,10 @@ export const API_ENDPOINTS = {
       gatewayPath("diary", `/api/v1/diaries/videos/${diaryVideoId}`),
   },
   video: {
-    uploadUrl: "/api/videos/upload-url",
-    complete: (videoUuid: string) => `/api/videos/${videoUuid}/complete` as const,
-    detail: (videoUuid: string) => `/api/videos/${videoUuid}` as const,
-    downloadUrl: (videoUuid: string) => `/api/videos/${videoUuid}/download-url` as const,
-    /** Kafka produce는 video-service. 토픽명은 백엔드 env로 나중에 채움 */
-    destination: (videoUuid: string) => `/api/videos/${videoUuid}/destination` as const,
+    uploadUrl: resolveVideoServicePath("/api/v1/videos/upload-url"),
+    complete: (videoUuid: string) => resolveVideoServicePath(`/api/v1/videos/${videoUuid}/complete`),
+    detail: (videoUuid: string) => resolveVideoServicePath(`/api/v1/videos/${videoUuid}`),
+    downloadUrl: (videoUuid: string) => resolveVideoServicePath(`/api/v1/videos/${videoUuid}/download-url`),
+    destination: (videoUuid: string) => resolveVideoServicePath(`/api/v1/videos/${videoUuid}/destination`),
   },
 } as const;

--- a/config/video-path.ts
+++ b/config/video-path.ts
@@ -1,0 +1,26 @@
+import { getApiUrl } from "@/lib/api/env";
+
+/** Gateway `/api/{serviceId}/**` + StripPrefix=2 */
+function gatewayPath(serviceId: string, servicePath: string): string {
+  const normalized = servicePath.startsWith("/") ? servicePath : `/${servicePath}`;
+  return `/api/${serviceId}${normalized}`;
+}
+
+export function shouldUseVideoGateway(): boolean {
+  const raw = process.env.VIDEO_USE_GATEWAY?.trim().toLowerCase();
+  return raw === "true" || raw === "1";
+}
+
+export function resolveVideoServicePath(servicePath: string): string {
+  if (shouldUseVideoGateway()) {
+    return gatewayPath("video", servicePath);
+  }
+  return servicePath.startsWith("/") ? servicePath : `/${servicePath}`;
+}
+
+export function getVideoRequestBaseUrl(): string {
+  if (shouldUseVideoGateway()) {
+    return getApiUrl();
+  }
+  return process.env.VIDEO_API_BASE_URL?.trim() || "http://localhost:8085";
+}

--- a/docs/video-local.env.example
+++ b/docs/video-local.env.example
@@ -1,6 +1,10 @@
 # Copy to project root as .env.local (gitignored)
-# = 앞뒤 공백 없이 작성
-# Day 1: video actions use the logged-in session userUuid (not DEV_USER_UUID).
+# Video identity: session JWT → X-User-UUID header (query userUuid 사용 안 함)
+
 API_URL=http://localhost:8000
 VIDEO_API_BASE_URL=http://localhost:8085
-DEV_USER_UUID=00000000-0000-4000-8000-000000000001
+VIDEO_USE_GATEWAY=false
+
+# develop/prod:
+# VIDEO_USE_GATEWAY=true
+# API_URL=<gateway-base>

--- a/lib/api/apiFetch.ts
+++ b/lib/api/apiFetch.ts
@@ -1,4 +1,4 @@
-import { getVideoApiBaseUrl } from "@/lib/api/env";
+import { getVideoRequestBaseUrl } from "@/config/video-path";
 import { getSessionAuthHeaders } from "@/lib/auth/server-token";
 
 export class ApiError extends Error {
@@ -26,7 +26,7 @@ function buildUrl(
   searchParams?: Record<string, string | undefined>,
   baseUrl?: string,
 ): string {
-  const base = (baseUrl ?? getVideoApiBaseUrl()).replace(/\/$/, "");
+  const base = (baseUrl ?? getVideoRequestBaseUrl()).replace(/\/$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   const url = new URL(`${base}${normalizedPath}`);
 

--- a/lib/api/env.ts
+++ b/lib/api/env.ts
@@ -1,13 +1,17 @@
+import { getVideoRequestBaseUrl, shouldUseVideoGateway } from "@/config/video-path";
+
 const DEFAULT_API_URL = "http://localhost:8000";
-const DEFAULT_VIDEO_API_BASE_URL = "http://localhost:8085";
 const DEFAULT_DEV_USER_UUID = "00000000-0000-4000-8000-000000000001";
+
+export { getVideoRequestBaseUrl, shouldUseVideoGateway };
 
 export function getApiUrl(): string {
   return process.env.API_URL?.trim() || DEFAULT_API_URL;
 }
 
+/** VIDEO_USE_GATEWAY=true 이면 gateway(8000), 아니면 VIDEO_API_BASE_URL(8085) */
 export function getVideoApiBaseUrl(): string {
-  return process.env.VIDEO_API_BASE_URL?.trim() || DEFAULT_VIDEO_API_BASE_URL;
+  return getVideoRequestBaseUrl();
 }
 
 export function getDevUserUuid(): string {

--- a/lib/api/videoApi.ts
+++ b/lib/api/videoApi.ts
@@ -13,16 +13,20 @@ import type {
   VideoUploadUrlResponse,
 } from "@/types/video/api";
 
+/**
+ * Actor identity comes from session headers (Authorization + X-User-UUID),
+ * not query `userUuid` (gateway strips client-supplied identity).
+ */
 export async function postUploadUrl(
-  userUuid: string,
-  contentType?: string,
+  contentType: string | undefined,
+  contentLengthBytes: number,
 ): Promise<VideoUploadUrlResponse> {
   return withAuthRetry(() =>
     apiFetch<VideoUploadUrlResponse>(API_ENDPOINTS.video.uploadUrl, {
       method: "POST",
       searchParams: {
-        userUuid,
         contentType,
+        contentLengthBytes: String(contentLengthBytes),
       },
     }),
   );
@@ -30,13 +34,11 @@ export async function postUploadUrl(
 
 export async function postComplete(
   videoUuid: string,
-  userUuid: string,
   request?: VideoCompleteRequest,
 ): Promise<VideoCompleteResponse> {
   return withAuthRetry(() =>
     apiFetch<VideoCompleteResponse>(API_ENDPOINTS.video.complete(videoUuid), {
       method: "POST",
-      searchParams: { userUuid },
       body: request ?? {},
     }),
   );

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -63,7 +63,8 @@ export async function getSessionAuthHeaders(): Promise<Record<string, string>> {
     sessionHeaders.Authorization = `Bearer ${jwt.accessToken}`;
   }
   if (typeof jwt.userUuid === "string" && jwt.userUuid) {
-    sessionHeaders["X-User-Uuid"] = jwt.userUuid;
+    // Canonical gateway / video header (legacy X-User-Uuid still accepted by video filter)
+    sessionHeaders["X-User-UUID"] = jwt.userUuid;
   }
   return sessionHeaders;
 }

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -36,7 +36,7 @@ export async function uploadRecordedVideo(
 
   const contentType = resolveUploadContentType(options?.recorderMimeType ?? blob.type);
 
-  const uploadUrlResult = await issueUploadUrlAction(contentType);
+  const uploadUrlResult = await issueUploadUrlAction(contentType, blob.size);
   const uploadUrlError = extractActionError(uploadUrlResult);
   if (uploadUrlError || !uploadUrlResult.ok) {
     throw new Error(uploadUrlError ?? "upload-url failed");

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -63,19 +63,18 @@ function mapDownloadUrl(result: VideoDownloadUrlResult): VideoDownloadUrlUi {
 }
 
 export async function issueUploadUrl(
-  userUuid: string,
-  contentType?: string,
+  contentType: string | undefined,
+  contentLengthBytes: number,
 ): Promise<VideoUploadUrlUi> {
-  const response = await videoApi.postUploadUrl(userUuid, contentType);
+  const response = await videoApi.postUploadUrl(contentType, contentLengthBytes);
   return mapUploadUrl(response);
 }
 
 export async function completeVideo(
   videoUuid: string,
-  userUuid: string,
   caption?: string,
 ): Promise<VideoCompleteUi> {
-  const response = await videoApi.postComplete(videoUuid, userUuid, { caption });
+  const response = await videoApi.postComplete(videoUuid, { caption });
   return mapComplete(response);
 }
 


### PR DESCRIPTION
## 작업 내용

백엔드 video 서비스 public API가 `/api/v1/videos/...`로 변경됨에 따라, 프론트의 API 경로 정의와 로컬 Caddy 설정을 다른 서비스(agit, topic 등)와 동일한 게이트웨이 패턴으로 맞췄습니다.

게이트웨이 모드에서는 `/api/video/api/v1/videos/...` → strip 후 `/api/v1/videos/...`로 전달됩니다.

## 관련 이슈

Close #N

## 변경 사항

### 1. video API 엔드포인트 경로 v1 통일

- **파일:** `config/api-endpoints.ts`
- **설명:** video 섹션 5개 경로를 `/api/videos/...` → `/api/v1/videos/...`로 변경. `resolveVideoServicePath`는 그대로 사용해 게이트웨이/직접 호출 모드 모두 지원.

```typescript
// config/api-endpoints.ts
video: {
  uploadUrl: resolveVideoServicePath("/api/v1/videos/upload-url"),
  complete: (videoUuid: string) =>
    resolveVideoServicePath(`/api/v1/videos/${videoUuid}/complete`),
  detail: (videoUuid: string) =>
    resolveVideoServicePath(`/api/v1/videos/${videoUuid}`),
  downloadUrl: (videoUuid: string) =>
    resolveVideoServicePath(`/api/v1/videos/${videoUuid}/download-url`),
  destination: (videoUuid: string) =>
    resolveVideoServicePath(`/api/v1/videos/${videoUuid}/destination`),
},
```

### 2. 로컬 Caddy 레거시 핸들러 제거

- **파일:** `Caddyfile`, `LOCAL_CADDY.md`
- **설명:** `/api/videos/*` 직행 프록시 블록 제거. 다른 서비스와 같이 `/api/video/*` 게이트웨이형 strip만 사용.

```caddyfile
# Caddyfile
# video
handle_path /api/video/* {
  reverse_proxy localhost:8085
}
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)
  - [ ] `VIDEO_USE_GATEWAY=true`: `/api/video/api/v1/videos/upload-url` 요청 정상
  - [ ] `VIDEO_USE_GATEWAY=false`: `http://localhost:8085/api/v1/videos/...` 직접 호출 정상

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인