### PR TITLE
[#138] Feature : 아지트 채팅 unread 배지·receipt FE 연동

### DIFF
--- a/actions/chatActions.ts
+++ b/actions/chatActions.ts
@@ -63,14 +63,17 @@ export async function getChatHistoryAction(
   }
 }
 
-export async function markChatReadAction(agitId: string): Promise<ActionResult<void>> {
+export async function markChatReadAction(
+  agitId: string,
+  readAt?: string,
+): Promise<ActionResult<void>> {
   const loginError = await requireLogin();
   if (loginError) {
     return actionFailure(loginError);
   }
 
   try {
-    await chatService.markChatRead(agitId);
+    await chatService.markChatRead(agitId, readAt);
     return actionSuccess(undefined);
   } catch (error) {
     return toActionError(error);

--- a/app/(agit)/agit/page.tsx
+++ b/app/(agit)/agit/page.tsx
@@ -1,10 +1,14 @@
 import { AgitListTemplate } from "@/components/templates";
 import { listMyAgits } from "@/services/agitService";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import { isEnableRemoteChatEnabled } from "@/lib/api/env";
 import type { UiAgit } from "@/types/agit/ui";
 
 export default async function AgitListPage() {
   let items: UiAgit[] = [];
   let error: string | undefined;
+  const currentUserUuid = await getServerUserUuid();
+  const enableRemoteChat = isEnableRemoteChatEnabled();
 
   try {
     items = await listMyAgits();
@@ -14,5 +18,12 @@ export default async function AgitListPage() {
       caught instanceof Error ? caught.message : "아지트 목록을 불러오지 못했습니다.";
   }
 
-  return <AgitListTemplate items={items} error={error} />;
+  return (
+    <AgitListTemplate
+      items={items}
+      error={error}
+      currentUserUuid={currentUserUuid}
+      enableRemoteChat={enableRemoteChat}
+    />
+  );
 }

--- a/components/molecules/AgitListRow.tsx
+++ b/components/molecules/AgitListRow.tsx
@@ -1,11 +1,28 @@
+"use client";
+
 import { DailyIcon, Pill, TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
+import { useAgitChatUnread } from "@/hooks/useAgitChatUnread";
 import type { UiAgit } from "@/types/agit/ui";
 import Image from "next/image";
 
 type AgitListRowProps = {
   agit: UiAgit;
 };
+
+function formatChatUnreadBadge(count: number): string {
+  if (count > 99) {
+    return "99+";
+  }
+  return String(count);
+}
+
+function resolveChatUnreadCount(agit: UiAgit): number {
+  if (typeof agit.chatUnreadCount === "number") {
+    return agit.chatUnreadCount;
+  }
+  return agit.hasNewChat ? 1 : 0;
+}
 
 function topicBadgeLabel(topicSummary: string) {
   return topicSummary.startsWith("#")
@@ -17,6 +34,9 @@ const ACTION_CLASS =
   "relative grid h-[40px] w-[40px] place-items-center rounded-[12px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)] no-underline transition-all duration-300 hover:border-[var(--dl-color-border-brand)]/40 hover:bg-gradient-to-b hover:from-[var(--dl-color-bg-brand-subtle)]/60 hover:to-[var(--dl-color-bg-elevated)] hover:text-[var(--dl-color-text-brand)] hover:shadow-[0_2px_12px_rgba(79,70,229,0.12)]";
 
 export function AgitListRow({ agit }: AgitListRowProps) {
+  const initialUnreadCount = resolveChatUnreadCount(agit);
+  const chatUnreadCount = useAgitChatUnread(agit.id, initialUnreadCount);
+
   return (
     <article className="overflow-hidden rounded-[18px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] shadow-[0_8px_24px_rgba(23,_23,_28,_0.04)]">
       <div className="relative">
@@ -54,11 +74,13 @@ export function AgitListRow({ agit }: AgitListRowProps) {
         <div className="absolute top-[8px] right-[8px] z-[2] flex flex-col gap-[8px]">
           <TextLink href={ROUTES.agit.chat(agit.id)} className={ACTION_CLASS} aria-label={`${agit.name} 채팅`}>
             <DailyIcon name="message" size={20} />
-            {agit.hasNewChat ? (
+            {chatUnreadCount > 0 ? (
               <span
-                className="absolute top-[7px] right-[7px] h-[7px] w-[7px] rounded-[999px] border border-[#fff] bg-[var(--dl-color-bg-brand)]"
-                aria-hidden
-              />
+                className="absolute top-[2px] right-[2px] grid min-h-[16px] min-w-[16px] place-items-center rounded-[999px] border border-[#fff] bg-[var(--dl-color-bg-brand)] px-[4px] text-[10px] font-semibold leading-none text-[var(--dl-color-text-inverse)]"
+                aria-label={`미읽음 ${chatUnreadCount}개`}
+              >
+                {formatChatUnreadBadge(chatUnreadCount)}
+              </span>
             ) : null}
           </TextLink>
           <TextLink href={ROUTES.agit.upload(agit.id)} className={ACTION_CLASS} aria-label={`${agit.name} 촬영`}>

--- a/components/molecules/ChatMessageBody.tsx
+++ b/components/molecules/ChatMessageBody.tsx
@@ -5,7 +5,7 @@ import { CHAT_BUBBLE_COLLAPSED_MAX_HEIGHT } from "@/lib/chat/limits";
 import { cacheChatMessage } from "@/lib/chat/messageCache";
 import type { UiChatMessage } from "@/types/chat/ui";
 import { useRouter } from "next/navigation";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 type ChatMessageBodyProps = {
   agitId: string;
@@ -13,6 +13,8 @@ type ChatMessageBodyProps = {
   bubbleClassName: string;
   textClassName: string;
   timeLabel?: string;
+  bubbleLeading?: ReactNode;
+  bubbleTrailing?: ReactNode;
   actionClassName?: string;
 };
 
@@ -22,6 +24,8 @@ export function ChatMessageBody({
   bubbleClassName,
   textClassName,
   timeLabel,
+  bubbleLeading,
+  bubbleTrailing,
   actionClassName = "text-[var(--dl-color-text-brand)]",
 }: ChatMessageBodyProps) {
   const router = useRouter();
@@ -67,14 +71,18 @@ export function ChatMessageBody({
 
   return (
     <div className={`flex max-w-full flex-col gap-1 ${message.isMine ? "items-end" : "items-start"}`}>
-      <div ref={bubbleRef} className={bubbleClassName}>
-        <div
-          ref={bodyRef}
-          className={`overflow-hidden whitespace-pre-wrap break-words ${textClassName}`}
-          style={{ maxHeight: CHAT_BUBBLE_COLLAPSED_MAX_HEIGHT }}
-        >
-          {message.content}
+      <div className={`flex max-w-full items-end gap-1 ${message.isMine ? "justify-end" : ""}`}>
+        {bubbleLeading}
+        <div ref={bubbleRef} className={bubbleClassName}>
+          <div
+            ref={bodyRef}
+            className={`overflow-hidden whitespace-pre-wrap break-words ${textClassName}`}
+            style={{ maxHeight: CHAT_BUBBLE_COLLAPSED_MAX_HEIGHT }}
+          >
+            {message.content}
+          </div>
         </div>
+        {bubbleTrailing}
       </div>
       {showMetaRow ? (
         showSplitMetaRow ? (

--- a/components/molecules/ChatRoomMessage.tsx
+++ b/components/molecules/ChatRoomMessage.tsx
@@ -2,6 +2,7 @@ import { UserAvatar } from "@/components/atoms/UserAvatar";
 import { ChatMessageBody } from "@/components/molecules/ChatMessageBody";
 import type { UiChatMessage } from "@/types/chat/ui";
 import { SystemMessageRow } from "@/components/molecules/SystemMessageRow";
+import type { ReactNode } from "react";
 
 type ChatRoomMessageProps = {
   agitId: string;
@@ -9,6 +10,25 @@ type ChatRoomMessageProps = {
   showTimeLabel?: boolean;
   compact?: boolean;
 };
+
+function resolveUnreadMemberCountLabel(message: UiChatMessage): string | null {
+  if (
+    message.type !== "TALK" ||
+    typeof message.unreadMemberCount !== "number" ||
+    message.unreadMemberCount <= 0
+  ) {
+    return null;
+  }
+  return String(message.unreadMemberCount);
+}
+
+function UnreadMemberCountLabel({ label }: { label: string }) {
+  return (
+    <span className="shrink-0 text-[11px] font-semibold text-[var(--dl-color-text-secondary)]">
+      {label}
+    </span>
+  );
+}
 
 export function ChatRoomMessage({
   agitId,
@@ -21,6 +41,10 @@ export function ChatRoomMessage({
   }
 
   const timeLabel = showTimeLabel ? message.timeLabel : undefined;
+  const unreadMemberCountLabel = resolveUnreadMemberCountLabel(message);
+  const unreadLabelNode: ReactNode = unreadMemberCountLabel ? (
+    <UnreadMemberCountLabel label={unreadMemberCountLabel} />
+  ) : null;
 
   if (message.isMine) {
     return (
@@ -30,6 +54,7 @@ export function ChatRoomMessage({
             agitId={agitId}
             message={message}
             timeLabel={timeLabel}
+            bubbleLeading={unreadLabelNode}
             bubbleClassName="w-fit max-w-full rounded-2xl bg-[var(--dl-color-bg-brand)] px-3 py-2.5"
             textClassName="text-sm leading-5 text-[var(--dl-color-text-inverse)]"
             actionClassName="text-[var(--dl-color-text-brand)]"
@@ -46,7 +71,7 @@ export function ChatRoomMessage({
       ) : message.profileImageSrc ? (
         <UserAvatar src={message.profileImageSrc} size={36} className="border-0 bg-[var(--dl-color-bg-surface)]" />
       ) : (
-        <span className="size-9 shrink-0 rounded-full bg-[var(--dl-color-bg-surface)]" aria-hidden />
+        <span className="size-9 shrink-0 rounded-full bg-[var(--dl-color-bg-surface)]" />
       )}
       <div className="flex max-w-[276px] flex-col gap-1">
         {!compact ? (
@@ -56,6 +81,7 @@ export function ChatRoomMessage({
           agitId={agitId}
           message={message}
           timeLabel={timeLabel}
+          bubbleTrailing={unreadLabelNode}
           bubbleClassName="w-fit max-w-full rounded-2xl bg-[var(--dl-color-bg-surface)] px-3 py-2.5"
           textClassName="text-sm leading-5 text-[var(--dl-color-text-primary)]"
         />

--- a/components/organisms/AgitListSection.tsx
+++ b/components/organisms/AgitListSection.tsx
@@ -1,20 +1,30 @@
 "use client";
 import leftoverStyles from "@/components/styles/leftover.module.css";
 
-import { DailyIcon, IconButton, IconLink, TextLink } from "@/components/atoms";
+import { IconButton, TextLink } from "@/components/atoms";
 import { AgitListRow, HeaderSearchLink, PageContainer, ScreenHeader } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
+import { useAgitListChatSync } from "@/hooks/useAgitListChatSync";
 import { Plus } from "lucide-react";
 import type { UiAgit } from "@/types/agit/ui";
 
 type AgitListSectionProps = {
   items: UiAgit[];
   error?: string;
+  currentUserUuid?: string;
+  enableRemoteChat?: boolean;
 };
 
-export function AgitListSection({ items, error }: AgitListSectionProps) {
+export function AgitListSection({
+  items,
+  error,
+  currentUserUuid,
+  enableRemoteChat = false,
+}: AgitListSectionProps) {
   const rooms = items;
   const totalVideos = rooms.reduce((sum, room) => sum + (room.todayVideoCount ?? 0), 0);
+
+  useAgitListChatSync({ items: rooms, currentUserUuid, enabled: enableRemoteChat });
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">

--- a/components/organisms/RoomChatSection.tsx
+++ b/components/organisms/RoomChatSection.tsx
@@ -18,8 +18,10 @@ import {
   readRoomHistoryCache,
   writeRoomHistoryCache,
 } from "@/lib/chat/roomHistoryCache";
+import { setAgitChatUnread } from "@/lib/chat/chatUnreadStore";
 import type { ApiAgitDetailMember } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
+import type { ApiChatReceiptPayload } from "@/types/chat/api";
 import type { UiChatHistory, UiChatMessage } from "@/types/chat/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -33,25 +35,6 @@ type RoomChatSectionProps = {
 
 function mergeMessages(existing: UiChatMessage[], incoming: UiChatMessage[]): UiChatMessage[] {
   return mergeChatMessages(existing, incoming);
-}
-
-function resolveInitialHistory(
-  agitId: string,
-  initialHistory: UiChatHistory,
-  enableRemoteChat: boolean,
-): UiChatHistory {
-  if (!enableRemoteChat) {
-    return initialHistory;
-  }
-  const cached = readRoomHistoryCache(agitId);
-  if (!cached) {
-    return initialHistory;
-  }
-  return {
-    messages: mergeMessages(initialHistory.messages, cached.messages),
-    nextCursor: cached.nextCursor ?? initialHistory.nextCursor,
-    hasNext: cached.hasNext ?? initialHistory.hasNext,
-  };
 }
 
 function scrollToBottom(container: HTMLDivElement | null) {
@@ -68,18 +51,18 @@ export function RoomChatSection({
   currentUserUuid,
   enableRemoteChat = false,
 }: RoomChatSectionProps) {
-  const resolvedInitialHistory = resolveInitialHistory(agit.id, initialHistory, enableRemoteChat);
   const [notify, setNotify] = useState(true);
   const [draft, setDraft] = useState("");
-  const [messages, setMessages] = useState(resolvedInitialHistory.messages);
-  const [nextCursor, setNextCursor] = useState(resolvedInitialHistory.nextCursor);
-  const [hasNext, setHasNext] = useState(resolvedInitialHistory.hasNext);
+  const [messages, setMessages] = useState(initialHistory.messages);
+  const [nextCursor, setNextCursor] = useState(initialHistory.nextCursor);
+  const [hasNext, setHasNext] = useState(initialHistory.hasNext);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const shouldStickToBottomRef = useRef(true);
   const messagesRef = useRef(messages);
   const nextCursorRef = useRef(nextCursor);
   const hasNextRef = useRef(hasNext);
+  const lastMarkedMessageIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -90,25 +73,89 @@ export function RoomChatSection({
   const handleIncomingMessage = useCallback(
     (payload: Parameters<typeof mapApiChatMessage>[0]) => {
       const mapped = mapApiChatMessage(payload, members, currentUserUuid);
-      setMessages((current) => mergeMessages(current, [mapped]));
+      const withUnreadCount =
+        mapped.type === "TALK" && mapped.unreadMemberCount === undefined
+          ? {
+              ...mapped,
+              unreadMemberCount: Math.max(0, members.length - 1),
+            }
+          : mapped;
+      setMessages((current) => mergeMessages(current, [withUnreadCount]));
     },
     [currentUserUuid, members],
   );
+
+  const handleIncomingReceipt = useCallback((payload: ApiChatReceiptPayload) => {
+    const receiptMessageId = payload.messageId.toLowerCase();
+    setMessages((current) =>
+      current.map((message) =>
+        message.id.toLowerCase() === receiptMessageId
+          ? { ...message, unreadMemberCount: payload.unreadMemberCount }
+          : message,
+      ),
+    );
+  }, []);
 
   const { sendMessage: sendRemoteMessage } = useAgitChatSocket({
     agitUuid: agit.id,
     enabled: enableRemoteChat && Boolean(currentUserUuid),
     onMessage: handleIncomingMessage,
+    onReceipt: handleIncomingReceipt,
   });
+
+  const markReadUpToLatest = useCallback(() => {
+    const latest = messagesRef.current.at(-1);
+    if (!latest) {
+      return;
+    }
+    if (lastMarkedMessageIdRef.current === latest.id) {
+      return;
+    }
+    lastMarkedMessageIdRef.current = latest.id;
+    void markChatReadAction(agit.id, new Date().toISOString()).then((result) => {
+      if (result.ok) {
+        setAgitChatUnread(agit.id, 0);
+      }
+    });
+  }, [agit.id]);
+
+  useEffect(() => {
+    if (!enableRemoteChat || messages.length === 0) {
+      return;
+    }
+    markReadUpToLatest();
+  }, [enableRemoteChat, markReadUpToLatest, messages]);
 
   useEffect(() => {
     if (!enableRemoteChat) {
       return;
     }
-    void markChatReadAction(agit.id);
     return () => {
-      void markChatReadAction(agit.id);
+      const latest = messagesRef.current.at(-1);
+      if (!latest) {
+        return;
+      }
+      void markChatReadAction(agit.id, new Date().toISOString()).then((result) => {
+        if (result.ok) {
+          setAgitChatUnread(agit.id, 0);
+        }
+      });
     };
+  }, [agit.id, enableRemoteChat]);
+
+  useEffect(() => {
+    if (!enableRemoteChat) {
+      return;
+    }
+    const cached = readRoomHistoryCache(agit.id);
+    if (!cached) {
+      return;
+    }
+    // SSR 초기값 이후 sessionStorage 캐시 병합
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 1회 클라이언트 캐시 반영
+    setMessages((current) => mergeMessages(current, cached.messages));
+    setNextCursor((current) => cached.nextCursor ?? current);
+    setHasNext((current) => cached.hasNext ?? current);
   }, [agit.id, enableRemoteChat]);
 
   useEffect(() => {

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -16,13 +16,22 @@ import type { UiTopicGallery } from "@/types/topic/ui";
 export function AgitListTemplate({
   items,
   error,
+  currentUserUuid,
+  enableRemoteChat = false,
 }: {
   items: UiAgit[];
   error?: string;
+  currentUserUuid?: string;
+  enableRemoteChat?: boolean;
 }) {
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
-      <AgitListSection items={items} error={error} />
+      <AgitListSection
+        items={items}
+        error={error}
+        currentUserUuid={currentUserUuid}
+        enableRemoteChat={enableRemoteChat}
+      />
     </AppChromeTemplate>
   );
 }

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -71,6 +71,8 @@ export const API_ENDPOINTS = {
   chat: {
     messages: (agitUuid: string) => gatewayPath("chat", `/api/v1/agits/${agitUuid}/messages`),
     read: (agitUuid: string) => gatewayPath("chat", `/api/v1/agits/${agitUuid}/read`),
+    chatState: (agitUuid: string) => gatewayPath("chat", `/api/v1/agits/${agitUuid}/chat-state`),
+    myAgitsUnread: gatewayPath("chat", "/api/v1/me/agits/chat-unread"),
     wsTicket: gatewayPath("chat", "/api/v1/ws/ticket"),
   },
   video: {

--- a/hooks/useAgitChatSocket.ts
+++ b/hooks/useAgitChatSocket.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { issueChatWsTicketAction } from "@/actions/chatActions";
-import type { ApiChatMessage } from "@/types/chat/api";
+import type { ApiChatMessage, ApiChatReceiptPayload } from "@/types/chat/api";
 import { Client } from "@stomp/stompjs";
 import { useEffect, useRef } from "react";
 import SockJS from "sockjs-client";
@@ -10,20 +10,27 @@ type UseAgitChatSocketOptions = {
   agitUuid: string;
   enabled?: boolean;
   onMessage: (message: ApiChatMessage) => void;
+  onReceipt?: (receipt: ApiChatReceiptPayload) => void;
 };
 
 export function useAgitChatSocket({
   agitUuid,
   enabled = true,
   onMessage,
+  onReceipt,
 }: UseAgitChatSocketOptions) {
   const clientRef = useRef<Client | null>(null);
   const onMessageRef = useRef(onMessage);
+  const onReceiptRef = useRef(onReceipt);
   const wsUrlRef = useRef("");
 
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
+
+  useEffect(() => {
+    onReceiptRef.current = onReceipt;
+  }, [onReceipt]);
 
   useEffect(() => {
     if (!enabled || !agitUuid) {
@@ -47,6 +54,14 @@ export function useAgitChatSocket({
             onMessageRef.current(payload);
           } catch {
             // 수신 payload 파싱 실패는 무시
+          }
+        });
+        client.subscribe(`/sub/agits/${agitUuid}/receipts`, (frame) => {
+          try {
+            const payload = JSON.parse(frame.body) as ApiChatReceiptPayload;
+            onReceiptRef.current?.(payload);
+          } catch {
+            // receipt payload 파싱 실패는 무시
           }
         });
       },

--- a/hooks/useAgitChatUnread.ts
+++ b/hooks/useAgitChatUnread.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import {
+  getAgitChatUnreadSnapshot,
+  subscribeAgitChatUnread,
+} from "@/lib/chat/chatUnreadStore";
+import { useSyncExternalStore } from "react";
+
+export function useAgitChatUnread(agitId: string, initialCount: number): number {
+  return useSyncExternalStore(
+    subscribeAgitChatUnread,
+    () => getAgitChatUnreadSnapshot(agitId, initialCount),
+    () => initialCount,
+  );
+}

--- a/hooks/useAgitListChatSync.ts
+++ b/hooks/useAgitListChatSync.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { issueChatWsTicketAction } from "@/actions/chatActions";
+import { incrementAgitChatUnread } from "@/lib/chat/chatUnreadStore";
+import type { ApiChatMessage } from "@/types/chat/api";
+import type { UiAgit } from "@/types/agit/ui";
+import { Client } from "@stomp/stompjs";
+import { useEffect, useMemo, useRef } from "react";
+import SockJS from "sockjs-client";
+
+type UseAgitListChatSyncOptions = {
+  items: UiAgit[];
+  currentUserUuid?: string;
+  enabled?: boolean;
+};
+
+function normalizeAgitId(agitId: string): string {
+  return agitId.trim().toLowerCase();
+}
+
+export function useAgitListChatSync({
+  items,
+  currentUserUuid,
+  enabled = false,
+}: UseAgitListChatSyncOptions) {
+  const wsUrlRef = useRef("");
+  const unreadByAgitIdRef = useRef<Map<string, number>>(new Map());
+  const agitIdsKey = useMemo(
+    () =>
+      items
+        .map((item) => item.id)
+        .sort()
+        .join(","),
+    [items],
+  );
+
+  useEffect(() => {
+    unreadByAgitIdRef.current = new Map(
+      items.map((item) => [normalizeAgitId(item.id), item.chatUnreadCount ?? 0]),
+    );
+  }, [items]);
+
+  useEffect(() => {
+    if (!enabled || !currentUserUuid || !agitIdsKey) {
+      return;
+    }
+
+    const agitIds = agitIdsKey.split(",").filter(Boolean);
+    const normalizedCurrentUserUuid = currentUserUuid.trim().toLowerCase();
+
+    const client = new Client({
+      reconnectDelay: 5000,
+      beforeConnect: async () => {
+        const result = await issueChatWsTicketAction();
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        wsUrlRef.current = result.data.wsUrl;
+      },
+      webSocketFactory: () => new SockJS(wsUrlRef.current),
+      onConnect: () => {
+        for (const agitId of agitIds) {
+          client.subscribe(`/sub/agits/${agitId}`, (frame) => {
+            try {
+              const payload = JSON.parse(frame.body) as ApiChatMessage;
+              if (payload.type !== "TALK" || !payload.senderUuid) {
+                return;
+              }
+              if (payload.senderUuid.trim().toLowerCase() === normalizedCurrentUserUuid) {
+                return;
+              }
+              const agitId = normalizeAgitId(payload.agitUuid);
+              const fallback = unreadByAgitIdRef.current.get(agitId) ?? 0;
+              incrementAgitChatUnread(agitId, fallback);
+              unreadByAgitIdRef.current.set(agitId, fallback + 1);
+            } catch {
+              // 수신 payload 파싱 실패는 무시
+            }
+          });
+        }
+      },
+    });
+
+    client.activate();
+
+    return () => {
+      client.deactivate();
+    };
+  }, [agitIdsKey, currentUserUuid, enabled]);
+}

--- a/lib/api/apiFetch.ts
+++ b/lib/api/apiFetch.ts
@@ -14,7 +14,7 @@ export class ApiError extends Error {
 
 type ApiFetchOptions = Omit<RequestInit, "body"> & {
   body?: unknown;
-  searchParams?: Record<string, string | undefined>;
+  searchParams?: Record<string, string | string[] | undefined>;
   /** 생략 시 API_URL (gateway base) */
   baseUrl?: string;
   /** false면 세션 토큰을 붙이지 않음. 로그인/재발급 등 공개 API용. 기본 true */
@@ -23,7 +23,7 @@ type ApiFetchOptions = Omit<RequestInit, "body"> & {
 
 function buildUrl(
   path: string,
-  searchParams?: Record<string, string | undefined>,
+  searchParams?: Record<string, string | string[] | undefined>,
   baseUrl?: string,
 ): string {
   const base = (baseUrl ?? getApiUrl()).replace(/\/$/, "");
@@ -32,9 +32,18 @@ function buildUrl(
 
   if (searchParams) {
     for (const [key, value] of Object.entries(searchParams)) {
-      if (value !== undefined && value !== "") {
-        url.searchParams.set(key, value);
+      if (value === undefined || value === "") {
+        continue;
       }
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (item !== undefined && item !== "") {
+            url.searchParams.append(key, item);
+          }
+        }
+        continue;
+      }
+      url.searchParams.set(key, value);
     }
   }
 

--- a/lib/api/chatApi.ts
+++ b/lib/api/chatApi.ts
@@ -3,7 +3,7 @@ import { getActorUserHeaders } from "@/lib/api/actorHeaders";
 import { apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl } from "@/lib/api/env";
 import { withAuthRetry } from "@/lib/api/withAuthRetry";
-import type { ApiChatHistory, ApiChatWsTicket } from "@/types/chat/api";
+import type { ApiChatHistory, ApiChatWsTicket, ApiMyAgitsChatUnreadResponse } from "@/types/chat/api";
 
 type ChatHistoryQuery = {
   cursorCreatedAt?: string;
@@ -29,12 +29,28 @@ export async function getChatHistory(
   );
 }
 
-export async function markChatRead(agitUuid: string): Promise<void> {
+export async function markChatRead(agitUuid: string, readAt?: string): Promise<void> {
   await withAuthRetry(async () =>
     apiFetch<void>(API_ENDPOINTS.chat.read(agitUuid), {
       method: "POST",
       baseUrl: getApiUrl(),
       headers: await getActorUserHeaders(),
+      body: readAt ? { readAt } : {},
+    }),
+  );
+}
+
+export async function getMyAgitsChatUnread(
+  agitUuids: string[],
+): Promise<ApiMyAgitsChatUnreadResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiMyAgitsChatUnreadResponse>(API_ENDPOINTS.chat.myAgitsUnread, {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      searchParams: {
+        agitUuids: agitUuids.length > 0 ? agitUuids : undefined,
+      },
     }),
   );
 }

--- a/lib/chat/chatUnreadStore.ts
+++ b/lib/chat/chatUnreadStore.ts
@@ -1,0 +1,33 @@
+type Listener = () => void;
+
+const overrides = new Map<string, number>();
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeAgitChatUnread(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getAgitChatUnreadSnapshot(agitId: string, fallback: number): number {
+  return overrides.get(agitId.trim().toLowerCase()) ?? fallback;
+}
+
+export function setAgitChatUnread(agitId: string, count: number): void {
+  overrides.set(agitId.trim().toLowerCase(), Math.max(0, count));
+  emit();
+}
+
+export function incrementAgitChatUnread(agitId: string, fallback: number): void {
+  const normalizedAgitId = agitId.trim().toLowerCase();
+  const current = getAgitChatUnreadSnapshot(normalizedAgitId, fallback);
+  overrides.set(normalizedAgitId, current + 1);
+  emit();
+}

--- a/lib/chat/mapMessage.ts
+++ b/lib/chat/mapMessage.ts
@@ -31,6 +31,10 @@ function mapMessage(
     isMine,
     timeLabel: formatChatMessageTime(message.createdAt),
     profileImageSrc: message.type === "TALK" && !isMine ? profile.profileImageSrc : undefined,
+    unreadMemberCount:
+      message.unreadMemberCount === null || message.unreadMemberCount === undefined
+        ? undefined
+        : message.unreadMemberCount,
   };
 }
 

--- a/lib/chat/roomHistoryCache.ts
+++ b/lib/chat/roomHistoryCache.ts
@@ -9,6 +9,12 @@ type ParsedRoomCacheEntry = {
   history: RoomHistoryCache;
 };
 
+function stripUnreadMemberCount(message: UiChatMessage): UiChatMessage {
+  const { unreadMemberCount, ...rest } = message;
+  void unreadMemberCount;
+  return rest;
+}
+
 const parsedRoomCache = new Map<string, ParsedRoomCacheEntry>();
 
 function storageKey(agitId: string): string {
@@ -19,9 +25,13 @@ export function writeRoomHistoryCache(agitId: string, history: RoomHistoryCache)
   if (typeof window === "undefined") {
     return;
   }
-  const raw = JSON.stringify(history);
+  const sanitized: RoomHistoryCache = {
+    ...history,
+    messages: history.messages.map(stripUnreadMemberCount),
+  };
+  const raw = JSON.stringify(sanitized);
   sessionStorage.setItem(storageKey(agitId), raw);
-  parsedRoomCache.set(agitId, { raw, history });
+  parsedRoomCache.set(agitId, { raw, history: sanitized });
 }
 
 export function readRoomHistoryCache(agitId: string): RoomHistoryCache | null {
@@ -39,8 +49,12 @@ export function readRoomHistoryCache(agitId: string): RoomHistoryCache | null {
   }
   try {
     const history = JSON.parse(raw) as RoomHistoryCache;
-    parsedRoomCache.set(agitId, { raw, history });
-    return history;
+    const sanitized: RoomHistoryCache = {
+      ...history,
+      messages: history.messages.map(stripUnreadMemberCount),
+    };
+    parsedRoomCache.set(agitId, { raw, history: sanitized });
+    return sanitized;
   } catch {
     parsedRoomCache.delete(agitId);
     return null;
@@ -61,7 +75,20 @@ export function mergeChatMessages(existing: UiChatMessage[], incoming: UiChatMes
     map.set(message.id, message);
   }
   for (const message of incoming) {
-    map.set(message.id, message);
+    const previous = map.get(message.id);
+    if (!previous) {
+      map.set(message.id, message);
+      continue;
+    }
+    map.set(message.id, {
+      ...previous,
+      ...message,
+      content: previous.type === "SYSTEM" ? previous.content : message.content,
+      unreadMemberCount:
+        message.unreadMemberCount !== undefined && message.unreadMemberCount !== null
+          ? message.unreadMemberCount
+          : previous.unreadMemberCount,
+    });
   }
   return [...map.values()].sort(
     (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -1,4 +1,6 @@
 import * as agitApi from "@/lib/api/agitApi";
+import { isEnableRemoteChatEnabled } from "@/lib/api/env";
+import * as chatService from "@/services/chatService";
 import type {
   ApiAgitDetail,
   ApiAgitLanding,
@@ -66,7 +68,25 @@ function mapAgitDetail(item: ApiAgitDetail): UiAgit {
 
 export async function listMyAgits(): Promise<UiAgit[]> {
   const items = await agitApi.getMyAgits();
-  return items.map(mapMyAgit);
+  const agits = items.map(mapMyAgit);
+
+  if (!isEnableRemoteChatEnabled() || agits.length === 0) {
+    return agits;
+  }
+
+  try {
+    const unreadMap = await chatService.getMyAgitsChatUnread(agits.map((agit) => agit.id));
+    return agits.map((agit) => {
+      const chatUnreadCount = unreadMap.get(agit.id) ?? 0;
+      return {
+        ...agit,
+        chatUnreadCount,
+        hasNewChat: chatUnreadCount > 0,
+      };
+    });
+  } catch {
+    return agits;
+  }
 }
 
 export async function getAgitAndMembers(agitId: string): Promise<{

--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -34,8 +34,18 @@ export async function getChatHistory(
   };
 }
 
-export async function markChatRead(agitUuid: string): Promise<void> {
-  await chatApi.markChatRead(agitUuid);
+export async function markChatRead(agitUuid: string, readAt?: string): Promise<void> {
+  await chatApi.markChatRead(agitUuid, readAt);
+}
+
+export async function getMyAgitsChatUnread(
+  agitUuids: string[],
+): Promise<Map<string, number>> {
+  if (agitUuids.length === 0) {
+    return new Map();
+  }
+  const response = await chatApi.getMyAgitsChatUnread(agitUuids);
+  return new Map(response.items.map((item) => [item.agitUuid, item.unreadMessageCount]));
 }
 
 export async function issueWsTicket(): Promise<{ ticket: string; expiresInSeconds: number }> {

--- a/types/agit/ui.ts
+++ b/types/agit/ui.ts
@@ -41,6 +41,7 @@ export type UiAgit = {
   inviteCode?: string;
   joined?: boolean;
   hasNewChat?: boolean;
+  chatUnreadCount?: number;
   hasTodayTopic?: boolean;
   myRole?: UiAgitRole;
 };

--- a/types/chat/api.ts
+++ b/types/chat/api.ts
@@ -8,6 +8,21 @@ export type ApiChatMessage = {
   content: string;
   payload?: Record<string, unknown> | null;
   createdAt: string;
+  unreadMemberCount?: number | null;
+};
+
+export type ApiChatReceiptPayload = {
+  messageId: string;
+  unreadMemberCount: number;
+};
+
+export type ApiAgitChatUnreadItem = {
+  agitUuid: string;
+  unreadMessageCount: number;
+};
+
+export type ApiMyAgitsChatUnreadResponse = {
+  items: ApiAgitChatUnreadItem[];
 };
 
 export type ApiChatCursor = {

--- a/types/chat/ui.ts
+++ b/types/chat/ui.ts
@@ -12,6 +12,7 @@ export type UiChatMessage = {
   isMine: boolean;
   timeLabel: string;
   profileImageSrc?: string;
+  unreadMemberCount?: number;
 };
 
 export type UiChatHistory = {


### PR DESCRIPTION
## 작업 내용

plip-chat Phase 2/3 BE(#26)와 연동하여 아지트 목록 채팅 배지와 채팅방 버블 unreadMemberCount를 FE에 반영했습니다. 목록 배지는 REST 초기값에 WS TALK 수신 시 실시간 증가를 더하고, 채팅방은 history enrich·receipt WS·markRead를 연동합니다. 긴 메시지 UI는 1차 사양(버블 옆 unread, meta row에 전체보기·시간)을 유지합니다.

## 관련 이슈

Close #138

## 변경 사항

### 1. 아지트 목록 unread 배지 REST + WS 실시간

- **파일:** `services/agitService.ts`, `lib/api/chatApi.ts`, `hooks/useAgitListChatSync.ts`, `lib/chat/chatUnreadStore.ts`, `hooks/useAgitChatUnread.ts`, `components/molecules/AgitListRow.tsx`, `app/(agit)/agit/page.tsx`, `components/organisms/AgitListSection.tsx`
- **설명:** `GET /me/agits/chat-unread`로 초기 배지를 merge하고, 목록 페이지에서 agit별 STOMP 구독으로 타인 TALK 수신 시 배지를 증가시킵니다. `ENABLE_REMOTE_CHAT`는 서버 prop으로 전달합니다.

```typescript
useAgitListChatSync({ items: rooms, currentUserUuid, enabled: enableRemoteChat });
incrementAgitChatUnread(agitId, fallback);
```

### 2. 채팅방 receipt WS·markRead·버블 unread

- **파일:** `components/organisms/RoomChatSection.tsx`, `hooks/useAgitChatSocket.ts`, `actions/chatActions.ts`, `lib/chat/mapMessage.ts`
- **설명:** `/sub/agits/{uuid}/receipts`로 unreadMemberCount를 갱신하고, markRead 성공 시 목록 store를 0으로 맞춥니다.

### 3. 버블 unread·긴 메시지 레이아웃

- **파일:** `components/molecules/ChatRoomMessage.tsx`, `components/molecules/ChatMessageBody.tsx`
- **설명:** unread는 버블 row(`bubbleLeading`/`bubbleTrailing`)에만 배치하고, 시간·전체보기는 기존 meta row에 유지합니다.

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (목록 WS 배지, 채팅 unread 3→2, 긴 메시지 레이아웃)

## 머지 전 체크

- [x] PR 제목 형식: `[#138] Feature : ...`
- [x] `Close #138` 연결
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
