### PR TITLE
[#134] Refactor : 하단 독 UI 애니메이션, ScreenHeader 1:1 일원화, IconButton 아톰 규격 및 서체 체계 고도화

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,20 @@
+/* Pretendard Variable & Paperlogy (페이퍼로지체) 대표 폰트 주입 */
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-gov-variable.min.css");
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-variable.min.css");
+
+@font-face {
+  font-family: 'Paperlogy';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/2408-3@1.0/Paperlogy-7Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'Paperlogy';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/2408-3@1.0/Paperlogy-8ExtraBold.woff2') format('woff2');
+  font-weight: 800;
+  font-style: normal;
+}
+
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
@@ -5,6 +22,8 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+  --font-title: "Paperlogy", "Pretendard Variable", sans-serif;
 
   /* PLIP design tokens */
   --plip-navy: #0b1753;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { Geist_Mono, Gothic_A1, Inter, Manrope, Montserrat, Poppins, Geist } from "next/font/google";
 import { auth } from "@/auth";
@@ -43,6 +43,14 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
   title: "PLIP",

--- a/components/atoms/FeedPill.tsx
+++ b/components/atoms/FeedPill.tsx
@@ -1,14 +1,13 @@
 import { cn } from "@/lib/utils";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 
+import { IconButton, type IconButtonProps } from "./IconButton";
+
 export const feedOverlayGlassClass =
   "border-0 bg-black/40 text-white shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md";
 
-export const feedPillIconButtonClass = cn(
-  "pointer-events-auto flex size-7 items-center justify-center rounded-full text-white cursor-pointer transition-colors no-underline",
-  feedOverlayGlassClass,
-  "hover:bg-black/60 focus-visible:bg-black/60 active:bg-black/70"
-);
+export const feedPillIconButtonClass =
+  "pointer-events-auto flex size-7 items-center justify-center rounded-full text-white cursor-pointer transition-colors no-underline border-0 bg-black/40 shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md hover:bg-black/60 active:bg-black/70";
 
 type FeedPillProps = Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {
   children: ReactNode;
@@ -29,20 +28,18 @@ export function FeedPill({ children, className = "", ...props }: FeedPillProps) 
   );
 }
 
-type FeedPillIconButtonProps = ComponentProps<"button"> & {
-  label: string;
-  children: ReactNode;
-};
+export type FeedPillIconButtonProps = IconButtonProps;
 
 export function FeedPillIconButton({ label, children, className = "", ...props }: FeedPillIconButtonProps) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      className={cn(feedPillIconButtonClass, className)}
+    <IconButton
+      variant="overlay"
+      size="lg"
+      label={label}
+      className={cn("pointer-events-auto", className)}
       {...props}
     >
       {children}
-    </button>
+    </IconButton>
   );
 }

--- a/components/atoms/IconButton.tsx
+++ b/components/atoms/IconButton.tsx
@@ -1,15 +1,33 @@
 import { cn } from "@/lib/utils";
 import type { ComponentProps, ReactNode } from "react";
-import { ui } from "./styles";
 import { TextLink } from "./TextLink";
 
-const SURFACE_CLASS = cn(ui.topbarBack, "border-0 cursor-pointer text-[var(--dl-color-text-primary)]");
+export type IconButtonVariant = "surface" | "outline" | "ghost" | "overlay" | "brand";
+export type IconButtonSize = "pill" | "sm" | "md" | "lg";
 
+const VARIANT_CLASSES: Record<IconButtonVariant, string> = {
+  surface: "border-0 bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-primary)] hover:bg-[var(--dl-color-bg-brand-subtle)] hover:text-[var(--dl-color-text-brand)]",
+  outline: "border border-[var(--dl-color-border-default)] bg-transparent text-[var(--dl-color-text-primary)] hover:bg-[var(--dl-color-bg-surface)] hover:border-[var(--dl-color-border-brand)]",
+  ghost: "border-0 bg-transparent text-[var(--dl-color-text-primary)] hover:bg-[var(--dl-color-bg-surface)]",
+  overlay: "border-0 bg-black/20 text-white shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md hover:bg-black/35 active:bg-black/50",
+  brand: "border-0 bg-[var(--dl-color-bg-brand)] text-white shadow-xs",
+};
 
