### PR TITLE
[#140] Feature : 다이어리 사이드 메뉴 테마별·날짜별 최근 비디오 기준 라우팅

### DIFF
--- a/app/(diary)/diary/[date]/page.tsx
+++ b/app/(diary)/diary/[date]/page.tsx
@@ -1,6 +1,6 @@
 import { DiaryDateTemplate } from "@/components/templates";
-import { getDiaryDateWindow } from "@/services/diaryService";
-import type { UiDiaryDateWindow } from "@/types/diary/ui";
+import { getDiaryDateWindow, getDiaryMenuNavTargets } from "@/services/diaryService";
+import type { UiDiaryDateWindow, UiDiaryMenuNav } from "@/types/diary/ui";
 import {
   isFutureDiaryDate,
   parseDiaryDateParam,
@@ -23,17 +23,22 @@ export default async function DiaryDatePage({ params }: DiaryDatePageProps) {
     focusDate: parsedDate,
     days: { [parsedDate]: [] },
   };
+  let menuNav: UiDiaryMenuNav | null = null;
   let error: string | undefined;
 
   try {
-    initialWindow = await getDiaryDateWindow(parsedDate, 1);
+    [initialWindow, menuNav] = await Promise.all([
+      getDiaryDateWindow(parsedDate, 1),
+      getDiaryMenuNavTargets(),
+    ]);
   } catch (caught) {
     initialWindow = {
       focusDate: parsedDate,
       days: { [parsedDate]: [] },
     };
+    menuNav = null;
     error = caught instanceof Error ? caught.message : "날짜 상세를 불러오지 못했습니다.";
   }
 
-  return <DiaryDateTemplate initialWindow={initialWindow} error={error} />;
+  return <DiaryDateTemplate initialWindow={initialWindow} menuNav={menuNav} error={error} />;
 }

--- a/app/(diary)/diary/page.tsx
+++ b/app/(diary)/diary/page.tsx
@@ -1,19 +1,21 @@
 import { DiaryMainTemplate } from "@/components/templates";
 import { getDiaryHomePageData } from "@/services/diaryService";
-import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
+import type { UiDiaryDateEntry, UiDiaryMenuNav, UiDiaryTheme } from "@/types/diary/ui";
 
 export default async function DiaryPage() {
   let entries: UiDiaryDateEntry[] = [];
   let themes: UiDiaryTheme[] = [];
+  let menuNav: UiDiaryMenuNav | null = null;
   let error: string | undefined;
 
   try {
-    ({ entries, themes } = await getDiaryHomePageData());
+    ({ entries, themes, menuNav } = await getDiaryHomePageData());
   } catch (caught) {
     entries = [];
     themes = [];
+    menuNav = null;
     error = caught instanceof Error ? caught.message : "다이어리 홈을 불러오지 못했습니다.";
   }
 
-  return <DiaryMainTemplate entries={entries} themes={themes} error={error} />;
+  return <DiaryMainTemplate entries={entries} themes={themes} menuNav={menuNav} error={error} />;
 }

--- a/app/(diary)/diary/themes/[themeId]/page.tsx
+++ b/app/(diary)/diary/themes/[themeId]/page.tsx
@@ -1,7 +1,7 @@
 import { DiaryThemeDetailTemplate } from "@/components/templates";
 import { ApiError } from "@/lib/api/apiFetch";
-import { getDiaryThemeTimeline } from "@/services/diaryService";
-import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
+import { getDiaryMenuNavTargets, getDiaryThemeTimeline } from "@/services/diaryService";
+import type { UiDiaryMenuNav, UiDiaryThemeDateGroup } from "@/types/diary/ui";
 import { parseThemeId } from "@/types/diary/schema";
 import { notFound } from "next/navigation";
 
@@ -21,14 +21,19 @@ export default async function DiaryThemePage({ params }: DiaryThemePageProps) {
   let dateGroups: UiDiaryThemeDateGroup[] = [];
   let nextCursor: string | null = null;
   let hasMore = false;
+  let menuNav: UiDiaryMenuNav | null = null;
   let error: string | undefined;
 
   try {
-    const result = await getDiaryThemeTimeline(parsedId.data);
+    const [result, navTargets] = await Promise.all([
+      getDiaryThemeTimeline(parsedId.data),
+      getDiaryMenuNavTargets(),
+    ]);
     themeName = result.theme.name;
     dateGroups = result.dateGroups;
     nextCursor = result.nextCursor;
     hasMore = result.hasMore;
+    menuNav = navTargets;
   } catch (caught) {
     if (caught instanceof ApiError && caught.status === 404) {
       notFound();
@@ -44,6 +49,7 @@ export default async function DiaryThemePage({ params }: DiaryThemePageProps) {
       dateGroups={dateGroups}
       initialNextCursor={nextCursor}
       initialHasMore={hasMore}
+      menuNav={menuNav}
       error={error}
     />
   );

--- a/app/(diary)/diary/themes/page.tsx
+++ b/app/(diary)/diary/themes/page.tsx
@@ -1,17 +1,19 @@
 import { DiaryThemesTemplate } from "@/components/templates";
-import { listDiaryThemes } from "@/services/diaryService";
-import type { UiDiaryTheme } from "@/types/diary/ui";
+import { getDiaryMenuNavTargets, listDiaryThemes } from "@/services/diaryService";
+import type { UiDiaryMenuNav, UiDiaryTheme } from "@/types/diary/ui";
 
 export default async function DiaryThemesPage() {
   let themes: UiDiaryTheme[] = [];
+  let menuNav: UiDiaryMenuNav | null = null;
   let error: string | undefined;
 
   try {
-    themes = await listDiaryThemes();
+    [themes, menuNav] = await Promise.all([listDiaryThemes(), getDiaryMenuNavTargets()]);
   } catch (caught) {
     themes = [];
+    menuNav = null;
     error = caught instanceof Error ? caught.message : "테마 목록을 불러오지 못했습니다.";
   }
 
-  return <DiaryThemesTemplate themes={themes} error={error} />;
+  return <DiaryThemesTemplate themes={themes} menuNav={menuNav} error={error} />;
 }

--- a/components/organisms/DiaryDateDetailSection.tsx
+++ b/components/organisms/DiaryDateDetailSection.tsx
@@ -5,7 +5,7 @@ import { DailyIcon, IconButton } from "@/components/atoms";
 import { DiaryThemeClipGroup, ScreenHeader } from "@/components/molecules";
 import { DiarySideMenu } from "@/components/organisms/DiarySideMenu";
 import { ROUTES } from "@/config/routes";
-import type { UiDiaryDateWindow } from "@/types/diary/ui";
+import type { UiDiaryDateWindow, UiDiaryMenuNav } from "@/types/diary/ui";
 import {
   getTodayKstDateString,
   isFutureDiaryDate,
@@ -16,6 +16,7 @@ import { useRef, useState, type PointerEvent } from "react";
 
 type DiaryDateDetailSectionProps = {
   initialWindow: UiDiaryDateWindow;
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
@@ -23,6 +24,7 @@ const SWIPE_THRESHOLD = 48;
 
 export function DiaryDateDetailSection({
   initialWindow,
+  menuNav,
   error: initialError,
 }: DiaryDateDetailSectionProps) {
   const router = useRouter();
@@ -205,7 +207,7 @@ export function DiaryDateDetailSection({
         </div>
       </div>
 
-      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} menuNav={menuNav} />
     </div>
   );
 }

--- a/components/organisms/DiaryMainSection.tsx
+++ b/components/organisms/DiaryMainSection.tsx
@@ -2,16 +2,17 @@
 
 import { PageContainer, ScreenHeader, DiaryDateScrollSection, ThemePreviewStrip } from "@/components/molecules";
 import { DiarySideMenu } from "@/components/organisms/DiarySideMenu";
-import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
+import type { UiDiaryDateEntry, UiDiaryMenuNav, UiDiaryTheme } from "@/types/diary/ui";
 import { useState } from "react";
 
 type DiaryMainSectionProps = {
   entries: UiDiaryDateEntry[];
   themes: UiDiaryTheme[];
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
-export function DiaryMainSection({ entries, themes, error }: DiaryMainSectionProps) {
+export function DiaryMainSection({ entries, themes, menuNav, error }: DiaryMainSectionProps) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -22,7 +23,7 @@ export function DiaryMainSection({ entries, themes, error }: DiaryMainSectionPro
         menuLabel="다이어리 메뉴"
       />
 
-      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} menuNav={menuNav} />
 
       <PageContainer as="div" aria-label="다이어리 컨텐츠" className="flex-1">
         <ThemePreviewStrip themes={themes} />

--- a/components/organisms/DiarySideMenu.tsx
+++ b/components/organisms/DiarySideMenu.tsx
@@ -4,18 +4,25 @@ import { TextLink } from "@/components/atoms";
 import { MenuNavRow, MonthCalendarGrid, SideSheetHeader, buildMonthGridCells } from "@/components/molecules";
 import { AnimatedSideSheet } from "@/components/molecules/AnimatedOverlays";
 import { ROUTES } from "@/config/routes";
+import type { UiDiaryMenuNav } from "@/types/diary/ui";
 import { CalendarDays, ChevronLeft, ChevronRight, FolderKanban, LayoutGrid } from "lucide-react";
 import { useMemo } from "react";
 
 type DiarySideMenuProps = {
   open: boolean;
   onClose: () => void;
+  menuNav?: UiDiaryMenuNav | null;
 };
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
-export function DiarySideMenu({ open, onClose }: DiarySideMenuProps) {
+export function DiarySideMenu({ open, onClose, menuNav }: DiarySideMenuProps) {
   const cells = useMemo(() => buildMonthGridCells(2026, 7, "adjacent"), []);
+
+  const themeByHref = menuNav?.themeId
+    ? ROUTES.diary.themes.detail(menuNav.themeId)
+    : ROUTES.diary.themes.root;
+  const dateByHref = menuNav?.date ? ROUTES.diary.date(menuNav.date) : ROUTES.diary.root;
 
   return (
     <AnimatedSideSheet
@@ -31,11 +38,11 @@ export function DiarySideMenu({ open, onClose }: DiarySideMenuProps) {
             <FolderKanban className="size-5 shrink-0 text-[var(--dl-color-text-brand)]" strokeWidth={2.2} />
             테마 관리
           </MenuNavRow>
-          <MenuNavRow href={ROUTES.diary.themes.root} onClick={onClose}>
+          <MenuNavRow href={themeByHref} onClick={onClose}>
             <LayoutGrid className="size-5 shrink-0 text-[var(--dl-color-text-brand)]" strokeWidth={2.2} />
             테마별
           </MenuNavRow>
-          <MenuNavRow href={ROUTES.diary.root} onClick={onClose}>
+          <MenuNavRow href={dateByHref} onClick={onClose}>
             <CalendarDays className="size-5 shrink-0 text-[var(--dl-color-text-brand)]" strokeWidth={2.2} />
             날짜별
           </MenuNavRow>

--- a/components/organisms/DiaryThemeDetailSection.tsx
+++ b/components/organisms/DiaryThemeDetailSection.tsx
@@ -5,7 +5,7 @@ import { DiaryThemeClipGroup, PageContainer, ScreenHeader } from "@/components/m
 import { DiarySideMenu } from "@/components/organisms/DiarySideMenu";
 import { ROUTES } from "@/config/routes";
 import { mergeThemeDateGroups } from "@/lib/diary/mergeThemeDateGroups";
-import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
+import type { UiDiaryMenuNav, UiDiaryThemeDateGroup } from "@/types/diary/ui";
 import { useState } from "react";
 
 type DiaryThemeDetailSectionProps = {
@@ -14,6 +14,7 @@ type DiaryThemeDetailSectionProps = {
   dateGroups: UiDiaryThemeDateGroup[];
   initialNextCursor: string | null;
   initialHasMore: boolean;
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
@@ -23,6 +24,7 @@ export function DiaryThemeDetailSection({
   dateGroups: initialDateGroups,
   initialNextCursor,
   initialHasMore,
+  menuNav,
   error: initialError,
 }: DiaryThemeDetailSectionProps) {
   const [dateGroups, setDateGroups] = useState(initialDateGroups);
@@ -61,7 +63,7 @@ export function DiaryThemeDetailSection({
         menuLabel="다이어리 메뉴"
       />
 
-      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} menuNav={menuNav} />
 
       <PageContainer aria-label={`${themeName} 테마 상세`} className="flex-1">
         {error ? <p className="m-0 text-center text-sm text-red-600">{error}</p> : null}

--- a/components/organisms/DiaryThemesListSection.tsx
+++ b/components/organisms/DiaryThemesListSection.tsx
@@ -4,15 +4,16 @@ import { DiaryThemeAddCard, DiaryThemeCard, PageContainer, ScreenHeader } from "
 import { DiarySideMenu } from "@/components/organisms/DiarySideMenu";
 import { ThemeBottomSheet } from "@/components/organisms/ThemeBottomSheet";
 import { ROUTES } from "@/config/routes";
-import type { UiDiaryTheme } from "@/types/diary/ui";
+import type { UiDiaryMenuNav, UiDiaryTheme } from "@/types/diary/ui";
 import { useState } from "react";
 
 type DiaryThemesListSectionProps = {
   themes: UiDiaryTheme[];
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
-export function DiaryThemesListSection({ themes, error: fetchError }: DiaryThemesListSectionProps) {
+export function DiaryThemesListSection({ themes, menuNav, error: fetchError }: DiaryThemesListSectionProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingTheme, setEditingTheme] = useState<UiDiaryTheme | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -41,7 +42,7 @@ export function DiaryThemesListSection({ themes, error: fetchError }: DiaryTheme
         menuLabel="다이어리 메뉴"
       />
 
-      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      <DiarySideMenu open={menuOpen} onClose={() => setMenuOpen(false)} menuNav={menuNav} />
 
       <PageContainer aria-label="테마 목록" className="flex-1">
         {fetchError ? (

--- a/components/templates/DiaryDateTemplate.tsx
+++ b/components/templates/DiaryDateTemplate.tsx
@@ -1,16 +1,17 @@
 import { DiaryDateDetailSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
-import type { UiDiaryDateWindow } from "@/types/diary/ui";
+import type { UiDiaryDateWindow, UiDiaryMenuNav } from "@/types/diary/ui";
 
 type DiaryDateTemplateProps = {
   initialWindow: UiDiaryDateWindow;
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
-export function DiaryDateTemplate({ initialWindow, error }: DiaryDateTemplateProps) {
+export function DiaryDateTemplate({ initialWindow, menuNav, error }: DiaryDateTemplateProps) {
   return (
     <DiaryTemplate fixedMain>
-      <DiaryDateDetailSection initialWindow={initialWindow} error={error} />
+      <DiaryDateDetailSection initialWindow={initialWindow} menuNav={menuNav} error={error} />
     </DiaryTemplate>
   );
 }

--- a/components/templates/DiaryMainTemplate.tsx
+++ b/components/templates/DiaryMainTemplate.tsx
@@ -1,17 +1,18 @@
 import { DiaryMainSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
-import type { UiDiaryDateEntry, UiDiaryTheme } from "@/types/diary/ui";
+import type { UiDiaryDateEntry, UiDiaryMenuNav, UiDiaryTheme } from "@/types/diary/ui";
 
 type DiaryMainTemplateProps = {
   entries: UiDiaryDateEntry[];
   themes: UiDiaryTheme[];
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
-export function DiaryMainTemplate({ entries, themes, error }: DiaryMainTemplateProps) {
+export function DiaryMainTemplate({ entries, themes, menuNav, error }: DiaryMainTemplateProps) {
   return (
     <DiaryTemplate fixedMain>
-      <DiaryMainSection entries={entries} themes={themes} error={error} />
+      <DiaryMainSection entries={entries} themes={themes} menuNav={menuNav} error={error} />
     </DiaryTemplate>
   );
 }

--- a/components/templates/DiaryThemeDetailTemplate.tsx
+++ b/components/templates/DiaryThemeDetailTemplate.tsx
@@ -1,6 +1,6 @@
 import { DiaryThemeDetailSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
-import type { UiDiaryThemeDateGroup } from "@/types/diary/ui";
+import type { UiDiaryMenuNav, UiDiaryThemeDateGroup } from "@/types/diary/ui";
 
 type DiaryThemeDetailTemplateProps = {
   themeId: string;
@@ -8,6 +8,7 @@ type DiaryThemeDetailTemplateProps = {
   dateGroups: UiDiaryThemeDateGroup[];
   initialNextCursor: string | null;
   initialHasMore: boolean;
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
@@ -17,6 +18,7 @@ export function DiaryThemeDetailTemplate({
   dateGroups,
   initialNextCursor,
   initialHasMore,
+  menuNav,
   error,
 }: DiaryThemeDetailTemplateProps) {
   return (
@@ -27,6 +29,7 @@ export function DiaryThemeDetailTemplate({
         dateGroups={dateGroups}
         initialNextCursor={initialNextCursor}
         initialHasMore={initialHasMore}
+        menuNav={menuNav}
         error={error}
       />
     </DiaryTemplate>

--- a/components/templates/DiaryThemesTemplate.tsx
+++ b/components/templates/DiaryThemesTemplate.tsx
@@ -1,16 +1,17 @@
 import { DiaryThemesListSection } from "@/components/organisms";
 import { DiaryTemplate } from "@/components/templates/DiaryTemplate";
-import type { UiDiaryTheme } from "@/types/diary/ui";
+import type { UiDiaryMenuNav, UiDiaryTheme } from "@/types/diary/ui";
 
 type DiaryThemesTemplateProps = {
   themes: UiDiaryTheme[];
+  menuNav?: UiDiaryMenuNav | null;
   error?: string;
 };
 
-export function DiaryThemesTemplate({ themes, error }: DiaryThemesTemplateProps) {
+export function DiaryThemesTemplate({ themes, menuNav, error }: DiaryThemesTemplateProps) {
   return (
     <DiaryTemplate>
-      <DiaryThemesListSection themes={themes} error={error} />
+      <DiaryThemesListSection themes={themes} menuNav={menuNav} error={error} />
     </DiaryTemplate>
   );
 }

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -4,6 +4,7 @@ import type {
   ApiDiaryDateResponse,
   ApiDiaryDateSection,
   ApiDiaryDateWindowResponse,
+  ApiDiaryHomeResponse,
   ApiDiaryHomeSection,
   ApiDiaryTheme,
   ApiDiaryTimelineSection,
@@ -15,6 +16,7 @@ import type {
   UiDiaryDateGroup,
   UiDiaryDateThemeGroup,
   UiDiaryDateWindow,
+  UiDiaryMenuNav,
   UiDiaryTheme,
   UiDiaryThemeDateGroup,
   UiDiaryThemeTimelinePage,
@@ -112,6 +114,31 @@ function normalizeHomeFeed(entries: UiDiaryDateEntry[]): UiDiaryDateEntry[] {
   return [todayEntry, ...otherEntries].sort((a, b) => b.date.localeCompare(a.date));
 }
 
+function resolveLatestDiaryVideoFromHome(response: ApiDiaryHomeResponse): UiDiaryMenuNav | null {
+  let latest: UiDiaryMenuNav & { createdAt: string } | null = null;
+
+  for (const section of response.sections) {
+    for (const video of section.videos) {
+      if (!latest || video.createdAt > latest.createdAt) {
+        latest = {
+          themeId: String(video.themeId),
+          date: section.date,
+          createdAt: video.createdAt,
+        };
+      }
+    }
+  }
+
+  if (!latest) {
+    return null;
+  }
+
+  return {
+    themeId: latest.themeId,
+    date: latest.date,
+  };
+}
+
 function mapHomeSection(section: ApiDiaryHomeSection): UiDiaryDateEntry {
   const thumbnailPaths = section.videos
     .map((video) => toOptionalThumbnail(video.thumbnailUrl))
@@ -204,12 +231,19 @@ export async function getDiaryHomeFeed(): Promise<UiDiaryDateEntry[]> {
 export async function getDiaryHomePageData(): Promise<{
   entries: UiDiaryDateEntry[];
   themes: UiDiaryTheme[];
+  menuNav: UiDiaryMenuNav | null;
 }> {
   const response = await diaryApi.getDiaryHome();
   return {
     entries: normalizeHomeFeed(response.sections.map(mapHomeSection)),
     themes: (response.themes ?? []).map(mapTheme),
+    menuNav: resolveLatestDiaryVideoFromHome(response),
   };
+}
+
+export async function getDiaryMenuNavTargets(): Promise<UiDiaryMenuNav | null> {
+  const response = await diaryApi.getDiaryHome();
+  return resolveLatestDiaryVideoFromHome(response);
 }
 
 export async function getDiaryCalendarDates(year: number, month: number): Promise<string[]> {

--- a/types/diary/ui.ts
+++ b/types/diary/ui.ts
@@ -48,3 +48,8 @@ export type UiDiaryDateWindow = {
   focusDate: string;
   days: Record<string, UiDiaryDateThemeGroup[]>;
 };
+
+export type UiDiaryMenuNav = {
+  themeId: string;
+  date: string;
+};


### PR DESCRIPTION
## 작업 내용

다이어리 사이드 메뉴의 테마별·날짜별 항목이 최근 등록 다이어리 비디오 기준으로 이동하도록 연동했습니다. 홈 피드 API(`GET /home`) 응답의 `sections.videos`에서 `createdAt` 기준 최근 비디오의 `themeId`·`date`를 추출해 `/diary/themes/{id}`, `/diary/{date}`로 라우팅합니다. 비디오가 없을 때는 기존과 동일하게 `/diary/themes`, `/diary`로 폴백합니다.

## 관련 이슈

Close #140

## 변경 사항

### 1. 홈 피드에서 최근 비디오 menuNav 추출

- **파일:** `services/diaryService.ts`, `types/diary/ui.ts`
- **설명:** `resolveLatestDiaryVideoFromHome`으로 최근 비디오 themeId·date 추출. `getDiaryHomePageData`·`getDiaryMenuNavTargets`에서 `menuNav` 반환. `UiDiaryMenuNav` 타입 추가.

```typescript
function resolveLatestDiaryVideoFromHome(response: ApiDiaryHomeResponse): UiDiaryMenuNav | null {
  let latest: UiDiaryMenuNav & { createdAt: string } | null = null;

  for (const section of response.sections) {
    for (const video of section.videos) {
      if (!latest || video.createdAt > latest.createdAt) {
        latest = {
          themeId: String(video.themeId),
          date: section.date,
          createdAt: video.createdAt,
        };
      }
    }
  }

  return latest ? { themeId: latest.themeId, date: latest.date } : null;
}
```

### 2. DiarySideMenu 테마별·날짜별 href 연동

- **파일:** `components/organisms/DiarySideMenu.tsx`
- **설명:** `menuNav` props 수신. 테마별 → `ROUTES.diary.themes.detail(themeId)`, 날짜별 → `ROUTES.diary.date(date)`. 값 없을 때 기존 root 경로 유지.

```typescript
const themeByHref = menuNav?.themeId
  ? ROUTES.diary.themes.detail(menuNav.themeId)
  : ROUTES.diary.themes.root;
const dateByHref = menuNav?.date ? ROUTES.diary.date(menuNav.date) : ROUTES.diary.root;
```

### 3. RSC 페이지·Template·Section props 전달

- **파일:** `app/(diary)/diary/**/page.tsx`, `components/templates/Diary*.tsx`, `components/organisms/Diary*Section.tsx`
- **설명:** 다이어리 홈은 `getDiaryHomePageData`의 `menuNav` 재사용. 테마·날짜 상세 등은 `getDiaryMenuNavTargets()` 병렬 호출 후 Template → Section → DiarySideMenu로 전달.

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`) — 테마별·날짜별 메뉴 이동 확인

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
