### PR TITLE
Feature: Chat WebSocket ticket·Gateway URL 연동 (#132)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,10 +15,8 @@
 # destination API 미연동 시 업로드만 성공 처리 (연동 후 false)
 # VIDEO_DESTINATION_NOT_WIRED_FALLBACK=true
 
-# --- plip-chat (REST는 API_URL/Gateway 경유, WS만 별도 URL) ---
-# Gateway는 /api/chat/** HTTP만 프록시합니다. STOMP(/ws/chat)는 chat-service 직접 연결합니다.
+# --- plip-chat (REST·WS 모두 API_URL Gateway 경유, WS는 ticket 발급 후 연결) ---
 # ENABLE_REMOTE_CHAT=true
-# CHAT_WS_URL=http://localhost:8082/ws/chat
 
 # --- 통합 개발환경용 테스트 계정 로그인 ---
 # DEV_LOGIN_EMAIL=dev-test@plip.local

--- a/actions/chatActions.ts
+++ b/actions/chatActions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { ApiError } from "@/lib/api/apiFetch";
+import * as chatApi from "@/lib/api/chatApi";
 import { getServerUserUuid } from "@/lib/auth/server-token";
 import * as chatService from "@/services/chatService";
 import { getAgitAndMembers } from "@/services/agitService";
@@ -71,6 +72,25 @@ export async function markChatReadAction(agitId: string): Promise<ActionResult<v
   try {
     await chatService.markChatRead(agitId);
     return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function issueChatWsTicketAction(): Promise<
+  ActionResult<{ ticket: string; expiresInSeconds: number; wsUrl: string }>
+> {
+  const loginError = await requireLogin();
+  if (loginError) {
+    return actionFailure(loginError);
+  }
+
+  try {
+    const ticket = await chatService.issueWsTicket();
+    return actionSuccess({
+      ...ticket,
+      wsUrl: chatApi.buildChatWsGatewayUrl(ticket.ticket),
+    });
   } catch (error) {
     return toActionError(error);
   }

--- a/app/(agit)/agit/[agitId]/chat/page.tsx
+++ b/app/(agit)/agit/[agitId]/chat/page.tsx
@@ -1,7 +1,7 @@
 import { getChatHistoryAction } from "@/actions/chatActions";
 import { AgitChatTemplate } from "@/components/templates";
 import { ROUTES } from "@/config/routes";
-import { getChatWsUrl, isEnableRemoteChatEnabled } from "@/lib/api/env";
+import { isEnableRemoteChatEnabled } from "@/lib/api/env";
 import { buildSeedChatHistory } from "@/lib/chat/seedMessages";
 import { getServerUserUuid } from "@/lib/auth/server-token";
 import { getAgitAndMembers } from "@/services/agitService";
@@ -51,7 +51,6 @@ export default async function AgitChatPage({ params }: PageProps) {
       members={members}
       currentUserUuid={currentUserUuid}
       enableRemoteChat={enableRemoteChat}
-      chatWsUrl={getChatWsUrl()}
     />
   );
 }

--- a/components/organisms/RoomChatSection.tsx
+++ b/components/organisms/RoomChatSection.tsx
@@ -29,7 +29,6 @@ type RoomChatSectionProps = {
   members: ApiAgitDetailMember[];
   currentUserUuid?: string;
   enableRemoteChat?: boolean;
-  chatWsUrl?: string;
 };
 
 function mergeMessages(existing: UiChatMessage[], incoming: UiChatMessage[]): UiChatMessage[] {
@@ -68,7 +67,6 @@ export function RoomChatSection({
   members,
   currentUserUuid,
   enableRemoteChat = false,
-  chatWsUrl,
 }: RoomChatSectionProps) {
   const resolvedInitialHistory = resolveInitialHistory(agit.id, initialHistory, enableRemoteChat);
   const [notify, setNotify] = useState(true);
@@ -99,9 +97,7 @@ export function RoomChatSection({
 
   const { sendMessage: sendRemoteMessage } = useAgitChatSocket({
     agitUuid: agit.id,
-    userUuid: currentUserUuid ?? "",
-    wsUrl: chatWsUrl ?? "",
-    enabled: enableRemoteChat && Boolean(currentUserUuid && chatWsUrl),
+    enabled: enableRemoteChat && Boolean(currentUserUuid),
     onMessage: handleIncomingMessage,
   });
 

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -65,14 +65,12 @@ export function AgitChatTemplate({
   members,
   currentUserUuid,
   enableRemoteChat = false,
-  chatWsUrl,
 }: {
   agit: UiAgit | null;
   initialHistory: UiChatHistory;
   members: ApiAgitDetailMember[];
   currentUserUuid?: string;
   enableRemoteChat?: boolean;
-  chatWsUrl?: string;
 }) {
   if (!agit) {
     return (
@@ -93,7 +91,6 @@ export function AgitChatTemplate({
         members={members}
         currentUserUuid={currentUserUuid}
         enableRemoteChat={enableRemoteChat}
-        chatWsUrl={chatWsUrl}
       />
     </AppChromeTemplate>
   );

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -71,6 +71,7 @@ export const API_ENDPOINTS = {
   chat: {
     messages: (agitUuid: string) => gatewayPath("chat", `/api/v1/agits/${agitUuid}/messages`),
     read: (agitUuid: string) => gatewayPath("chat", `/api/v1/agits/${agitUuid}/read`),
+    wsTicket: gatewayPath("chat", "/api/v1/ws/ticket"),
   },
   video: {
     uploadUrl: gatewayPath("video", "/api/v1/videos/upload-url"),

--- a/hooks/useAgitChatSocket.ts
+++ b/hooks/useAgitChatSocket.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { issueChatWsTicketAction } from "@/actions/chatActions";
 import type { ApiChatMessage } from "@/types/chat/api";
 import { Client } from "@stomp/stompjs";
 import { useEffect, useRef } from "react";
@@ -7,37 +8,38 @@ import SockJS from "sockjs-client";
 
 type UseAgitChatSocketOptions = {
   agitUuid: string;
-  userUuid: string;
-  wsUrl: string;
   enabled?: boolean;
   onMessage: (message: ApiChatMessage) => void;
 };
 
 export function useAgitChatSocket({
   agitUuid,
-  userUuid,
-  wsUrl,
   enabled = true,
   onMessage,
 }: UseAgitChatSocketOptions) {
   const clientRef = useRef<Client | null>(null);
   const onMessageRef = useRef(onMessage);
+  const wsUrlRef = useRef("");
 
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
 
   useEffect(() => {
-    if (!enabled || !agitUuid || !userUuid || !wsUrl) {
+    if (!enabled || !agitUuid) {
       return;
     }
 
     const client = new Client({
-      webSocketFactory: () => new SockJS(wsUrl),
-      connectHeaders: {
-        "X-User-UUID": userUuid,
-      },
       reconnectDelay: 5000,
+      beforeConnect: async () => {
+        const result = await issueChatWsTicketAction();
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        wsUrlRef.current = result.data.wsUrl;
+      },
+      webSocketFactory: () => new SockJS(wsUrlRef.current),
       onConnect: () => {
         client.subscribe(`/sub/agits/${agitUuid}`, (frame) => {
           try {
@@ -57,7 +59,7 @@ export function useAgitChatSocket({
       client.deactivate();
       clientRef.current = null;
     };
-  }, [agitUuid, enabled, userUuid, wsUrl]);
+  }, [agitUuid, enabled]);
 
   const sendMessage = (content: string) => {
     const trimmed = content.trim();

--- a/lib/api/chatApi.ts
+++ b/lib/api/chatApi.ts
@@ -3,7 +3,7 @@ import { getActorUserHeaders } from "@/lib/api/actorHeaders";
 import { apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl } from "@/lib/api/env";
 import { withAuthRetry } from "@/lib/api/withAuthRetry";
-import type { ApiChatHistory } from "@/types/chat/api";
+import type { ApiChatHistory, ApiChatWsTicket } from "@/types/chat/api";
 
 type ChatHistoryQuery = {
   cursorCreatedAt?: string;
@@ -37,4 +37,19 @@ export async function markChatRead(agitUuid: string): Promise<void> {
       headers: await getActorUserHeaders(),
     }),
   );
+}
+
+export async function issueWsTicket(): Promise<ApiChatWsTicket> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiChatWsTicket>(API_ENDPOINTS.chat.wsTicket, {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export function buildChatWsGatewayUrl(ticket: string): string {
+  const base = getApiUrl().replace(/\/$/, "");
+  return `${base}/api/chat/ws/chat?ticket=${encodeURIComponent(ticket)}`;
 }

--- a/lib/api/env.ts
+++ b/lib/api/env.ts
@@ -1,5 +1,4 @@
 const DEFAULT_API_URL = "http://localhost:8000";
-const DEFAULT_CHAT_WS_URL = "http://localhost:8082/ws/chat";
 const DEFAULT_DEV_USER_UUID = "00000000-0000-4000-8000-000000000001";
 
 export function getApiUrl(): string {
@@ -8,11 +7,6 @@ export function getApiUrl(): string {
 
 export function getDevUserUuid(): string {
   return process.env.DEV_USER_UUID?.trim() || DEFAULT_DEV_USER_UUID;
-}
-
-/** STOMP WebSocket 엔드포인트. Gateway 미경유 시 chat-service 직접 연결 */
-export function getChatWsUrl(): string {
-  return process.env.CHAT_WS_URL?.trim() || DEFAULT_CHAT_WS_URL;
 }
 
 export function getDevLoginEmail(): string | undefined {

--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -37,3 +37,7 @@ export async function getChatHistory(
 export async function markChatRead(agitUuid: string): Promise<void> {
   await chatApi.markChatRead(agitUuid);
 }
+
+export async function issueWsTicket(): Promise<{ ticket: string; expiresInSeconds: number }> {
+  return chatApi.issueWsTicket();
+}

--- a/types/chat/api.ts
+++ b/types/chat/api.ts
@@ -20,3 +20,8 @@ export type ApiChatHistory = {
   nextCursor: ApiChatCursor | null;
   hasNext: boolean;
 };
+
+export type ApiChatWsTicket = {
+  ticket: string;
+  expiresInSeconds: number;
+};


### PR DESCRIPTION
## Summary
- POST /api/chat/api/v1/ws/ticket API·server action 추가
- useAgitChatSocket: beforeConnect에서 ticket 발급 후 Gateway SockJS(/api/chat/ws/chat?ticket=) 연결, 재연결 시 ticket 재발급
- CHAT_WS_URL, STOMP X-User-UUID 헤더 제거
- .env.local.example Gateway WS 안내 갱신

선행: plip-gateway #9, plip-chat ticket 인증

Closes #132

## Test plan
- [x] eslint / typecheck 통과 (pre-push hook)
- [x] ENABLE_REMOTE_CHAT=true + Gateway 기동 상태에서 채팅방 실시간 송수신 확인
- [x] ticket 없이 WS 직접 연결 시도 없음