### PR TITLE
[#126] Fix : 소셜 가입 약관 단계 다음 버튼 비활성화 수정

### DIFF
--- a/components/organisms/SignUpForm.tsx
+++ b/components/organisms/SignUpForm.tsx
@@ -45,8 +45,7 @@ export function SignUpForm() {
   const requiredTerms = terms.filter((term) => term.required);
   const optionalTerms = terms.filter((term) => !term.required);
   const agreeAll = terms.length > 0 && terms.every((term) => agreements[term.id]);
-  const allRequiredAgreed =
-    requiredTerms.length > 0 && requiredTerms.every((term) => agreements[term.id] === true);
+  const allRequiredAgreed = requiredTerms.every((term) => agreements[term.id] === true);
 
   const activeStep: SignUpStep = isSocialSignup ? 3 : step;
 
@@ -390,7 +389,7 @@ export function SignUpForm() {
           ))}
         </section>
       ) : null}
-      <SubmitButton variant="brand" disabled={!allRequiredAgreed || termsLoading || terms.length === 0 || pending}>
+      <SubmitButton variant="brand" disabled={!allRequiredAgreed || termsLoading || pending}>
         {pending ? "처리 중..." : "다음"}
       </SubmitButton>
       <p className="text-center text-[11px] text-[var(--dl-color-text-tertiary)]">


### PR DESCRIPTION
## 작업 내용

소셜 최초 가입 약관 동의 단계에서 ACTIVE 필수 약관이 없거나 약관 목록이 비어 있을 때 "다음" 버튼이 영구 비활성화되던 문제를 수정했습니다. 백엔드는 필수 약관이 없으면 빈 동의로도 소셜 가입을 허용하므로, 프론트 버튼 활성화 조건을 동일하게 맞췄습니다.

## 관련 이슈

Close #126

## 변경 사항

### 1. 필수 약관 없을 때 다음 버튼 활성화

- **파일:** `components/organisms/SignUpForm.tsx`
- **설명:** `allRequiredAgreed`에서 `requiredTerms.length > 0` 조건을 제거하고, SubmitButton의 `terms.length === 0` 비활성 조건을 제거했습니다.

```typescript
// components/organisms/SignUpForm.tsx
const allRequiredAgreed = requiredTerms.every((term) => agreements[term.id] === true);

<SubmitButton variant="brand" disabled={!allRequiredAgreed || termsLoading || pending}>
  {pending ? "처리 중..." : "다음"}
</SubmitButton>
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
- [x] @headdrop 승인
