### PR TITLE
[#136] Feature : 방 가입 페이지 랜딩 API OG 메타데이터 연동 및 초대 URL 복사 기능 구현

### DIFF
--- a/app/(agit)/agit/join/[code]/page.tsx
+++ b/app/(agit)/agit/join/[code]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { InviteJoinLandingTemplate } from "@/components/templates";
 import { ApiError } from "@/lib/api/apiFetch";
 import { getAgitLanding } from "@/services/agitService";
@@ -6,6 +7,46 @@ import type { UiAgit } from "@/types/agit/ui";
 type PageProps = {
   params: Promise<{ code: string }>;
 };
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { code } = await params;
+  const inviteCode = decodeURIComponent(code).trim();
+
+  try {
+    const agit = await getAgitLanding(inviteCode);
+    if (!agit) {
+      return {
+        title: "아지트 초대 - PLIP",
+        description: "PLIP 아지트 초대 페이지입니다.",
+      };
+    }
+
+    const title = `${agit.name} - 아지트 초대 | PLIP`;
+    const description =
+      agit.description || `${agit.name} 아지트에 초대를 받았습니다. PLIP에서 함께 일상을 공유해보세요.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title: `${agit.name} 아지트에 초대되었습니다`,
+        description,
+        images: agit.thumbnailSrc ? [{ url: agit.thumbnailSrc }] : [],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: `${agit.name} 아지트에 초대되었습니다`,
+        description,
+        images: agit.thumbnailSrc ? [agit.thumbnailSrc] : [],
+      },
+    };
+  } catch {
+    return {
+      title: "아지트 초대 - PLIP",
+      description: "PLIP 아지트 초대 페이지입니다.",
+    };
+  }
+}
 
 export default async function AgitInviteJoinPage({ params }: PageProps) {
   const { code } = await params;
@@ -16,12 +57,16 @@ export default async function AgitInviteJoinPage({ params }: PageProps) {
   try {
     agit = await getAgitLanding(inviteCode);
   } catch (caught) {
-    if (caught instanceof ApiError && (caught.status === 400 || caught.status === 404)) {
-      agit = null;
+    agit = null;
+    if (caught instanceof ApiError) {
+      error = `[API Error ${caught.status}] ${caught.message}`;
+    } else if (caught instanceof Error) {
+      error = `[Error] ${caught.message}`;
     } else {
-      error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
+      error = "아지트를 불러오지 못했습니다.";
     }
   }
 
   return <InviteJoinLandingTemplate agit={agit} error={error} />;
 }
+

--- a/auth.ts
+++ b/auth.ts
@@ -204,6 +204,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         return Response.redirect(new URL("/diary", request.nextUrl));
       }
 
+      // 방 가입 랜딩 페이지(/agit/join/[code])는 비로그인 상태에서도 접근 허용
+      if (
+        pathname.startsWith("/agit/join/") &&
+        !pathname.includes("/profile") &&
+        !pathname.includes("/complete")
+      ) {
+        return true;
+      }
+
       if (matchesPrefix(pathname, PROTECTED_PREFIXES) && !isLoggedIn) {
         return false;
       }

--- a/components/organisms/AgitMenuDrawer.tsx
+++ b/components/organisms/AgitMenuDrawer.tsx
@@ -92,8 +92,13 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
 
   async function copyInviteCode() {
     if (!inviteCode) return;
-    const ok = await copyText(inviteCode);
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const joinUrl = `${origin}${ROUTES.agit.join(inviteCode)}`;
+    const ok = await copyText(joinUrl);
     setCopied(ok);
+    if (ok) {
+      toast.add({ type: "success", title: "초대 링크가 복사되었습니다" });
+    }
   }
 
   async function reissueInviteCode() {
@@ -156,7 +161,7 @@ export function AgitMenuDrawer({ agit, open, onClose }: AgitMenuDrawerProps) {
             className="flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 bg-transparent px-2.5 text-left disabled:cursor-default"
             onClick={copyInviteCode}
             disabled={!inviteCode}
-            aria-label="초대코드 복사"
+            aria-label="초대 URL 복사"
           >
             <div className="flex min-w-0 items-center gap-2">
               <Link2 className="size-3.5 shrink-0 text-[#262433]" strokeWidth={2} />

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -107,7 +107,7 @@ export async function getAgitLanding(code: string): Promise<ApiAgitLanding> {
   return apiFetch<ApiAgitLanding>(API_ENDPOINTS.agit.landing(code), {
     method: "GET",
     baseUrl: getApiUrl(),
-    auth: false,
+    headers: await getActorUserHeaders(),
   });
 }
 


### PR DESCRIPTION
## 작업 내용

방 가입 페이지(`/agit/join/[code]`)에서 오픈그래프(OG) 메타데이터가 랜딩 API 정보를 받아서 설정되도록 `generateMetadata`를 연동하고, 방 메뉴에서 초대 코드 복사 시 전체 진입 URL이 클립보드에 복사되도록 개선했습니다. 또한 비로그인 사용자도 방 가입 랜딩 페이지를 조회할 수 있도록 미들웨어 세션 인증 예외 규칙을 보완했습니다.

## 관련 이슈

Close #136

## 변경 사항

### 1. 방 가입 페이지 Dynamic OG 메타데이터 연동 및 에러 처리

- **파일:** `app/(agit)/agit/join/[code]/page.tsx`
- **설명:** `generateMetadata` 함수를 구현하여 랜딩 API(`getAgitLanding`) 정보(아지트 이름, 설명, 썸네일 등)를 기반으로 OpenGraph 메타태그를 생성하고, API 에러 발생 시 상태 코드 및 메시지를 화면에 명확히 표시하도록 개선했습니다.

```typescript
// app/(agit)/agit/join/[code]/page.tsx
export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
  const { code } = await params;
  const inviteCode = decodeURIComponent(code).trim();

  try {
    const agit = await getAgitLanding(inviteCode);
    if (!agit) {
      return {
        title: "아지트 초대 - PLIP",
        description: "PLIP 아지트 초대 페이지입니다.",
      };
    }

    const title = `${agit.name} - 아지트 초대 | PLIP`;
    const description =
      agit.description || `${agit.name} 아지트에 초대를 받았습니다. PLIP에서 함께 일상을 공유해보세요.`;

    return {
      title,
      description,
      openGraph: {
        title: `${agit.name} 아지트에 초대되었습니다`,
        description,
        images: agit.thumbnailSrc ? [{ url: agit.thumbnailSrc }] : [],
      },
      twitter: {
        card: "summary_large_image",
        title: `${agit.name} 아지트에 초대되었습니다`,
        description,
        images: agit.thumbnailSrc ? [agit.thumbnailSrc] : [],
      },
    };
  } catch {
    return {
      title: "아지트 초대 - PLIP",
      description: "PLIP 아지트 초대 페이지입니다.",
    };
  }
}
```

### 2. 게스트 사용자 방 가입 랜딩 페이지 접근 허용

- **파일:** `auth.ts`
- **설명:** `authorized` 콜백 규칙을 수정하여 비로그인 사용자도 초대 받은 방 가입 랜딩 페이지(`/agit/join/[code]`)에 접근하여 정보를 볼 수 있도록 허용했습니다.

```typescript
// auth.ts
    authorized({ auth: session, request }: { auth: Session | null; request: NextRequest }) {
      const pathname = request.nextUrl.pathname;
      const isLoggedIn = session?.isLoggedIn === true;

      if (matchesPrefix(pathname, GUEST_ONLY_PREFIXES) && isLoggedIn) {
        return Response.redirect(new URL("/diary", request.nextUrl));
      }

      // 방 가입 랜딩 페이지(/agit/join/[code])는 비로그인 상태에서도 접근 허용
      if (
        pathname.startsWith("/agit/join/") &&
        !pathname.includes("/profile") &&
        !pathname.includes("/complete")
      ) {
        return true;
      }

      if (matchesPrefix(pathname, PROTECTED_PREFIXES) && !isLoggedIn) {
        return false;
      }

      return true;
    },
```

### 3. 방 메뉴 초대 진입 URL 복사 기능 개선

- **파일:** `components/organisms/AgitMenuDrawer.tsx`
- **설명:** 초대 버튼 클릭 시 초대 코드 단독 텍스트 대신 클라이언트 진입 Full URL(`window.location.origin + /agit/join/[code]`)을 클립보드에 복사하도록 수정했습니다.

```typescript
// components/organisms/AgitMenuDrawer.tsx
  async function copyInviteCode() {
    if (!inviteCode) return;
    const origin = typeof window !== "undefined" ? window.location.origin : "";
    const joinUrl = `${origin}${ROUTES.agit.join(inviteCode)}`;
    const ok = await copyText(joinUrl);
    setCopied(ok);
    if (ok) {
      toast.add({ type: "success", title: "초대 링크가 복사되었습니다" });
    }
  }
```

### 4. getAgitLanding API Actor 헤더 전달

- **파일:** `lib/api/agitApi.ts`
- **설명:** 백엔드 Gateway 인증 요구사항 대응을 위해 `getAgitLanding` 호출 시 게스트 Fallback 헤더(`getActorUserHeaders()`)를 전송하도록 수정했습니다.

```typescript
// lib/api/agitApi.ts
export async function getAgitLanding(code: string): Promise<ApiAgitLanding> {
  return apiFetch<ApiAgitLanding>(API_ENDPOINTS.agit.landing(code), {
    method: "GET",
    baseUrl: getApiUrl(),
    headers: await getActorUserHeaders(),
  });
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
