### PR TITLE
[#122] Refactor : 아토믹 디자인 계층 구조 정돈 및 공통 레이아웃/헤더(SSOT) 일원화

### DIFF
--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -1,17 +1,45 @@
-export { AppLogo } from "./AppLogo";
-export { AuroraButtonLink } from "./AuroraButtonLink";
-export { AuthCopyright } from "./AuthCopyright";
-export { Badge } from "./Badge";
+// ==========================================
+// ⚛️ Atoms (Domain-Data-Free UI Primitives)
+// ==========================================
+
+// Buttons & Interactive Elements
 export { Button } from "./Button";
-export { Checkbox } from "./Checkbox";
-export { GlassInput } from "./GlassInput";
+export { IconButton, IconLink } from "./IconButton";
 export { GradientButton } from "./GradientButton";
 export { GradientButtonLink } from "./GradientButtonLink";
-export { Heading } from "./Heading";
-export { IconButton, IconLink } from "./IconButton";
-export { InlineCode } from "./InlineCode";
+export { AuroraButtonLink } from "./AuroraButtonLink";
+export { SubmitButton } from "./SubmitButton";
+export { Switch } from "./Switch";
+export { Checkbox } from "./Checkbox";
+
+// Form & Input Elements
 export { Input } from "./Input";
+export { GlassInput } from "./GlassInput";
 export { Label } from "./Label";
+
+// Typography & Text
+export { Heading } from "./Heading";
+export { Text } from "./Text";
+export { TextLink } from "./TextLink";
+export { PageTitle } from "./PageTitle";
+export { ScreenTitle, ScreenSubtitle } from "./ScreenTitle";
+export { InlineCode } from "./InlineCode";
+
+// Badges, Chips & Pills
+export { Badge } from "./Badge";
+export { Pill } from "./Pill";
+export { FeedPill, FeedPillIconButton, feedOverlayGlassClass, feedPillIconButtonClass } from "./FeedPill";
+export { ThemeChip } from "./ThemeChip";
+
+// Avatars & Media
+export { UserAvatar } from "./UserAvatar";
+export { UserProfileAvatar } from "./UserProfileAvatar";
+export { VideoThumbnail } from "./VideoThumbnail";
+
+// Static Branding, Icons & Layout Extras
+export { AppLogo } from "./AppLogo";
+export { PlipLogo } from "./PlipLogo";
+export { DailyIcon, type DailyIconName } from "./DailyIcon";
 export {
   NavAgitIcon,
   NavCaptureIcon,
@@ -22,21 +50,8 @@ export {
   NavInboxIcon,
   NavMyPageIcon,
 } from "./NavIcons";
-export { CursorSpark } from "./CursorSpark";
-export { DailyIcon, type DailyIconName } from "./DailyIcon";
-export { FeedPill, FeedPillIconButton, feedOverlayGlassClass, feedPillIconButtonClass } from "./FeedPill";
-export { Pill } from "./Pill";
-export { PageTitle } from "./PageTitle";
-export { ScreenSubtitle, ScreenTitle } from "./ScreenTitle";
-export { PlipLogo } from "./PlipLogo";
 export { Separator } from "./Separator";
+export { CursorSpark } from "./CursorSpark";
+export { AuthCopyright } from "./AuthCopyright";
 export { ui } from "./styles";
-export { SubmitButton } from "./SubmitButton";
-export { Switch } from "./Switch";
-export { Text } from "./Text";
-export { TextLink } from "./TextLink";
-export { UserAvatar } from "./UserAvatar";
-export { UserProfileAvatar } from "./UserProfileAvatar";
-export { ThemeChip } from "./ThemeChip";
-export { VideoThumbnail } from "./VideoThumbnail";
 

--- a/components/molecules/PageContainer.tsx
+++ b/components/molecules/PageContainer.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+import type { ElementType, ReactNode } from "react";
+
+type PageContainerProps = {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+  gap?: "default" | "tight" | "none";
+  "aria-label"?: string;
+};
+
+/**
+ * 아지트/다이어리 등 표준 앱 화면의 단일 진실 공급원(Single Source of Truth) 레이아웃 컨테이너
+ * - 기본 표준 여백: p-[12px_24px_24px] (좌우 24px, 상단 12px, 하단 24px)
+ * - 기본 요소 간격: gap-[14px]
+ */
+export function PageContainer({
+  children,
+  as: Component = "section",
+  className,
+  gap = "default",
+  "aria-label": ariaLabel,
+}: PageContainerProps) {
+  return (
+    <Component
+      aria-label={ariaLabel}
+      className={cn(
+        "flex min-h-0 flex-1 flex-col overflow-y-auto p-[12px_24px_24px]",
+        gap === "default" && "gap-[14px]",
+        gap === "tight" && "gap-[8px]",
+        className
+      )}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/components/molecules/ScreenHeader.tsx
+++ b/components/molecules/ScreenHeader.tsx
@@ -6,9 +6,9 @@ import type { ReactNode } from "react";
 export type ScreenHeaderTone = "default" | "glass" | "overlay" | "plain";
 
 const TONE_CLASS: Record<ScreenHeaderTone, string> = {
-  default: "shrink-0 px-[23px] pt-3",
-  glass: "sticky top-0 z-20 border-b border-white/70 bg-white/50 px-4 py-3.5 backdrop-blur-xl",
-  overlay: "relative z-10 px-4 py-3",
+  default: "shrink-0 px-6 pt-3",
+  glass: "sticky top-0 z-20 border-b border-black/5 bg-white/70 px-6 py-3 backdrop-blur-xl",
+  overlay: "relative z-10 px-6 py-3",
   plain: "",
 };
 
@@ -27,8 +27,21 @@ const SUBTITLE_TONE: Record<ScreenHeaderTone, string> = {
 };
 
 type ScreenHeaderProps = {
+  /** 뒤로가기 이동 경로 (제공 시 HeaderBackLink 자동 렌더링) */
+  backHref?: string;
+  /** 뒤로가기 클릭 콜백 (제공 시 HeaderBackButton 자동 렌더링) */
+  onBack?: () => void;
+  backLabel?: string;
+
+  /** 메뉴 버튼 클릭 콜백 (제공 시 HeaderMenuButton 자동 렌더링) */
+  onMenuOpen?: () => void;
+  menuLabel?: string;
+
+  /** 커스텀 leading 요소 (backHref/onBack보다 우선 적용) */
   leading?: ReactNode;
+  /** 커스텀 trailing 요소 */
   trailing?: ReactNode;
+
   title?: ReactNode;
   subtitle?: ReactNode;
   titleAlign?: "start" | "center";
@@ -75,11 +88,11 @@ export function HeaderBackButton({ onClick, label = "뒤로" }: { onClick: () =>
 
 export function HeaderMenuButton({
   onClick,
-  label,
+  label = "메뉴",
   expanded,
 }: {
   onClick: () => void;
-  label: string;
+  label?: string;
   expanded?: boolean;
 }) {
   return (
@@ -103,41 +116,66 @@ type AuthTopBarProps = {
 
 /** @deprecated ScreenHeader 슬롯을 쓰세요. 기존 인증·플로우 화면 호환용. */
 export function AuthTopBar({ title, backHref, onBack, step, trailing }: AuthTopBarProps) {
-  const leading = onBack ? (
-    <HeaderBackButton onClick={onBack} />
-  ) : backHref ? (
-    <HeaderBackLink href={backHref} />
-  ) : undefined;
-
   return (
     <ScreenHeader
       tone="plain"
-      leading={leading}
+      backHref={backHref}
+      onBack={onBack}
       title={title || undefined}
       trailing={trailing ?? (step ? <HeaderStep>{step}</HeaderStep> : undefined)}
     />
   );
 }
 
+/**
+ * 아지트/다이어리 표준 헤더 단일 진실 공급원 (Single Source of Truth) 컴포넌트
+ */
 export function ScreenHeader({
+  backHref,
+  onBack,
+  backLabel,
+  onMenuOpen,
+  menuLabel,
   leading,
   trailing,
   title,
   subtitle,
   titleAlign = "start",
-  tone = "default",
+  tone = "plain",
   className,
 }: ScreenHeaderProps) {
-  const end = trailing ?? (leading ? <span className="size-11 shrink-0" aria-hidden /> : null);
+  const resolvedLeading =
+    leading ??
+    (onBack ? (
+      <HeaderBackButton onClick={onBack} label={backLabel} />
+    ) : backHref ? (
+      <HeaderBackLink href={backHref} label={backLabel} />
+    ) : null);
+
+  const menuButton = onMenuOpen ? (
+    <HeaderMenuButton label={menuLabel} onClick={onMenuOpen} />
+  ) : null;
+
+  const resolvedTrailing =
+    trailing || menuButton ? (
+      <>
+        {trailing}
+        {menuButton}
+      </>
+    ) : resolvedLeading ? (
+      <span className="size-11 shrink-0" aria-hidden />
+    ) : null;
 
   return (
     <header className={cn("flex items-center gap-3", TONE_CLASS[tone], className)}>
-      {leading}
+      {resolvedLeading}
       <div className={cn("min-w-0 flex-1", titleAlign === "center" ? "text-center" : null)}>
         {asTitle(title, tone)}
         {asSubtitle(subtitle, tone)}
       </div>
-      {end ? <div className="flex shrink-0 items-center gap-2">{end}</div> : null}
+      {resolvedTrailing ? (
+        <div className="flex shrink-0 items-center gap-2">{resolvedTrailing}</div>
+      ) : null}
     </header>
   );
 }

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -1,3 +1,8 @@
+// ==========================================
+// 🧬 Molecules
+// ==========================================
+
+// --- 1. Pure / Generic UI Molecules (Domain-Data-Free) ---
 export { ActionSheet } from "./ActionSheet";
 export {
   AnimatedDialog,
@@ -6,75 +11,88 @@ export {
   OverlayPortalProvider,
   useOverlayPortalHost,
 } from "./AnimatedOverlays";
-export { AgitListRow } from "./AgitListRow";
-export { ManageListRow } from "./ManageListRow";
-export { DestinationToggle } from "./DestinationToggle";
-export { DiaryCard } from "./DiaryCard";
-export { MemberManageRow } from "./MemberManageRow";
-export { NoticeCard } from "./NoticeCard";
-export { NotificationIconToggle } from "./NotificationIconToggle";
-export { ProgressTrack } from "./ProgressTrack";
-export { CaptureClipOverlays } from "./CaptureClipOverlays";
-export { TopicChip } from "./TopicChip";
-export { TopicClipPage } from "./TopicClipPage";
-export { TopicEmptySlot } from "./TopicEmptySlot";
-export { TopicFeedPillHeader } from "./TopicFeedPillHeader";
-export { TopicVideoTile } from "./TopicVideoTile";
-export { VideoClipThumbnail } from "./VideoClipThumbnail";
-export { VideoCenterClock } from "./VideoCenterClock";
-export { VideoBottomInfo } from "./VideoBottomInfo";
-export { VideoReactionBar } from "./VideoReactionBar";
-export { AgreementRow } from "./AgreementRow";
-export { AuthDivider } from "./AuthDivider";
-export { AuthField } from "./AuthField";
-export { AuthNavigationLinks } from "./AuthNavigationLinks";
 export {
+  ScreenHeader,
   AuthTopBar,
   HeaderBackButton,
   HeaderBackLink,
   HeaderMenuButton,
   HeaderStep,
-  ScreenHeader,
 } from "./ScreenHeader";
+export { PageContainer } from "./PageContainer";
+export { SectionHeader } from "./SectionHeader";
+export { ProgressTrack } from "./ProgressTrack";
+export { UploadProgress } from "./UploadProgress";
+export { CursorShapePicker } from "./CursorShapePicker";
+export { LinkButton } from "./LinkButton";
+export { ExternalLink } from "./ExternalLink";
+export { NoticeCard } from "./NoticeCard";
+export { NotificationIconToggle } from "./NotificationIconToggle";
+export { DailyToggle } from "./DailyToggle";
+export { DestinationToggle } from "./DestinationToggle";
+export { CapacityStepper } from "./CapacityStepper";
+export { MenuNavRow, SideSheetHeader } from "./SideSheetMenu";
+
+// --- 2. Auth & Form Molecules ---
+export { AuthField } from "./AuthField";
+export { AuthDivider } from "./AuthDivider";
+export { AuthNavigationLinks } from "./AuthNavigationLinks";
+export { FormField } from "./FormField";
+export { PasswordInput } from "./PasswordInput";
+export { CheckboxField } from "./CheckboxField";
+export { SwitchField } from "./SwitchField";
+export { AgreementRow } from "./AgreementRow";
+export { EmailWithOtpAction } from "./EmailWithOtpAction";
+export { SocialAuthButtons } from "./SocialAuthButtons";
+export { SocialLoginSection } from "./SocialLoginSection";
+
+// --- 3. Navigation & App Shell Molecules ---
+export { BottomNavigation } from "./BottomNavigation";
 export { ExploreNav } from "./ExploreNav";
+export { RoomNav } from "./RoomNav";
+export { FeedActionRail } from "./FeedActionRail";
+export { FeedTopBar } from "./FeedTopBar";
+export { MyPageMenuItem } from "./MyPageMenuItem";
+export { SettingsRow } from "./SettingsRow";
+
+// --- 4. Agit & Topic Domain Molecules (Data-Driven) ---
+export { TopicVideoTile } from "./TopicVideoTile";
+export { TopicEmptySlot } from "./TopicEmptySlot";
+export { TopicFeedPillHeader } from "./TopicFeedPillHeader";
+export { TopicChip } from "./TopicChip";
 export { TopicOption } from "./TopicOption";
-export { ChatBubble } from "./ChatBubble";
-export { ChatPollCard } from "./ChatPollCard";
+export { TopicClipPage } from "./TopicClipPage";
+export { TopicDatePicker } from "./TopicDatePicker";
+export { AgitListRow } from "./AgitListRow";
+export { ManageListRow } from "./ManageListRow";
+export { ManageQuickLink } from "./ManageQuickLink";
+export { RoomInfoRow } from "./RoomInfoRow";
+
+// --- 5. Diary Domain Molecules (Data-Driven) ---
+export { DiaryCard } from "./DiaryCard";
+export { DiaryEntryCard } from "./DiaryEntryCard";
+export { DiaryDateScrollSection } from "./DiaryDateScrollSection";
+export { DiaryThemeClipGroup } from "./DiaryThemeClipGroup";
+export { DiaryNotifyTimePicker } from "./DiaryNotifyTimePicker";
 export { CalendarClipCard } from "./CalendarClipCard";
 export { CalendarDay } from "./CalendarDay";
 export { MonthCalendarGrid, buildMonthGridCells, type MonthGridCell } from "./MonthCalendarGrid";
-export { ManageQuickLink } from "./ManageQuickLink";
-export { PollChoiceRow } from "./PollChoiceRow";
-export { RoomNav } from "./RoomNav";
-export { BottomNavigation } from "./BottomNavigation";
-export { CheckboxField } from "./CheckboxField";
-export { CursorShapePicker } from "./CursorShapePicker";
-export { DiaryDateScrollSection } from "./DiaryDateScrollSection";
-export { DiaryEntryCard } from "./DiaryEntryCard";
-export { DiaryNotifyTimePicker } from "./DiaryNotifyTimePicker";
-export { DiaryThemeClipGroup } from "./DiaryThemeClipGroup";
-export { EmailWithOtpAction } from "./EmailWithOtpAction";
-export { ExternalLink } from "./ExternalLink";
-export { FeedActionRail } from "./FeedActionRail";
-export { FeedTopBar } from "./FeedTopBar";
-export { FormField } from "./FormField";
-export { LinkButton } from "./LinkButton";
-export { MyPageMenuItem } from "./MyPageMenuItem";
-export { UploadProgress } from "./UploadProgress";
-export { DailyToggle } from "./DailyToggle";
-export { SettingsRow } from "./SettingsRow";
-export { MenuNavRow, SideSheetHeader } from "./SideSheetMenu";
-export { CapacityStepper } from "./CapacityStepper";
-export { ProfileOption } from "./ProfileOption";
-export { RoomInfoRow } from "./RoomInfoRow";
-export { ThumbnailUpload } from "./ThumbnailUpload";
-export { PasswordInput } from "./PasswordInput";
-export { SectionHeader } from "./SectionHeader";
-export { SocialAuthButtons } from "./SocialAuthButtons";
-export { SocialLoginSection } from "./SocialLoginSection";
-export { SwitchField } from "./SwitchField";
 export { ThemePreviewStrip } from "./ThemePreviewStrip";
+
+// --- 6. Video, Media & Capture Molecules ---
+export { VideoClipThumbnail } from "./VideoClipThumbnail";
+export { VideoCenterClock } from "./VideoCenterClock";
+export { VideoBottomInfo } from "./VideoBottomInfo";
+export { VideoReactionBar } from "./VideoReactionBar";
 export { VideoThumbnailGrid } from "./VideoThumbnailGrid";
+export { CaptureClipOverlays } from "./CaptureClipOverlays";
+export { ThumbnailUpload } from "./ThumbnailUpload";
+
+// --- 7. Chat, Social & Member Molecules ---
+export { ChatBubble } from "./ChatBubble";
+export { ChatPollCard } from "./ChatPollCard";
+export { PollChoiceRow } from "./PollChoiceRow";
+export { MemberManageRow } from "./MemberManageRow";
+export { ProfileOption } from "./ProfileOption";
 export { UserProfileBadge } from "./UserProfileBadge";
-export { TopicDatePicker } from "./TopicDatePicker";
 

--- a/components/organisms/AgitDetailSection.tsx
+++ b/components/organisms/AgitDetailSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TextLink } from "@/components/atoms";
-import { HeaderBackLink, HeaderMenuButton, ScreenHeader } from "@/components/molecules";
+import { ScreenHeader } from "@/components/molecules";
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
 import { ROUTES } from "@/config/routes";
@@ -65,10 +65,12 @@ export function AgitDetailSection({ agit, gallery, error, galleryError }: AgitDe
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
-        leading={<HeaderBackLink href={ROUTES.agit.root} />}
+        tone="default"
+        backHref={ROUTES.agit.root}
         title={heading}
         subtitle={formatTopicMeta(gallery)}
-        trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
+        onMenuOpen={() => setMenuOpen(true)}
+        menuLabel="아지트 메뉴"
       />
 
       {galleryError ? (

--- a/components/organisms/AgitListSection.tsx
+++ b/components/organisms/AgitListSection.tsx
@@ -2,7 +2,7 @@
 import leftoverStyles from "@/components/styles/leftover.module.css";
 
 import { DailyIcon, IconLink, TextLink } from "@/components/atoms";
-import { AgitListRow, ScreenHeader } from "@/components/molecules";
+import { AgitListRow, PageContainer, ScreenHeader } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
 import type { UiAgit } from "@/types/agit/ui";
 
@@ -16,7 +16,7 @@ export function AgitListSection({ items, error }: AgitListSectionProps) {
   const totalVideos = rooms.reduce((sum, room) => sum + (room.todayVideoCount ?? 0), 0);
 
   return (
-    <section aria-label="내 아지트" className="flex flex-1 flex-col gap-[14px] p-[12px_24px_24px]">
+    <PageContainer aria-label="내 아지트">
       <ScreenHeader
         tone="plain"
         title="아지트"
@@ -64,6 +64,6 @@ export function AgitListSection({ items, error }: AgitListSectionProps) {
           <small>새 루틴을 함께 시작해요</small>
         </span>
       </TextLink>
-    </section>
+    </PageContainer>
   );
 }

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -142,8 +142,8 @@ export function DiaryDateDetailSection({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[var(--dc-page-bg)]">
-      <div className="shrink-0 px-4 pb-[1.15rem] pt-[0.9rem]">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="shrink-0 px-6 pb-[1.15rem] pt-3">
         <ScreenHeader
           tone="plain"
           titleAlign="center"
@@ -164,7 +164,14 @@ export function DiaryDateDetailSection({
           >
             ‹
           </TextLink>
-          <h2 className="m-0 text-center text-[1rem] font-extrabold text-[#111]">{formatDiaryDate(focusDate)}</h2>
+          <div className="text-center">
+            <h1 className="m-0 text-[1.4rem] font-bold leading-tight tracking-tight text-[var(--dl-color-text-primary)]">
+              {formatDiaryDate(focusDate)}
+            </h1>
+            <p className="m-[0.25rem_0_0] text-[0.8rem] font-semibold text-[var(--dl-color-text-secondary)]">
+              {focusDate}
+            </p>
+          </div>
           {canGoNext ? (
             <TextLink
               href={ROUTES.diary.date(nextDate)}
@@ -186,7 +193,7 @@ export function DiaryDateDetailSection({
       </div>
 
       <div
-        className="flex min-h-0 flex-1 flex-col gap-[1.15rem] overflow-y-auto px-4 pb-7 touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none]"
+        className="flex min-h-0 flex-1 flex-col gap-[1.15rem] overflow-y-auto px-6 pb-6 touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none]"
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}

--- a/components/organisms/DiaryHeader.tsx
+++ b/components/organisms/DiaryHeader.tsx
@@ -16,7 +16,7 @@ export function DiaryHeader({
 }: DiaryHeaderProps) {
   return (
     <ScreenHeader
-      tone="glass"
+      tone="default"
       title={title}
       trailing={
         <>

--- a/components/organisms/DiaryMainSection.tsx
+++ b/components/organisms/DiaryMainSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { DiaryDateScrollSection, ThemePreviewStrip } from "@/components/molecules";
-import { DiaryHeader, DiarySideMenu } from "@/components/organisms";
+import { PageContainer, ScreenHeader, DiaryDateScrollSection, ThemePreviewStrip } from "@/components/molecules";
+import { DiarySideMenu } from "@/components/organisms/DiarySideMenu";
 import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
 import { useState } from "react";
 
@@ -15,19 +15,31 @@ export function DiaryMainSection({ entries, themes, error }: DiaryMainSectionPro
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <DiaryHeader onMenuOpen={() => setMenuOpen(true)} />
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ScreenHeader
+        title="다이어리"
+        tone="default"
+        onMenuOpen={() => setMenuOpen(true)}
+        menuLabel="다이어리 메뉴"
+      />
+
       <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-4 pt-3">
+      <PageContainer as="div" aria-label="다이어리 컨텐츠" className="flex-1">
         <ThemePreviewStrip themes={themes} />
-        {error ? <p className="m-0 mt-3 px-1 text-sm text-red-600">{error}</p> : null}
+
+        {error ? (
+          <p className="m-0 text-sm text-[var(--dl-color-text-danger)]" role="alert">
+            {error}
+          </p>
+        ) : null}
+
         <div className="mt-8 flex min-h-0 flex-1 flex-col gap-4">
           {entries.map((entry) => (
             <DiaryDateScrollSection key={entry.date} entry={entry} />
           ))}
         </div>
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/components/organisms/DiaryThemeDetailSection.tsx
+++ b/components/organisms/DiaryThemeDetailSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { loadDiaryThemeTimelinePageAction } from "@/actions/diaryActions";
-import { ScreenTitle } from "@/components/atoms";
-import { DiaryThemeClipGroup, HeaderBackLink, HeaderMenuButton, ScreenHeader } from "@/components/molecules";
+import { DiaryThemeClipGroup, PageContainer, ScreenHeader } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
 import { mergeThemeDateGroups } from "@/lib/diary/mergeThemeDateGroups";
 import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
@@ -52,13 +51,13 @@ export function DiaryThemeDetailSection({
   }
 
   return (
-    <div className="flex flex-col gap-[1.15rem] p-[0.9rem_1rem_1.75rem]">
+    <PageContainer aria-label={`${themeName} 테마 상세`}>
       <ScreenHeader
-        tone="plain"
         titleAlign="center"
-        leading={<HeaderBackLink href={ROUTES.diary.themes.root} />}
-        title={<ScreenTitle className="text-[1rem] font-extrabold text-[#111]">{themeName}</ScreenTitle>}
-        trailing={<HeaderMenuButton label="테마 옵션" onClick={() => undefined} />}
+        backHref={ROUTES.diary.themes.root}
+        title={themeName}
+        onMenuOpen={() => undefined}
+        menuLabel="테마 옵션"
       />
 
       {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
@@ -93,6 +92,6 @@ export function DiaryThemeDetailSection({
           {loadingMore ? "불러오는 중..." : "더보기"}
         </button>
       ) : null}
-    </div>
+    </PageContainer>
   );
 }

--- a/components/organisms/DiaryThemesListSection.tsx
+++ b/components/organisms/DiaryThemesListSection.tsx
@@ -2,7 +2,7 @@
 
 import { deleteThemeAction } from "@/actions/diaryActions";
 import { TextLink } from "@/components/atoms";
-import { HeaderBackLink, ScreenHeader } from "@/components/molecules";
+import { PageContainer, ScreenHeader } from "@/components/molecules";
 import { AnimatedDropdown } from "@/components/molecules/AnimatedOverlays";
 import { CreateThemeDialog } from "@/components/organisms/CreateThemeDialog";
 import { ROUTES } from "@/config/routes";
@@ -153,11 +153,10 @@ export function DiaryThemesListSection({ themes, error: fetchError }: DiaryTheme
 
   return (
     <>
-      <div className="flex flex-col gap-[0.95rem] p-[0.9rem_1rem_1.5rem]">
+      <PageContainer aria-label="테마 목록">
         <ScreenHeader
-          tone="plain"
           titleAlign="center"
-          leading={<HeaderBackLink href={ROUTES.diary.root} />}
+          backHref={ROUTES.diary.root}
           title="테마"
           trailing={
             <button
@@ -201,7 +200,7 @@ export function DiaryThemesListSection({ themes, error: fetchError }: DiaryTheme
             </div>
           ))}
         </div>
-      </div>
+      </PageContainer>
 
       <CreateThemeDialog open={dialogOpen} onClose={closeDialog} theme={editingTheme} />
     </>

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { getTopicVideosAction } from "@/actions/topicActions";
-import { DailyIcon, FeedPillIconButton, SubmitButton } from "@/components/atoms";
-import { HeaderBackLink, HeaderMenuButton, ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
+import { DailyIcon, SubmitButton } from "@/components/atoms";
+import { ScreenHeader, TopicFeedPillHeader } from "@/components/molecules";
 import { AgitMenuDrawer } from "@/components/organisms/AgitMenuDrawer";
 import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
 import { TopicGallerySection } from "@/components/organisms/TopicGallerySection";
@@ -203,9 +203,11 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
       <>
         <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dl-color-bg-surface-default)]">
           <ScreenHeader
-            leading={<HeaderBackLink href={ROUTES.agit.root} />}
+            tone="default"
+            backHref={ROUTES.agit.root}
             title={resolvedAgit?.name || "아지트"}
-            trailing={<HeaderMenuButton label="아지트 메뉴" onClick={() => setMenuOpen(true)} />}
+            onMenuOpen={() => setMenuOpen(true)}
+            menuLabel="아지트 메뉴"
           />
           <TopicFeedEmptyCover
             isFullyEmpty={true}
@@ -231,22 +233,15 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
   return (
     <>
       <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-        {/* 상단 헤더: ScreenHeader와 TopicFeedPillHeader 모두 absolute 오버레이로 상단에 올려서 스크롤러 높이가 변하지 않도록 보장 */}
+        {/* 상단 헤더: 커버 슬라이드에서는 아지트 표준 헤더, 실제 영상 피드 슬라이드에서는 TopicFeedPillHeader */}
         {isAtCoverSlide ? (
-          <div className="pointer-events-none absolute top-0 inset-x-0 z-30">
+          <div className="pointer-events-auto absolute top-0 inset-x-0 z-30">
             <ScreenHeader
-              tone="overlay"
-              leading={
-                <FeedPillIconButton label="뒤로" onClick={handleBack}>
-                  <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
-                </FeedPillIconButton>
-              }
+              tone="default"
+              onBack={handleBack}
               title={resolvedAgit?.name || "아지트"}
-              trailing={
-                <FeedPillIconButton label="아지트 메뉴" onClick={() => setMenuOpen(true)}>
-                  <DailyIcon name="ellipsis" size={16} className="brightness-0 invert" />
-                </FeedPillIconButton>
-              }
+              onMenuOpen={() => setMenuOpen(true)}
+              menuLabel="아지트 메뉴"
             />
           </div>
         ) : (

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -77,10 +77,7 @@ export function TopicsLayoutSection({
   }
 
   return (
-    <section className="flex w-full flex-col gap-3.5">
-      <p className="m-0 text-[13px] font-normal leading-5 text-[var(--dl-color-text-secondary)]">
-        토픽을 진행 상태별로 보고 만들 수 있어요
-      </p>
+    <div className="flex w-full flex-col gap-3.5">
 
       <TextLink
         href={ROUTES.agit.topicCreate(agitId)}
@@ -208,6 +205,6 @@ export function TopicsLayoutSection({
           </div>
         );
       })}
-    </section>
+    </div>
   );
 }

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -1,40 +1,22 @@
-export { AgitMenuDrawer } from "./AgitMenuDrawer";
-export { AgitManageForm } from "./AgitManageForm";
-export { AgitProfileEditForm } from "./AgitProfileEditForm";
-export { ChatMoreSheet } from "./ChatMoreSheet";
-export { MoveTopicSheet } from "./MoveTopicSheet";
-export { TopicCreateForm } from "./TopicCreateForm";
-export { TopicEditForm } from "./TopicEditForm";
-export { TopicFeedSection } from "./TopicFeedSection";
-export { TopicGallerySection } from "./TopicGallerySection";
-export { TopicViewerSection } from "./TopicViewerSection";
-export { ViewerActionsSheet } from "./ViewerActionsSheet";
-export { WelcomeSection } from "./WelcomeSection";
-export { ExploreSection } from "./ExploreSection";
-export { RoomUploadSection } from "./RoomUploadSection";
-export { RoomChatSection } from "./RoomChatSection";
-export { RecordCalendar } from "./RecordCalendar";
-export { RoomManageHub } from "./RoomManageHub";
-export { FullpageVideoViewer } from "./FullpageVideoViewer";
+// ==========================================
+// 🦠 Organisms
+// ==========================================
+
+// --- 1. Video Viewers (Base & Domain Implementations) ---
 export { BaseVideoViewer } from "./BaseVideoViewer";
 export { AgitVideoViewer } from "./AgitVideoViewer";
 export { DiaryVideoViewer } from "./DiaryVideoViewer";
-export { TopicsLayoutSection } from "./TopicsLayoutSection";
-export { MembersPermissionsSection } from "./MembersPermissionsSection";
-export { InvitesSafetySection } from "./InvitesSafetySection";
-export { AccountSecuritySection } from "./AccountSecuritySection";
-export { ProfileHubSection } from "./ProfileHubSection";
-export { WithdrawAccountDialog } from "./WithdrawAccountDialog";
-export { TermsAgreementsForm } from "./TermsAgreementsForm";
-export { CreateRoomAccessForm } from "./CreateRoomAccessForm";
-export { CreateRoomBasicForm } from "./CreateRoomBasicForm";
-export { InviteConfirmSection } from "./InviteConfirmSection";
-export { InviteJoinProfileForm } from "./InviteJoinProfileForm";
-export { JoinCompleteSection } from "./JoinCompleteSection";
-export { AgitLandingDetail } from "./AgitLandingDetail";
-export { RoomProfileSelect } from "./RoomProfileSelect";
+export { FullpageVideoViewer } from "./FullpageVideoViewer";
+export { ClipViewerSection } from "./ClipViewerSection";
+export { ViewerActionsSheet } from "./ViewerActionsSheet";
+
+// --- 2. Agit & Topic Organisms (Master) ---
+export { AgitMenuDrawer } from "./AgitMenuDrawer";
 export { AgitDetailSection } from "./AgitDetailSection";
 export { AgitListSection } from "./AgitListSection";
+export { AgitManageForm } from "./AgitManageForm";
+export { AgitLandingDetail } from "./AgitLandingDetail";
+export { AgitProfileEditForm } from "./AgitProfileEditForm";
 export {
   AgitChatSection,
   AgitEnterSection,
@@ -42,25 +24,49 @@ export {
   AgitSearchSection,
   AgitTopicsSection,
 } from "./AgitSubSections";
-export { ChangePasswordForm } from "./ChangePasswordForm";
+export { TopicsLayoutSection } from "./TopicsLayoutSection";
+export { TopicFeedSection } from "./TopicFeedSection";
+export { TopicGallerySection } from "./TopicGallerySection";
+export { TopicViewerSection } from "./TopicViewerSection";
+export { TopicCreateForm } from "./TopicCreateForm";
+export { TopicEditForm } from "./TopicEditForm";
+export { MoveTopicSheet } from "./MoveTopicSheet";
+export { ChatMoreSheet } from "./ChatMoreSheet";
+
+// --- 3. Diary Organisms (Extended) ---
+export { DiaryMainSection } from "./DiaryMainSection";
+export { DiaryDateDetailSection } from "./DiaryDateDetailSection";
+export { DiaryThemeDetailSection } from "./DiaryThemeDetailSection";
+export { DiaryThemesListSection } from "./DiaryThemesListSection";
+export { DiaryHeader } from "./DiaryHeader";
+export { DiarySideMenu } from "./DiarySideMenu";
+export { RecordCalendar } from "./RecordCalendar";
+export { CreateThemeDialog } from "./CreateThemeDialog";
+
+// --- 4. Capture & Upload Organisms ---
 export { CaptureCameraStage } from "./CaptureCameraStage";
 export { CaptureFlowSection } from "./CaptureFlowSection";
 export { CapturePreviewStage } from "./CapturePreviewStage";
 export { CaptureUploadSettingsStage } from "./CaptureUploadSettingsStage";
-export { ClipViewerSection } from "./ClipViewerSection";
 export { CreateClipSection } from "./CreateClipSection";
 export { UploadWizard } from "./UploadWizard";
-export { CreateThemeDialog } from "./CreateThemeDialog";
-export { DiaryDateDetailSection } from "./DiaryDateDetailSection";
-export { DiaryHeader } from "./DiaryHeader";
-export { DiaryMainSection } from "./DiaryMainSection";
-export { DiarySideMenu } from "./DiarySideMenu";
-export { DiaryThemeDetailSection } from "./DiaryThemeDetailSection";
-export { DiaryThemesListSection } from "./DiaryThemesListSection";
+export { RoomUploadSection } from "./RoomUploadSection";
+
+// --- 5. Auth & Account Organisms ---
+export { LoginForm } from "./LoginForm";
+export { SignUpForm } from "./SignUpForm";
 export { ForgotPasswordForm } from "./ForgotPasswordForm";
-export { HeroSection } from "./HeroSection";
-export { HomeFeedSection } from "./HomeFeedSection";
-export { IntroCursorEffects } from "./IntroCursorEffects";
+export { ResetPasswordForm } from "./ResetPasswordForm";
+export { ChangePasswordForm } from "./ChangePasswordForm";
+export { TermsAgreementsForm } from "./TermsAgreementsForm";
+export { AccountSecuritySection } from "./AccountSecuritySection";
+export { WithdrawAccountDialog } from "./WithdrawAccountDialog";
+export { NotificationSettingsForm } from "./NotificationSettingsForm";
+
+// --- 6. Profile & MyPage Organisms ---
+export { ProfileEditForm } from "./ProfileEditForm";
+export { ProfileSetupForm } from "./ProfileSetupForm";
+export { ProfileHubSection } from "./ProfileHubSection";
 export {
   MyPageMenuSection,
   MyPagePointsSection,
@@ -68,12 +74,24 @@ export {
   MyPageSettingsSection,
   MyPageWithdrawSection,
 } from "./MyPageSections";
-export { LoginForm } from "./LoginForm";
-export { MobileDeviceFrame } from "./MobileDeviceFrame";
-export { NotificationSettingsForm } from "./NotificationSettingsForm";
-export { ProfileEditForm } from "./ProfileEditForm";
-export { ProfileSetupForm } from "./ProfileSetupForm";
-export { ResetPasswordForm } from "./ResetPasswordForm";
+
+// --- 7. Room Flow & Management Organisms ---
+export { RoomManageHub } from "./RoomManageHub";
+export { RoomChatSection } from "./RoomChatSection";
+export { RoomProfileSelect } from "./RoomProfileSelect";
+export { CreateRoomBasicForm } from "./CreateRoomBasicForm";
+export { CreateRoomAccessForm } from "./CreateRoomAccessForm";
+export { InviteConfirmSection } from "./InviteConfirmSection";
+export { InviteJoinProfileForm } from "./InviteJoinProfileForm";
+export { JoinCompleteSection } from "./JoinCompleteSection";
+export { MembersPermissionsSection } from "./MembersPermissionsSection";
+export { InvitesSafetySection } from "./InvitesSafetySection";
+
+// --- 8. Home, Explore & Shop Organisms ---
+export { HomeFeedSection } from "./HomeFeedSection";
+export { HeroSection } from "./HeroSection";
+export { WelcomeSection } from "./WelcomeSection";
+export { ExploreSection } from "./ExploreSection";
 export {
   ShopChargeSection,
   ShopHomeSection,
@@ -84,4 +102,5 @@ export {
   ShopRefundSection,
   ShopWishlistSection,
 } from "./ShopSections";
-export { SignUpForm } from "./SignUpForm";
+export { IntroCursorEffects } from "./IntroCursorEffects";
+export { MobileDeviceFrame } from "./MobileDeviceFrame";

--- a/components/templates/AppChromeTemplate.tsx
+++ b/components/templates/AppChromeTemplate.tsx
@@ -10,6 +10,15 @@ type AppChromeTemplateProps = {
   variant?: "feed" | "light" | "diary";
   className?: string;
   mainOverflow?: "auto" | "hidden";
+  /** 아지트 기준 표준 여백 래퍼 적용 ('default': px-5 pb-6 pt-3, 'auth': px-5 pb-10 pt-6, 'none': 패딩 없음) */
+  padded?: boolean | "default" | "auth" | "none";
+  contentClassName?: string;
+};
+
+const PADDING_STYLES = {
+  default: "p-[12px_24px_24px]",
+  auth: "mx-auto flex w-full max-w-[390px] flex-col gap-4 px-6 pb-10 pt-6",
+  none: "",
 };
 
 export function AppChromeTemplate({
@@ -20,18 +29,27 @@ export function AppChromeTemplate({
   variant = "feed",
   className = "",
   mainOverflow = "auto",
+  padded = "none",
+  contentClassName = "",
 }: AppChromeTemplateProps) {
   const shellClass =
     variant === "light" || variant === "diary"
       ? "relative mx-auto flex h-full min-h-0 w-full flex-col overflow-hidden bg-[var(--dl-color-bg-elevated)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dl-color-text-primary)]"
       : "relative mx-auto flex h-full min-h-0 w-full flex-col overflow-hidden bg-[var(--plip-tt-bg)] text-[var(--plip-tt-text)]";
 
+  const paddingClass =
+    padded === true || padded === "default"
+      ? PADDING_STYLES.default
+      : padded === "auth"
+        ? PADDING_STYLES.auth
+        : PADDING_STYLES.none;
+
   return (
     <div className={`${shellClass} ${className}`.trim()}>
       <div className={`flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden ${showNav ? "pb-[80px]" : ""}`}>
         {header}
         <main
-          className={`flex min-h-0 w-full flex-1 flex-col ${mainOverflow === "hidden" ? "overflow-hidden" : "overflow-y-auto"}`}
+          className={`flex min-h-0 w-full flex-1 flex-col ${mainOverflow === "hidden" ? "overflow-hidden" : "overflow-y-auto"} ${paddingClass} ${contentClassName}`.trim()}
         >
           {children}
         </main>
@@ -43,8 +61,8 @@ export function AppChromeTemplate({
 
 export function AgitFlowChrome({ children }: { children: ReactNode }) {
   return (
-    <AppChromeTemplate activeTab="agit" variant="light">
-      <div className={`${ui.authContent} min-h-0 flex-1 overflow-y-auto`}>{children}</div>
+    <AppChromeTemplate activeTab="agit" variant="light" padded="auth">
+      {children}
     </AppChromeTemplate>
   );
 }

--- a/components/templates/DiaryMainTemplate.tsx
+++ b/components/templates/DiaryMainTemplate.tsx
@@ -10,7 +10,7 @@ type DiaryMainTemplateProps = {
 
 export function DiaryMainTemplate({ entries, themes, error }: DiaryMainTemplateProps) {
   return (
-    <DiaryTemplate>
+    <DiaryTemplate fixedMain>
       <DiaryMainSection entries={entries} themes={themes} error={error} />
     </DiaryTemplate>
   );

--- a/components/templates/DiaryTemplate.tsx
+++ b/components/templates/DiaryTemplate.tsx
@@ -1,34 +1,45 @@
 "use client";
 
+import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 import { FullpageVideoViewer } from "@/components/organisms/FullpageVideoViewer";
 import { FullpageViewerTemplate } from "@/components/templates/FullpageViewerTemplate";
 import { useVideoViewer } from "@/components/providers/VideoViewerProvider";
-import { BottomNavigation } from "@/components/molecules";
 import type { ReactNode } from "react";
 
 type DiaryTemplateProps = {
   children: ReactNode;
   /** true면 main 스크롤 없이 자식이 높이·내부 스크롤을 관리 (날짜 상세 등) */
   fixedMain?: boolean;
+  header?: ReactNode;
+  showNav?: boolean;
+  /** 아지트 기준 표준 여백 래퍼 적용 */
+  padded?: boolean | "default" | "auth" | "none";
+  contentClassName?: string;
 };
 
-export function DiaryTemplate({ children, fixedMain = false }: DiaryTemplateProps) {
+export function DiaryTemplate({
+  children,
+  fixedMain = false,
+  header,
+  showNav = true,
+  padded = "none",
+  contentClassName = "",
+}: DiaryTemplateProps) {
   const { isOpen, activeClipId, videoList, closeViewer } = useVideoViewer();
 
   return (
-    <div className="relative mx-auto flex h-full min-h-0 w-full max-w-full flex-col overflow-hidden bg-[var(--dc-page-bg)] font-[family-name:var(--font-inter),var(--font-sans),system-ui,sans-serif] text-[var(--dc-fg-primary)]">
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden pb-[80px]">
-        <main
-          className={
-            fixedMain
-              ? "flex min-h-0 w-full flex-1 flex-col overflow-hidden"
-              : "flex min-h-0 w-full flex-1 flex-col overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none]"
-          }
-        >
-          {children}
-        </main>
-      </div>
-      <BottomNavigation active="diary" variant="light" />
+    <>
+      <AppChromeTemplate
+        activeTab="diary"
+        variant="light"
+        header={header}
+        showNav={showNav}
+        mainOverflow={fixedMain ? "hidden" : "auto"}
+        padded={padded}
+        contentClassName={contentClassName}
+      >
+        {children}
+      </AppChromeTemplate>
 
       {isOpen && activeClipId && (
         <FullpageViewerTemplate isOpen={isOpen} onClose={closeViewer}>
@@ -39,6 +50,6 @@ export function DiaryTemplate({ children, fixedMain = false }: DiaryTemplateProp
           />
         </FullpageViewerTemplate>
       )}
-    </div>
+    </>
   );
 }

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -1,5 +1,5 @@
 import { TextLink } from "@/components/atoms";
-import { AuthTopBar, HeaderBackLink, ScreenHeader } from "@/components/molecules";
+import { AuthTopBar, HeaderBackLink, PageContainer, ScreenHeader } from "@/components/molecules";
 import { AgitManageForm } from "@/components/organisms/AgitManageForm";
 import { AgitProfileEditForm } from "@/components/organisms/AgitProfileEditForm";
 import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySection";
@@ -55,21 +55,20 @@ export function TopicsLayoutTemplate({
 
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <PageContainer aria-label="토픽 목록">
         <ScreenHeader
-          leading={<HeaderBackLink href={ROUTES.agit.detail(agit.id)} />}
+          backHref={ROUTES.agit.detail(agit.id)}
           title="토픽"
+          subtitle="토픽을 진행 상태별로 보고 만들 수 있어요"
         />
-        <div className="min-h-0 flex-1 overflow-y-auto px-[23px] pb-6">
-          <TopicsLayoutSection
-            agitId={agit.id}
-            sections={sections}
-            myRole={agit.myRole}
-            currentUserUuid={currentUserUuid}
-            memberCount={agit.memberCount}
-          />
-        </div>
-      </div>
+        <TopicsLayoutSection
+          agitId={agit.id}
+          sections={sections}
+          myRole={agit.myRole}
+          currentUserUuid={currentUserUuid}
+          memberCount={agit.memberCount}
+        />
+      </PageContainer>
     </AppChromeTemplate>
   );
 }


### PR DESCRIPTION
## 작업 내용

아토믹 디자인 패턴(Atoms / Molecules / Organisms)에 따라 도메인 데이터 의존성 기반 컴포넌트 분류 및 인덱스 export를 재정돈했습니다.
또한 아지트(Agit)와 다이어리(Diary) 화면 간의 여백 및 헤더 편차를 해결하기 위해 단일 진실 공급원(SSOT) 방식의 `<PageContainer>` 분자 컴포넌트와 `<ScreenHeader>` 선언적 props를 도입하여 전사 표준 레이아웃으로 일원화했습니다.

## 관련 이슈

Close #122

## 변경 사항

### 1. 아토믹 디자인 분류 기준 확립 및 인덱스 파일 정돈

- **파일:** `components/atoms/index.ts`, `components/molecules/index.ts`, `components/organisms/index.ts`
- **설명:** 도메인 데이터 DTO나 API 타입에 의존하지 않는 순수 UI Primitive를 Atoms에 배치하고, Molecules 및 Organisms를 Generic과 Domain(Agit, Diary, Chat, Video 등)별로 체계적으로 그룹화하여 export를 정돈했습니다.

### 2. 표준 레이아웃 분자 컴포넌트 `<PageContainer>` 신설 및 적용

- **파일:** `components/molecules/PageContainer.tsx`, `components/organisms/AgitListSection.tsx`, `components/organisms/DiaryMainSection.tsx`, `components/templates/RoomManageTemplates.tsx`
- **설명:** 아지트 표준 여백(`p-[12px_24px_24px]`)과 간격(`gap-[14px]`)을 단일 관리하는 `<PageContainer>` 컴포넌트를 신설하여 화면별 중복 클래스 복사 없이 단일 소스로 레이아웃을 관리합니다.

```typescript
// components/molecules/PageContainer.tsx
export function PageContainer({
  children,
  as: Component = "section",
  className,
  gap = "default",
  "aria-label": ariaLabel,
}: PageContainerProps) {
  return (
    <Component
      aria-label={ariaLabel}
      className={cn(
        "flex min-h-0 flex-1 flex-col overflow-y-auto p-[12px_24px_24px]",
        gap === "default" && "gap-[14px]",
        gap === "tight" && "gap-[8px]",
        className
      )}
    >
      {children}
    </Component>
  );
}
```

### 3. `<ScreenHeader>` 단일 진실 공급원(SSOT) props 확장 및 화면 일원화

- **파일:** `components/molecules/ScreenHeader.tsx`, `components/organisms/AgitDetailSection.tsx`, `components/organisms/TopicFeedSection.tsx`, `components/organisms/DiaryThemesListSection.tsx`
- **설명:** `backHref`, `onBack`, `onMenuOpen`, `menuLabel` props를 헤더 내부에서 자체 처리하도록 개선하고, 좌우 패딩을 `px-6` (24px)로 통일하여 토픽 목록/피드 빈 화면/다이어리 화면의 수직 정렬선을 일치시켰습니다.

### 4. 다이어리 메인 화면(`/diary`) 고유 뷰포트 구조 복원

- **파일:** `components/templates/DiaryTemplate.tsx`, `components/templates/DiaryMainTemplate.tsx`, `components/organisms/DiaryMainSection.tsx`
- **설명:** 다이어리 홈 화면의 상단 고정 헤더와 독립 스크롤 영역(`PageContainer`) 구조를 복원하여 아지트 표준 24px 여백을 유지하면서도 부드러운 스크롤 사용자 경험을 제공합니다.

## 테스트

- [x] `npx tsc --noEmit` (0 errors)
- [x] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#122] Refactor : 아토믹 디자인 계층 구조 정돈 및 공통 레이아웃/헤더(SSOT) 일원화`
- [x] 커밋 메시지 형식: `Refactor: 변경 요약` (16 commits)
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