-type IconButtonProps = ComponentProps<"button"> & {
+const SIZE_CLASSES: Record<IconButtonSize, string> = {
+  pill: "size-7 rounded-full text-xs",                       // 컴팩트 알약 규격 (28px)
+  sm: "size-8 rounded-[var(--dl-radius-md)] text-xs",        // 32px
+  md: "size-9 rounded-[var(--dl-radius-md)] text-sm",        // 36px
+  lg: "size-11 rounded-[var(--dl-radius-md)] text-base",     // 44px (표준 터치 가이드라인 규격)
+};
+
+const BASE_ICON_CLASS =
+  "inline-flex shrink-0 cursor-pointer items-center justify-center no-underline transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 select-none";
+
+export type IconButtonProps = ComponentProps<"button"> & {
   label: string;
   children?: ReactNode;
-  variant?: "default" | "surface";
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
 };
 
 export function IconButton({
@@ -17,20 +35,15 @@ export function IconButton({
   children,
   className = "",
   type = "button",
-  variant = "default",
+  variant = "surface",
+  size = "lg",
   ...props
 }: IconButtonProps) {
   return (
     <button
       type={type}
       aria-label={label}
-      className={cn(
-        variant === "surface"
-          ? SURFACE_CLASS
-          : "inline-flex size-8 cursor-pointer items-center justify-center rounded-md border border-zinc-200 text-zinc-600 sm:size-9 dark:border-zinc-700 dark:text-zinc-300",
-
-        className,
-      )}
+      className={cn(BASE_ICON_CLASS, VARIANT_CLASSES[variant], SIZE_CLASSES[size], className)}
       {...props}
     >
       {children ?? (
@@ -42,13 +55,26 @@ export function IconButton({
   );
 }
 
-type IconLinkProps = ComponentProps<typeof TextLink> & {
+export type IconLinkProps = ComponentProps<typeof TextLink> & {
   label: string;
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
 };
 
-export function IconLink({ label, className, children, ...props }: IconLinkProps) {
+export function IconLink({
+  label,
+  className,
+  children,
+  variant = "surface",
+  size = "lg",
+  ...props
+}: IconLinkProps) {
   return (
-    <TextLink aria-label={label} className={cn(SURFACE_CLASS, className)} {...props}>
+    <TextLink
+      aria-label={label}
+      className={cn(BASE_ICON_CLASS, VARIANT_CLASSES[variant], SIZE_CLASSES[size], className)}
+      {...props}
+    >
       {children}
     </TextLink>
   );

--- a/components/atoms/ScreenTitle.tsx
+++ b/components/atoms/ScreenTitle.tsx
@@ -8,7 +8,7 @@ type ScreenTitleProps = {
 
 export function ScreenTitle({ children, className }: ScreenTitleProps) {
   return (
-    <h1 className={cn("m-0 text-[22px] font-bold leading-[27px] text-[var(--dl-color-text-primary)]", className)}>
+    <h1 className={cn("m-0 text-[22px] font-bold leading-[27px] font-[family-name:var(--font-title)] text-[var(--dl-color-text-primary)]", className)}>
       {children}
     </h1>
   );

--- a/components/molecules/AgitListRow.tsx
+++ b/components/molecules/AgitListRow.tsx
@@ -14,7 +14,7 @@ function topicBadgeLabel(topicSummary: string) {
 }
 
 const ACTION_CLASS =
-  "relative grid h-[40px] w-[40px] place-items-center rounded-[12px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline";
+  "relative grid h-[40px] w-[40px] place-items-center rounded-[12px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline transition-all duration-300 hover:border-[var(--dl-color-border-brand)]/40 hover:bg-gradient-to-b hover:from-[var(--dl-color-bg-brand-subtle)]/60 hover:to-[var(--dl-color-bg-elevated)] hover:text-[var(--dl-color-text-brand)] hover:shadow-[0_2px_12px_rgba(79,70,229,0.12)]";
 
 export function AgitListRow({ agit }: AgitListRowProps) {
   return (

--- a/components/molecules/BottomNavigation.tsx
+++ b/components/molecules/BottomNavigation.tsx
@@ -63,34 +63,63 @@ export function BottomNavigation({
 
   return (
     <LayoutGroup id="app-bottom-nav">
-      <nav
-        aria-label="주 메뉴"
-        className="absolute inset-x-0 bottom-0 z-30 flex h-[80px] shrink-0 items-center justify-between border-t border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] p-[6px_16px]"
-        onMouseLeave={() => setHoveredId(null)}
-      >
-        {NAV_ITEMS.map((item) => {
-          const isActive = active === item.id;
-          const isHovered = hoveredId === item.id;
+      <div className="absolute inset-x-0 bottom-0 z-30 h-[calc(80px+env(safe-area-inset-bottom,0px))] w-full pointer-events-none overflow-visible">
+        <nav
+          aria-label="주 메뉴"
+          className="pointer-events-auto relative flex h-full w-full items-center justify-between border-t border-black/5 dark:border-white/10 bg-[var(--dl-color-bg-elevated)] px-4 pt-1.5 pb-[calc(0.375rem+env(safe-area-inset-bottom,0px))] overflow-visible"
+          onMouseLeave={() => setHoveredId(null)}
+        >
+          {NAV_ITEMS.map((item) => {
+            const isActive = active === item.id;
+            const isHovered = hoveredId === item.id;
 
-          if (item.create) {
-            return (
-              <TextLink
-                key={item.id}
-                href={item.href}
-                aria-label={item.label}
-                className="relative z-10 flex h-16 w-16 flex-col items-center justify-center gap-1 text-[var(--dl-color-text-tertiary)] !no-underline"
-                onMouseEnter={() => setHoveredId(item.id)}
-                onFocus={() => setHoveredId(item.id)}
-              >
-                <span className="grid size-10 place-items-center rounded-full bg-[var(--dl-color-bg-brand)]">
-                  {item.icon}
-                </span>
-                <span className="text-[11px] font-medium leading-[14px] whitespace-nowrap">
-                  {item.label}
-                </span>
-              </TextLink>
-            );
-          }
+            if (item.create) {
+              return (
+                <div
+                  key={item.id}
+                  className="relative z-20 flex h-16 w-16 items-center justify-center overflow-visible"
+                  onMouseEnter={() => setHoveredId(item.id)}
+                  onFocus={() => setHoveredId(item.id)}
+                >
+                  {/* 1. Active Indicator */}
+                  {isActive && (
+                    <motion.div
+                      layoutId="bottom-nav-active-pill"
+                      className="absolute -inset-x-1 inset-y-0 z-0 rounded-2xl bg-gradient-to-b from-[var(--dl-color-bg-brand-subtle)]/90 via-[var(--dl-color-bg-brand-subtle)] to-[var(--dl-color-bg-brand-subtle)]/60 border border-[var(--dl-color-border-brand)]/10 shadow-[0_2px_12px_rgba(79,70,229,0.12)] transition-colors duration-300 pointer-events-none"
+                      transition={{
+                        type: "spring",
+                        stiffness: 350,
+                        damping: 28,
+                      }}
+                    />
+                  )}
+
+                  {/* 2. Hover Indicator */}
+                  {isHovered && !isActive && (
+                    <motion.div
+                      layoutId="bottom-nav-hover-pill"
+                      className="absolute -inset-x-1 inset-y-0 z-0 rounded-2xl bg-gradient-to-b from-gray-100/90 to-gray-50/50 dark:from-white/10 dark:to-white/5 transition-colors duration-300 pointer-events-none"
+                      transition={{
+                        type: "spring",
+                        stiffness: 350,
+                        damping: 28,
+                      }}
+                    />
+                  )}
+
+                  <TextLink
+                    href={item.href}
+                    aria-label={item.label}
+                    className="relative z-10 flex items-center justify-center !no-underline overflow-visible group"
+                  >
+                    {/* 상단은 솟아오르고(-40px), 좌우 섀도우도 뚫려있으며(-30px), 하단만 독 바운더리(0px)에 맞춘 3D 카메라 버튼 */}
+                    <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 grid size-[84px] place-items-center rounded-full bg-[linear-gradient(145deg,var(--dl-color-bg-brand),#3b82f6)] ring-4 ring-white/20 shadow-[0_-6px_20px_rgba(79,70,229,0.4)] [clip-path:inset(-40px_-30px_0px_-30px)] transition-all duration-200 group-hover:scale-105 group-hover:ring-white/40 group-hover:shadow-[0_-8px_25px_rgba(79,70,229,0.6)] group-active:scale-95">
+                      <Camera className="size-9 text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.3)] transition-transform duration-200 group-hover:scale-110" strokeWidth={2.2} />
+                    </span>
+                  </TextLink>
+                </div>
+              );
+            }
 
           return (
             <TextLink
@@ -98,14 +127,14 @@ export function BottomNavigation({
               href={item.href}
               aria-label={item.label}
               aria-current={isActive ? "page" : undefined}
-              className={`relative flex h-16 w-16 flex-col items-center justify-center gap-1 !no-underline transition-colors ${isActive
+              className={`relative z-10 flex h-16 w-16 flex-col items-center justify-center gap-1 !no-underline transition-colors ${isActive
                 ? "font-bold text-[var(--dl-color-text-brand)]"
                 : "text-[var(--dl-color-text-tertiary)] hover:text-[var(--dl-color-text-primary)]"
                 }`}
               onMouseEnter={() => setHoveredId(item.id)}
               onFocus={() => setHoveredId(item.id)}
             >
-              {/* 1. Active Indicator (외곽에 은은한 그라데이션이 들어간 둥근 사각형 슬라이딩) */}
+              {/* 1. Active Indicator */}
               {isActive && (
                 <motion.div
                   layoutId="bottom-nav-active-pill"
@@ -118,7 +147,7 @@ export function BottomNavigation({
                 />
               )}
 
-              {/* 2. Hover Indicator (호버 시 은은한 소프트 그라데이션 및 칼라 트랜지션) */}
+              {/* 2. Hover Indicator */}
               {isHovered && !isActive && (
                 <motion.div
                   layoutId="bottom-nav-hover-pill"
@@ -131,7 +160,7 @@ export function BottomNavigation({
                 />
               )}
 
-              {/* 아이콘 및 라벨 (z-10) */}
+              {/* 아이콘 및 라벨 */}
               <span className="relative z-10 flex flex-col items-center justify-center gap-1 transition-colors duration-300">
                 {item.icon}
                 <span className="text-[11px] font-medium leading-[14px] whitespace-nowrap transition-colors duration-300">
@@ -142,6 +171,7 @@ export function BottomNavigation({
           );
         })}
       </nav>
+    </div>
     </LayoutGroup>
   );
 }

--- a/components/molecules/CaptureClipOverlays.tsx
+++ b/components/molecules/CaptureClipOverlays.tsx
@@ -37,7 +37,7 @@ export function CaptureClipOverlays({ capturedAt, caption, scale = 1 }: CaptureC
               </p>
             ) : null}
             <p
-              className="m-0 font-light text-white/80 opacity-80 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]"
+              className="absolute left-1/2 top-full -translate-x-1/2 mt-1 m-0 font-light text-white/80 opacity-80 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)] whitespace-nowrap pointer-events-none"
               style={{ fontSize: Math.min(captionSize, 13), lineHeight: 1.2 }}
             >
               {trimmedCaption}

--- a/components/molecules/DiaryDateScrollSection.tsx
+++ b/components/molecules/DiaryDateScrollSection.tsx
@@ -1,4 +1,4 @@
-import { TextLink } from "@/components/atoms";
+import { IconButton, TextLink } from "@/components/atoms";
 import { Card } from "@/components/ui/card";
 import { formatDiaryDate, formatDiaryWeekday } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
@@ -34,16 +34,22 @@ export function DiaryDateScrollSection({ entry, className }: DiaryDateScrollSect
 
 
       <TextLink href={href} className="block min-h-0 flex-1 no-underline">
-        <Card className="flex h-full min-h-0 flex-col overflow-hidden border-0 p-0 shadow-none ring-1 ring-black/5">
+        <Card className="flex h-full min-h-0 flex-col overflow-hidden border-0 p-0 shadow-none ring-0">
           {isEmpty ? (
-            <div className="flex h-full min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-secondary text-muted-foreground">
-              <span className="grid size-10 place-items-center rounded-full bg-white shadow-sm ring-1 ring-black/5">
-                <Plus className="size-5 text-primary" />
-              </span>
-              <span className="text-xs font-semibold">다이어리 기록</span>
+            <div className="flex h-full min-h-0 min-h-[96px] flex-1 flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-[var(--dl-color-border-brand)] bg-[linear-gradient(135deg,rgba(247,244,255,0.85),rgba(255,255,255,0.95))] p-4 shadow-[0_8px_24px_rgba(23,_23,_28,_0.03)] transition-all hover:bg-[var(--dl-color-bg-brand-subtle)]">
+              <IconButton
+                variant="brand"
+                size="md"
+                label="다이어리 기록"
+                tabIndex={-1}
+                className="pointer-events-none rounded-xl"
+              >
+                <Plus className="size-5 stroke-[2.5]" />
+              </IconButton>
+              <span className="text-xs font-bold text-[var(--dl-color-text-brand)]">다이어리 기록</span>
             </div>
           ) : (
-            <div className="grid h-full min-h-0 flex-1 grid-cols-3 gap-px bg-white">
+            <div className="grid h-full min-h-0 flex-1 grid-cols-3 gap-px bg-white rounded-[18px] overflow-hidden">
               {TILES.map((tile) => (
                 <div key={tile} className={cn("min-h-0", tile)} aria-hidden />
               ))}

--- a/components/molecules/DiaryThemeCard.tsx
+++ b/components/molecules/DiaryThemeCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TextLink } from "@/components/atoms";
+import { IconButton, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
 import type { UiDiaryTheme } from "@/types/diary/ui";
 import { Pencil, Plus } from "lucide-react";
@@ -77,9 +77,15 @@ export function DiaryThemeAddCard({ onClick }: DiaryThemeAddCardProps) {
       className="flex aspect-[1/1.22] w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-[var(--dl-color-border-brand)] bg-[linear-gradient(135deg,rgba(247,244,255,0.85),rgba(255,255,255,0.95))] p-4 shadow-[0_8px_24px_rgba(23,_23,_28,_0.03)] transition-all hover:bg-[var(--dl-color-bg-brand-subtle)] hover:shadow-xs"
       aria-label="새 테마 추가"
     >
-      <span className="grid size-10 place-items-center rounded-xl bg-[var(--dl-color-bg-brand)] text-white shadow-xs">
+      <IconButton
+        variant="brand"
+        size="md"
+        label="새 테마 추가"
+        tabIndex={-1}
+        className="pointer-events-none rounded-xl"
+      >
         <Plus className="size-5 stroke-[2.5]" />
-      </span>
+      </IconButton>
       <span className="text-xs font-bold text-[var(--dl-color-text-brand)]">테마 추가</span>
     </button>
   );

--- a/components/molecules/ScreenHeader.tsx
+++ b/components/molecules/ScreenHeader.tsx
@@ -3,13 +3,14 @@ import { ui } from "@/components/atoms/styles";
 import { cn } from "@/lib/utils";
 import type { ReactNode } from "react";
 
-export type ScreenHeaderTone = "default" | "glass" | "overlay" | "plain";
+export type ScreenHeaderTone = "default" | "glass" | "overlay" | "plain" | "sticky";
 
 const TONE_CLASS: Record<ScreenHeaderTone, string> = {
-  default: "shrink-0 px-6 pt-3",
-  glass: "sticky top-0 z-20 border-b border-black/5 bg-white/70 px-6 py-3 backdrop-blur-xl",
-  overlay: "relative z-10 px-6 py-3",
+  default: "shrink-0 px-6 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-3 bg-[var(--dl-color-bg-elevated)]",
+  glass: "sticky top-0 z-20 border-b border-black/5 bg-white/70 px-6 pt-[calc(0.75rem+env(safe-area-inset-top,0px))] pb-3 backdrop-blur-xl",
+  overlay: "relative z-10 px-6 pt-[calc(0.75rem+env(safe-area-inset-top,0px))] pb-3",
   plain: "",
+  sticky: "sticky top-0 z-20 shrink-0 px-6 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-1 bg-[var(--dl-color-bg-elevated)]",
 };
 
 const TITLE_TONE: Record<ScreenHeaderTone, string> = {
@@ -17,6 +18,7 @@ const TITLE_TONE: Record<ScreenHeaderTone, string> = {
   glass: "text-[#161823] tracking-tight",
   overlay: "text-white",
   plain: "",
+  sticky: "",
 };
 
 const SUBTITLE_TONE: Record<ScreenHeaderTone, string> = {
@@ -24,6 +26,7 @@ const SUBTITLE_TONE: Record<ScreenHeaderTone, string> = {
   glass: "",
   overlay: "text-white/78",
   plain: "",
+  sticky: "",
 };
 
 type ScreenHeaderProps = {
@@ -65,11 +68,7 @@ function asSubtitle(subtitle: ReactNode, tone: ScreenHeaderTone): ReactNode {
 
 export function HeaderBackLink({ href, label = "뒤로", onClick }: { href?: string; label?: string; onClick?: () => void }) {
   if (onClick) {
-    return (
-      <IconButton variant="surface" label={label} onClick={onClick}>
-        <DailyIcon name="chevronLeft" size={20} />
-      </IconButton>
-    );
+    return <HeaderBackButton onClick={onClick} label={label} />;
   }
   return (
     <IconLink href={href || "#"} label={label}>
@@ -98,6 +97,25 @@ export function HeaderMenuButton({
   return (
     <IconButton variant="surface" label={label} aria-expanded={expanded} onClick={onClick}>
       <DailyIcon name="ellipsis" size={20} />
+    </IconButton>
+  );
+}
+
+export function HeaderSearchLink({ href, label = "검색", onClick }: { href?: string; label?: string; onClick?: () => void }) {
+  if (onClick) {
+    return <HeaderSearchButton onClick={onClick} label={label} />;
+  }
+  return (
+    <IconLink href={href || "#"} label={label}>
+      <DailyIcon name="search" size={20} />
+    </IconLink>
+  );
+}
+
+export function HeaderSearchButton({ onClick, label = "검색" }: { onClick: () => void; label?: string }) {
+  return (
+    <IconButton variant="surface" label={label} onClick={onClick}>
+      <DailyIcon name="search" size={20} />
     </IconButton>
   );
 }
@@ -141,7 +159,7 @@ export function ScreenHeader({
   title,
   subtitle,
   titleAlign = "start",
-  tone = "plain",
+  tone = "sticky",
   className,
 }: ScreenHeaderProps) {
   const resolvedLeading =
@@ -166,16 +184,26 @@ export function ScreenHeader({
       <span className="size-11 shrink-0" aria-hidden />
     ) : null;
 
+  const isSticky = tone === "sticky";
+
   return (
-    <header className={cn("flex items-center gap-3", TONE_CLASS[tone], className)}>
+    <header className={cn("relative flex items-center gap-3", TONE_CLASS[tone], className)}>
       {resolvedLeading}
-      <div className={cn("min-w-0 flex-1", titleAlign === "center" ? "text-center" : null)}>
+      <div className={cn("min-w-0 flex-1 ", titleAlign === "center" ? "text-center" : null)}>
         {asTitle(title, tone)}
         {asSubtitle(subtitle, tone)}
       </div>
       {resolvedTrailing ? (
         <div className="flex shrink-0 items-center gap-2">{resolvedTrailing}</div>
       ) : null}
+
+      {/* 헤더 하단으로 부드럽게 빠지는 리얼 알파 그라데이션 페이드 오버레이 */}
+      {/* {isSticky && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute left-0 right-0 top-full h-5 bg-gradient-to-b from-[var(--dl-color-bg-elevated)] to-transparent"
+        />
+      )} */}
     </header>
   );
 }

--- a/components/molecules/TopicFeedPillHeader.tsx
+++ b/components/molecules/TopicFeedPillHeader.tsx
@@ -11,23 +11,25 @@ type TopicFeedPillHeaderProps = {
 export function TopicFeedPillHeader({ backHref = "#", onBack, title, videoCount, onMenuClick }: TopicFeedPillHeaderProps) {
   return (
     <>
-      <div className="pointer-events-none absolute top-3 left-3 z-30">
+      <div className="pointer-events-none absolute top-4 left-6 z-30">
         {onBack ? (
           <FeedPillIconButton label="뒤로" onClick={onBack}>
-            <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+            <DailyIcon name="chevronLeft" size={20} className="brightness-0 invert" />
           </FeedPillIconButton>
         ) : (
           <IconLink
             href={backHref}
             label="뒤로"
-            className={feedPillIconButtonClass}
+            variant="overlay"
+            size="lg"
+            className="pointer-events-auto"
           >
-            <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+            <DailyIcon name="chevronLeft" size={20} className="brightness-0 invert" />
           </IconLink>
         )}
       </div>
 
-      <div className="pointer-events-none absolute inset-x-0 top-3 z-30 flex justify-center px-14">
+      <div className="pointer-events-none absolute inset-x-0 top-4 z-30 flex justify-center px-16">
         <div className="pointer-events-auto relative max-w-full">
           <FeedPill>
             <span className="min-w-0 overflow-hidden [text-overflow:ellipsis] whitespace-nowrap">{title}</span>
@@ -42,9 +44,9 @@ export function TopicFeedPillHeader({ backHref = "#", onBack, title, videoCount,
       </div>
 
       {onMenuClick && (
-        <div className="pointer-events-none absolute top-3 right-3 z-30">
+        <div className="pointer-events-none absolute top-4 right-6 z-30">
           <FeedPillIconButton label="메뉴" onClick={onMenuClick}>
-            <DailyIcon name="ellipsis" size={16} className="brightness-0 invert" />
+            <DailyIcon name="ellipsis" size={20} className="brightness-0 invert" />
           </FeedPillIconButton>
         </div>
       )}

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -1,5 +1,5 @@
-import { UserAvatar } from "@/components/atoms";
 import { CaptureClipOverlays } from "@/components/molecules/CaptureClipOverlays";
+import { UserProfileBadge } from "@/components/molecules/UserProfileBadge";
 import { VideoClipThumbnail } from "@/components/molecules/VideoClipThumbnail";
 import { parseUploadedAtToDate } from "@/lib/video/formatOverlayClock";
 import type { UiTopicVideo } from "@/types/topic/ui";
@@ -37,13 +37,13 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
         caption={video.caption}
         scale={1}
       />
-      <div className="pointer-events-none absolute inset-0 z-10">
-        <div className="absolute bottom-3 left-3 flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-2">
-          <UserAvatar src={video.profileImageSrc} size={28} />
-          <p className="m-0 overflow-hidden text-[13px] font-semibold leading-4 text-white [text-overflow:ellipsis] whitespace-nowrap [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-            {video.profileNickname}
-          </p>
-        </div>
+      <div className="pointer-events-none absolute inset-0 z-10 flex flex-col justify-end p-6">
+        <UserProfileBadge
+          profileUrl={video.profileImageSrc}
+          nickname={video.profileNickname}
+          size="sm"
+          textClassName="!text-white font-semibold text-sm drop-shadow"
+        />
       </div>
     </>
   );

--- a/components/molecules/VideoBottomInfo.tsx
+++ b/components/molecules/VideoBottomInfo.tsx
@@ -16,7 +16,7 @@ export function VideoBottomInfo({
   return (
     <div
       className={cn(
-        "relative z-10 mt-auto flex items-end justify-between px-6 pb-12 text-white",
+        "relative z-10 mt-auto flex items-center justify-between px-6 pb-12 text-white",
         className
       )}
     >

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -19,6 +19,8 @@ export {
   HeaderBackButton,
   HeaderBackLink,
   HeaderMenuButton,
+  HeaderSearchButton,
+  HeaderSearchLink,
   HeaderStep,
 } from "./ScreenHeader";
 export { PageContainer } from "./PageContainer";

--- a/components/organisms/AgitListSection.tsx
+++ b/components/organisms/AgitListSection.tsx
@@ -1,9 +1,10 @@
 "use client";
 import leftoverStyles from "@/components/styles/leftover.module.css";
 
-import { DailyIcon, IconLink, TextLink } from "@/components/atoms";
-import { AgitListRow, PageContainer, ScreenHeader } from "@/components/molecules";
+import { DailyIcon, IconButton, IconLink, TextLink } from "@/components/atoms";
+import { AgitListRow, HeaderSearchLink, PageContainer, ScreenHeader } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
+import { Plus } from "lucide-react";
 import type { UiAgit } from "@/types/agit/ui";
 
 type AgitListSectionProps = {
@@ -16,54 +17,57 @@ export function AgitListSection({ items, error }: AgitListSectionProps) {
   const totalVideos = rooms.reduce((sum, room) => sum + (room.todayVideoCount ?? 0), 0);
 
   return (
-    <PageContainer aria-label="내 아지트">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
-        tone="plain"
         title="아지트"
-        subtitle="참여 중인 방에서 오늘의 기록을 이어가요"
-        trailing={
-          <IconLink href={ROUTES.agit.search} label="검색">
-            <DailyIcon name="search" size={20} />
-          </IconLink>
-        }
+        trailing={<HeaderSearchLink href={ROUTES.agit.search} />}
       />
 
-      {error ? (
-        <p className="m-0 text-[14px] text-[var(--dl-color-text-secondary)]" role="alert">
-          {error}
-        </p>
-      ) : null}
+      <PageContainer aria-label="내 아지트" className="flex-1">
 
-      <div className="flex items-center justify-between gap-[12px] p-[2px_2px_0]">
-        <div className="dl-azit-list__summary-copy">
-          <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">참여 중인 아지트</p>
-          <p className="m-[4px_0_0] text-[11px] font-medium text-[var(--dl-color-text-brand)]">오늘 업로드 {totalVideos}개</p>
-        </div>
-        <span className="grid min-w-[34px] h-[34px] place-items-center p-[0_10px] rounded-[999px] bg-[var(--dl-color-bg-brand-subtle)] text-[13px] font-bold text-[var(--dl-color-text-brand)]">{rooms.length}</span>
-      </div>
+        {error ? (
+          <p className="m-0 text-[14px] text-[var(--dl-color-text-secondary)]" role="alert">
+            {error}
+          </p>
+        ) : null}
 
-      <div className="grid grid-cols-2 gap-[12px]">
-        {rooms.length > 0 ? (
-          rooms.map((room) => <AgitListRow key={room.id} agit={room} />)
-        ) : (
-          <div className="col-span-2 flex flex-col items-center gap-[8px] p-[28px_16px] [border:1px_dashed_var(--dl-color-border-default)] rounded-[16px] text-center text-[var(--dl-color-text-secondary)]">
-            <p>참여 중인 아지트가 없어요.</p>
-            <TextLink href={ROUTES.agit.create} className="!text-[var(--dl-color-text-brand)] text-sm font-medium leading-5 !no-underline hover:!underline">
-              새 아지트 만들기
-            </TextLink>
+        <div className="flex items-center justify-between gap-[12px] p-[2px_2px_0]">
+          <div className="dl-azit-list__summary-copy">
+            <p className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">참여 중인 아지트</p>
+            <p className="m-[4px_0_0] text-[11px] font-medium text-[var(--dl-color-text-brand)]">오늘 업로드 {totalVideos}개</p>
           </div>
-        )}
-      </div>
+          <span className="grid min-w-[34px] h-[34px] place-items-center p-[0_10px] rounded-[999px] bg-[var(--dl-color-bg-brand-subtle)] text-[13px] font-bold text-[var(--dl-color-text-brand)]">{rooms.length}</span>
+        </div>
 
-      <TextLink href={ROUTES.agit.create} className={`${leftoverStyles.dlAzitListCreate} mt-1 flex items-center gap-3 rounded-2xl border border-[var(--dl-color-border-brand)] bg-[linear-gradient(135deg,rgba(247,244,255,0.95),rgba(255,255,255,0.98))] p-3.5 text-[var(--dl-color-text-primary)] no-underline`}>
-        <span className="grid w-[40px] h-[40px] place-items-center rounded-[12px] bg-[var(--dl-color-bg-brand)] text-[#fff] text-[22px] font-medium leading-none" aria-hidden>
-          +
-        </span>
-        <span>
-          <strong>아지트 만들기</strong>
-          <small>새 루틴을 함께 시작해요</small>
-        </span>
-      </TextLink>
-    </PageContainer>
+        <div className="grid grid-cols-2 gap-[12px]">
+          {rooms.length > 0 ? (
+            rooms.map((room) => <AgitListRow key={room.id} agit={room} />)
+          ) : (
+            <div className="col-span-2 flex flex-col items-center gap-[8px] p-[28px_16px] [border:1px_dashed_var(--dl-color-border-default)] rounded-[16px] text-center text-[var(--dl-color-text-secondary)]">
+              <p>참여 중인 아지트가 없어요.</p>
+              <TextLink href={ROUTES.agit.create} className="!text-[var(--dl-color-text-brand)] text-sm font-medium leading-5 !no-underline hover:!underline">
+                새 아지트 만들기
+              </TextLink>
+            </div>
+          )}
+        </div>
+
+        <TextLink href={ROUTES.agit.create} className={`${leftoverStyles.dlAzitListCreate} mt-1 flex items-center gap-3 rounded-2xl border border-dashed border-[var(--dl-color-border-brand)] bg-[linear-gradient(135deg,rgba(247,244,255,0.95),rgba(255,255,255,0.98))] p-3.5 text-[var(--dl-color-text-primary)] no-underline hover:bg-[var(--dl-color-bg-brand-subtle)] transition-all`}>
+          <IconButton
+            variant="brand"
+            size="md"
+            label="아지트 만들기"
+            tabIndex={-1}
+            className="pointer-events-none rounded-xl"
+          >
+            <Plus className="size-5 stroke-[2.5]" />
+          </IconButton>
+          <span>
+            <strong>아지트 만들기</strong>
+            <small>새 루틴을 함께 시작해요</small>
+          </span>
+        </TextLink>
+      </PageContainer>
+    </div>
   );
 }

--- a/components/organisms/AgitVideoViewer.tsx
+++ b/components/organisms/AgitVideoViewer.tsx
@@ -43,7 +43,7 @@ export function AgitVideoViewer({
         headerSubtitle={agitName}
         headerTrailing={
           <FeedPillIconButton label="더보기" onClick={() => setActionsOpen(true)}>
-            <DailyIcon name="ellipsis" size={16} className="brightness-0 invert" />
+            <DailyIcon name="ellipsis" size={20} className="brightness-0 invert" />
           </FeedPillIconButton>
         }
         overlayChildren={({ currentItem: item, currentDetail }: BaseVideoViewerOverlayProps) => (
@@ -58,8 +58,8 @@ export function AgitVideoViewer({
             {/* 우측 이모지 리액션 바 */}
             <VideoReactionBar />
 
-            {/* 하단 오버레이: 좌측 작성자 아토믹 뱃지 / 우측 정규화된 날짜 */}
-            <div className="relative z-10 mt-auto flex items-end justify-between px-6 pb-12 text-white pointer-events-none">
+            {/* 하단 오버레이: 좌측 작성자 아토믹 뱃지 / 우측 정규화된 날짜 (세로 정중앙 맞춤) */}
+            <div className="relative z-10 mt-auto flex items-center justify-between px-6 pb-12 text-white pointer-events-none">
               <UserProfileBadge
                 profileUrl={item.authorProfileUrl}
                 nickname={item.authorName || "작성자"}

--- a/components/organisms/BaseVideoViewer.tsx
+++ b/components/organisms/BaseVideoViewer.tsx
@@ -151,7 +151,7 @@ export function BaseVideoViewer({
         titleAlign="center"
         leading={
           <FeedPillIconButton label="닫기" onClick={() => onClose?.()}>
-            <DailyIcon name="chevronLeft" size={16} className="brightness-0 invert" />
+            <DailyIcon name="chevronLeft" size={20} className="brightness-0 invert" />
           </FeedPillIconButton>
         }
         title={headerTitle ?? currentItem.topicName ?? currentItem.title ?? "오늘의 영상"}

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { fetchDiaryDateWindowAction } from "@/actions/diaryActions";
-import { DailyIcon } from "@/components/atoms";
+import { DailyIcon, IconButton } from "@/components/atoms";
 import { DiaryThemeClipGroup, ScreenHeader } from "@/components/molecules";
 import { DiarySideMenu } from "@/components/organisms/DiarySideMenu";
 import { ROUTES } from "@/config/routes";
@@ -143,41 +143,39 @@ export function DiaryDateDetailSection({
   const formattedDate = focusDate.replaceAll("-", ".");
 
   return (
-    <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
-        tone="plain"
-        titleAlign="center"
         backHref={ROUTES.diary.root}
         title={formattedDate}
+        titleAlign="center"
         onMenuOpen={() => setMenuOpen(true)}
         menuLabel="다이어리 메뉴"
-        className="shrink-0 px-6 pt-3 pb-3"
       />
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         {/* 화면 중앙 좌우 플로팅 날짜 이동 버튼 */}
-        <button
-          type="button"
-          className="absolute left-2.5 top-1/2 z-20 -translate-y-1/2 grid size-10 cursor-pointer place-items-center rounded-full border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)]/85 text-[var(--dl-color-text-primary)] shadow-[0_4px_16px_rgba(23,23,28,0.08)] backdrop-blur-md transition-opacity hover:opacity-100 disabled:pointer-events-none disabled:opacity-20"
-          aria-label="이전 날짜"
+        <IconButton
+          variant="surface"
+          label="이전 날짜"
           onClick={goPrev}
+          className="absolute left-2.5 top-1/2 z-20 -translate-y-1/2 rounded-full border border-[var(--dl-color-border-default)] shadow-[0_4px_16px_rgba(23,23,28,0.08)] backdrop-blur-md transition-opacity hover:opacity-100 disabled:pointer-events-none disabled:opacity-20"
         >
           <DailyIcon name="chevronLeft" size={20} />
-        </button>
+        </IconButton>
 
-        <button
-          type="button"
-          className="absolute right-2.5 top-1/2 z-20 -translate-y-1/2 grid size-10 cursor-pointer place-items-center rounded-full border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)]/85 text-[var(--dl-color-text-primary)] shadow-[0_4px_16px_rgba(23,23,28,0.08)] backdrop-blur-md transition-opacity hover:opacity-100 disabled:pointer-events-none disabled:opacity-20"
-          aria-label="다음 날짜"
+        <IconButton
+          variant="surface"
+          label="다음 날짜"
           disabled={!canGoNext}
           onClick={goNext}
+          className="absolute right-2.5 top-1/2 z-20 -translate-y-1/2 rounded-full border border-[var(--dl-color-border-default)] shadow-[0_4px_16px_rgba(23,23,28,0.08)] backdrop-blur-md transition-opacity hover:opacity-100 disabled:pointer-events-none disabled:opacity-20"
         >
           <DailyIcon name="chevronRight" size={20} />
-        </button>
+        </IconButton>
 
         {/* 다이어리 클립 목록 */}
         <div
-          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 pt-2 pb-6 touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none]"
+          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-[12px_24px_24px] pt-2 touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none]"
           onPointerDown={handlePointerDown}
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerCancel}

--- a/components/organisms/DiaryMainSection.tsx
+++ b/components/organisms/DiaryMainSection.tsx
@@ -18,7 +18,6 @@ export function DiaryMainSection({ entries, themes, error }: DiaryMainSectionPro
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
         title="다이어리"
-        tone="default"
         onMenuOpen={() => setMenuOpen(true)}
         menuLabel="다이어리 메뉴"
       />

--- a/components/organisms/DiaryThemeDetailSection.tsx
+++ b/components/organisms/DiaryThemeDetailSection.tsx
@@ -53,16 +53,17 @@ export function DiaryThemeDetailSection({
   }
 
   return (
-    <>
-      <PageContainer aria-label={`${themeName} 테마 상세`}>
-        <ScreenHeader
-          titleAlign="center"
-          backHref={ROUTES.diary.themes.root}
-          title={themeName}
-          onMenuOpen={() => setMenuOpen(true)}
-          menuLabel="다이어리 메뉴"
-        />
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ScreenHeader
+        title={themeName}
+        backHref={ROUTES.diary.themes.root}
+        onMenuOpen={() => setMenuOpen(true)}
+        menuLabel="다이어리 메뉴"
+      />
 
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+
+      <PageContainer aria-label={`${themeName} 테마 상세`} className="flex-1">
         {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}
 
         {dateGroups.length > 0 ? (
@@ -96,8 +97,6 @@ export function DiaryThemeDetailSection({
           </button>
         ) : null}
       </PageContainer>
-
-      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
-    </>
+    </div>
   );
 }

--- a/components/organisms/DiaryThemesListSection.tsx
+++ b/components/organisms/DiaryThemesListSection.tsx
@@ -33,16 +33,17 @@ export function DiaryThemesListSection({ themes, error: fetchError }: DiaryTheme
   }
 
   return (
-    <>
-      <PageContainer aria-label="테마 목록">
-        <ScreenHeader
-          backHref={ROUTES.diary.root}
-          title="테마"
-          tone="plain"
-          onMenuOpen={() => setMenuOpen(true)}
-          menuLabel="다이어리 메뉴"
-        />
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ScreenHeader
+        backHref={ROUTES.diary.root}
+        title="테마"
+        onMenuOpen={() => setMenuOpen(true)}
+        menuLabel="다이어리 메뉴"
+      />
 
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+
+      <PageContainer aria-label="테마 목록" className="flex-1">
         {fetchError ? (
           <p className="m-0 text-sm text-[var(--dl-color-text-danger)]" role="alert">
             {fetchError}
@@ -70,8 +71,6 @@ export function DiaryThemesListSection({ themes, error: fetchError }: DiaryTheme
         onClose={closeSheet}
         theme={editingTheme}
       />
-
-      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
-    </>
+    </div>
   );
 }

--- a/components/organisms/ProfileHubSection.tsx
+++ b/components/organisms/ProfileHubSection.tsx
@@ -2,7 +2,7 @@
 
 import { logoutAction } from "@/actions/authActions";
 import { SubmitButton, TextLink, UserAvatar } from "@/components/atoms";
-import { SettingsRow } from "@/components/molecules/SettingsRow";
+import { PageContainer, ScreenHeader, SettingsRow } from "@/components/molecules";
 import { WithdrawAccountDialog } from "@/components/organisms/WithdrawAccountDialog";
 import { toast } from "@/components/ui/toast";
 import { ROUTES } from "@/config/routes";
@@ -50,10 +50,12 @@ export function ProfileHubSection({ profile }: ProfileHubSectionProps) {
   }
 
   return (
-    <>
-      <section className="flex w-full flex-col gap-3.5 pb-6" aria-label="마이페이지">
-        <h1 className="m-0 text-[26px] font-bold text-[var(--dl-color-text-primary)]">마이페이지</h1>
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ScreenHeader
+        tone="default"
+        title="설정" />
 
+      <PageContainer aria-label="마이페이지" className="flex-1">
         <div className="flex w-full items-center gap-[12px] rounded-[18px] bg-[var(--dl-color-bg-brand-subtle)] p-[14px]">
           <UserAvatar src={displayProfile.profileImageUrl} size={64} />
           <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
@@ -130,7 +132,7 @@ export function ProfileHubSection({ profile }: ProfileHubSectionProps) {
             회원 탈퇴
           </button>
         </div>
-      </section>
+      </PageContainer>
 
       <WithdrawAccountDialog
         open={withdrawOpen}
@@ -138,6 +140,6 @@ export function ProfileHubSection({ profile }: ProfileHubSectionProps) {
         email={displayProfile.email}
         requiresPasswordConfirmation={displayProfile.hasLocalAuth}
       />
-    </>
+    </div>
   );
 }

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -40,7 +40,7 @@ function TopicFeedEmptyCover({
 }: TopicFeedEmptyCoverProps) {
   return (
     <div
-      className="flex h-full min-h-0 w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 pt-16 text-center bg-[var(--dl-color-bg-surface-default)]"
+      className="relative flex min-h-full w-full shrink-0 snap-start snap-always flex-col items-center justify-center p-6 text-center bg-[var(--dl-color-bg-surface-default)]"
       style={style}
     >
       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--dl-color-bg-surface-subtle)]">
@@ -49,7 +49,7 @@ function TopicFeedEmptyCover({
       <p className="m-0 mt-4 text-base font-semibold text-[var(--dl-color-text-primary)]">
         {isFullyEmpty ? "등록된 토픽이 없습니다." : "진행 중인 토픽이 없습니다."}
       </p>
-      <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)]">
+      <p className="mt-1.5 mb-6 text-xs font-normal leading-relaxed text-[var(--dl-color-text-secondary)] max-w-xs break-keep">
         {isFullyEmpty
           ? "새로운 토픽을 생성하고 영상 기록을 시작해 보세요."
           : "새로운 토픽을 생성하거나, 아래로 끌어 이전 기록을 확인하세요."}
@@ -68,10 +68,18 @@ function TopicFeedEmptyCover({
         <button
           type="button"
           onClick={onScrollToFeed}
-          className="mt-8 flex flex-col items-center gap-1.5 text-xs font-semibold text-[var(--dl-color-text-secondary)] animate-bounce cursor-pointer border-0 bg-transparent"
+          className="absolute top-[75%] left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-1 border-0 bg-transparent p-2 text-center cursor-pointer group"
         >
-          <span>이전 기록 피드 보기</span>
-          <DailyIcon name="chevronLeft" size={16} className="-rotate-90 brightness-0 opacity-60" />
+          <span className="text-[11px] font-medium text-[var(--dl-color-text-tertiary)] group-hover:text-[var(--dl-color-text-primary)] transition-colors whitespace-nowrap">
+            이전 기록 피드 보기
+          </span>
+          <span className="inline-block animate-bounce">
+            <DailyIcon
+              name="chevronLeft"
+              size={16}
+              className="-rotate-90 text-[var(--dl-color-text-tertiary)] group-hover:text-[var(--dl-color-text-primary)] opacity-70 transition-colors"
+            />
+          </span>
         </button>
       )}
     </div>
@@ -295,7 +303,7 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
 
         {/* 피드 슬라이드 노출 시 하단 우측 고정 날짜 */}
         {!isAtCoverSlide && (
-          <div className="pointer-events-none absolute bottom-4 right-4 z-30 flex items-center">
+          <div className="pointer-events-none absolute bottom-7 right-6 z-30 flex items-center">
             <span className="text-xs font-medium text-white/80 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
               {extractDate(currentTopic.startDate)}
             </span>

--- a/components/templates/AppChromeTemplate.tsx
+++ b/components/templates/AppChromeTemplate.tsx
@@ -46,7 +46,7 @@ export function AppChromeTemplate({
 
   return (
     <div className={`${shellClass} ${className}`.trim()}>
-      <div className={`flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden ${showNav ? "pb-[80px]" : ""}`}>
+      <div className={`flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden ${showNav ? "pb-[calc(80px+env(safe-area-inset-bottom,0px))]" : ""}`}>
         {header}
         <main
           className={`flex min-h-0 w-full flex-1 flex-col ${mainOverflow === "hidden" ? "overflow-hidden" : "overflow-y-auto"} ${paddingClass} ${contentClassName}`.trim()}

--- a/components/templates/DiaryThemeDetailTemplate.tsx
+++ b/components/templates/DiaryThemeDetailTemplate.tsx
@@ -20,7 +20,7 @@ export function DiaryThemeDetailTemplate({
   error,
 }: DiaryThemeDetailTemplateProps) {
   return (
-    <DiaryTemplate>
+    <DiaryTemplate fixedMain>
       <DiaryThemeDetailSection
         themeId={themeId}
         themeName={themeName}

--- a/components/templates/MyPageTemplate.tsx
+++ b/components/templates/MyPageTemplate.tsx
@@ -1,6 +1,5 @@
-import { BottomNavigation } from "@/components/molecules";
+import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 import { ProfileHubSection } from "@/components/organisms/ProfileHubSection";
-import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import type { UiUserProfile } from "@/types/user/ui";
 import type { ReactNode } from "react";
 
@@ -16,13 +15,13 @@ export function MyPageTemplate({
   children,
 }: MyPageTemplateProps) {
   return (
-    <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
-      <div className={`min-h-0 flex-1 overflow-y-auto ${showBottomNav ? "pb-[120px]" : ""}`}>
-        <DailyLoopAuthTemplate>
-          {children ?? <ProfileHubSection profile={profile} />}
-        </DailyLoopAuthTemplate>
-      </div>
-      {showBottomNav ? <BottomNavigation active="mypage" variant="light" /> : null}
-    </div>
+    <AppChromeTemplate
+      activeTab="mypage"
+      variant="light"
+      showNav={showBottomNav}
+      mainOverflow="hidden"
+    >
+      {children ?? <ProfileHubSection profile={profile} />}
+    </AppChromeTemplate>
   );
 }


### PR DESCRIPTION
## 작업 내용

하단 네비게이션 독(BottomNavigation)의 레이아웃 트림 및 카메라 버튼 3D 브랜드 그라데이션·네온 글래스 링 인터랙션을 개선하고, 다이어리/아지트/마이페이지 전 페이지의 고정 헤더(`ScreenHeader`) 및 페이지 컨테이너 래퍼 구조를 1:1 대칭 표준화했습니다. 

또한 `IconButton` / `IconLink` 아톰 컴포넌트의 배리언트(`surface`, `overlay`, `brand` 등) 및 터치 규격(44px)을 표준화하여 비디오 뷰어 및 생성/추가 카드에 일괄 연동했으며, 모바일 Edge-to-Edge 뷰포트 세이프 에어리어 및 본문(Pretendard Variable) / 헤더(Paperlogy) 서체 체계를 고도화했습니다.

## 관련 이슈

Close #134

## 변경 사항

### 1. 하단 네비게이션 독 레이아웃 및 3D 카메라 버튼 인터랙션 개선
- **파일**: [BottomNavigation.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/molecules/BottomNavigation.tsx), [CaptureClipOverlays.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/molecules/CaptureClipOverlays.tsx)
- **설명**: 하단 독 상단 보더라인을 은은한 글래스 톤(`border-black/5 dark:border-white/10`)으로 정돈하고, 솟아오른 카메라 버튼에 3D 브랜드 그라데이션, 반투명 네온 글래스 링 및 호버/액티브 스케일 반응 모션을 반영했습니다.
- **코드**:
```tsx
<span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 grid size-[84px] place-items-center rounded-full bg-[linear-gradient(145deg,var(--dl-color-bg-brand),#3b82f6)] ring-4 ring-white/20 shadow-[0_-6px_20px_rgba(79,70,229,0.4)] [clip-path:inset(-40px_-30px_0px_-30px)] transition-all duration-200 group-hover:scale-105 group-hover:ring-white/40 group-active:scale-95">
  <Camera className="size-9 text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.3)] transition-transform duration-200 group-hover:scale-110" strokeWidth={2.2} />
</span>
```

### 2. ScreenHeader 공통 탑바 헤더 1:1 대칭 일원화
- **파일**: [ScreenHeader.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/molecules/ScreenHeader.tsx), [MyPageTemplate.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/templates/MyPageTemplate.tsx), [ProfileHubSection.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/organisms/ProfileHubSection.tsx), [DiaryMainSection.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/organisms/DiaryMainSection.tsx)
- **설명**: 다이어리, 아지트, 마이페이지 전체 화면에 음수 마진 없이 표준 24px 패딩과 `<ScreenHeader />` + `<PageContainer className="flex-1">` 래퍼 구조를 1:1 동등하게 연결했습니다.
- **코드**:
```tsx
<div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
  <ScreenHeader tone="default" title="설정" />
  <PageContainer aria-label="마이페이지" className="flex-1">
    {/* 마이페이지 콘텐츠 */}
  </PageContainer>
</div>
```

### 3. IconButton / IconLink 아톰 표준화 및 뷰어·추가 카드 연동
- **파일**: [IconButton.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/atoms/IconButton.tsx), [TopicFeedPillHeader.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/molecules/TopicFeedPillHeader.tsx), [TopicVideoTile.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/molecules/TopicVideoTile.tsx), [AgitListSection.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/organisms/AgitListSection.tsx)
- **설명**: `IconButton`에 `variant` (`surface` | `outline` | `ghost` | `overlay` | `brand`) 및 `size` (`pill` | `sm` | `md` | `lg` - 44px) 분리를 적용하고, 호버/액티브 독 모션(`hover:scale-105 active:scale-95`)을 반영하였습니다. 다이어리 미기록, 테마 추가, 아지트 생성 카드 아이콘 요소에도 `<IconButton variant="brand" size="md" />` 아톰을 일원화했습니다.
- **코드**:
```tsx
const BASE_ICON_CLASS =
  "inline-flex shrink-0 cursor-pointer items-center justify-center no-underline transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 select-none";

const VARIANT_CLASSES: Record<IconButtonVariant, string> = {
  surface: "border-0 bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-primary)] hover:bg-[var(--dl-color-bg-brand-subtle)] hover:text-[var(--dl-color-text-brand)]",
  overlay: "border-0 bg-black/20 text-white shadow-[0_4px_16px_rgba(0,0,0,0.16)] backdrop-blur-md hover:bg-black/35 active:bg-black/50",
  brand: "border-0 bg-[var(--dl-color-bg-brand)] text-white shadow-xs",
  ...
};
```

### 4. 모바일 뷰포트 Edge-to-Edge 대응 및 Pretendard / Paperlogy 서체 적용
- **파일**: [layout.tsx](file:///c:/Users/G11/team-yes/plip-user-app/app/layout.tsx), [globals.css](file:///c:/Users/G11/team-yes/plip-user-app/app/globals.css), [ScreenTitle.tsx](file:///c:/Users/G11/team-yes/plip-user-app/components/atoms/ScreenTitle.tsx)
- **설명**: `viewportFit: "cover"` 메타 설정 및 상하단 세이프 에어리어(`env(safe-area-inset-top/bottom)`)를 적용했습니다. 본문 서체에는 대한민국 표준 모바일 가독 서체인 `Pretendard Variable`을 전역 주입하고, 공통 헤더 제목에는 감성 서체인 `Paperlogy(페이퍼로지체)`(`--font-title`)를 연동했습니다.
- **코드**:
```css
:root {
  --font-sans: "Pretendard Variable", Pretendard, -apple-system, sans-serif;
  --font-title: "Paperlogy", "Pretendard Variable", sans-serif;
}
```

## 테스트

- [x] 모바일/PC 로컬 화면에서 `ScreenHeader` 고정 탑바 및 독 높이 레이아웃 1:1 대칭 검증
- [x] 하단 독 3D 카메라 버튼 및 아이콘 버튼 호버/액티브 스케일 모션 동작 확인
- [x] 비디오 풀뷰어 및 피드 그룹 뷰어 내 닫기/메뉴/프로필 뱃지 수평 수직 중앙 정렬 확인
- [x] Pretendard 본문 폰트 및 ScreenHeader 페이퍼로지 제목 서체 렌더링 검증
- [x] Turbopack `npm run dev` 빌드 파싱 정상 동작 확인
