### PR TITLE
[#143] Feature:  아지트 토픽 피드 영상 자동재생 및 풀스크린 뷰어 자동재생

### DIFF
--- a/components/molecules/TopicClipPage.tsx
+++ b/components/molecules/TopicClipPage.tsx
@@ -7,6 +7,7 @@ type TopicClipPageProps = {
   captureHref: string;
   showCaptureSlot?: boolean;
   onSelectVideo?: (videoId: string) => void;
+  playbackEnabled?: boolean;
 };
 
 export function TopicClipPage({
@@ -14,6 +15,7 @@ export function TopicClipPage({
   captureHref,
   showCaptureSlot = false,
   onSelectVideo,
+  playbackEnabled = true,
 }: TopicClipPageProps) {
   if (videos.length === 0 && !showCaptureSlot) {
     return <div className="flex h-full min-h-0 w-full flex-col" />;
@@ -22,7 +24,12 @@ export function TopicClipPage({
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
       {videos.map((video) => (
-        <TopicVideoTile key={video.id} video={video} onSelect={onSelectVideo} />
+        <TopicVideoTile
+          key={video.id}
+          video={video}
+          onSelect={onSelectVideo}
+          playbackEnabled={playbackEnabled}
+        />
       ))}
       {showCaptureSlot ? <TopicEmptySlot captureHref={captureHref} /> : null}
     </div>

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -1,30 +1,43 @@
+"use client";
+
 import { CaptureClipOverlays } from "@/components/molecules/CaptureClipOverlays";
 import { UserProfileBadge } from "@/components/molecules/UserProfileBadge";
 import { VideoClipThumbnail } from "@/components/molecules/VideoClipThumbnail";
+import { useVideoPlayback } from "@/hooks/useVideoPlayback";
 import { parseUploadedAtToDate } from "@/lib/video/formatOverlayClock";
 import type { UiTopicVideo } from "@/types/topic/ui";
 
 type TopicVideoTileProps = {
   video: UiTopicVideo;
   onSelect?: (videoId: string) => void;
+  playbackEnabled?: boolean;
 };
 
-export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
+export function TopicVideoTile({
+  video,
+  onSelect,
+  playbackEnabled = true,
+}: TopicVideoTileProps) {
+  const { containerRef, videoRef, shouldRenderVideo, posterUrl, videoProps } = useVideoPlayback({
+    videoUuid: video.id,
+    rawPlaybackUrl: video.rawPlaybackUrl,
+    thumbnailUrl: video.thumbnailSrc,
+    mode: "feed",
+    enabled: playbackEnabled,
+    fetchIfMissing: true,
+  });
+
   const body = (
     <>
-      {video.rawPlaybackUrl ? (
+      {shouldRenderVideo ? (
         <video
-          src={video.rawPlaybackUrl}
-          poster={video.thumbnailSrc}
-          autoPlay
-          loop
-          muted
-          playsInline
+          ref={videoRef}
+          {...videoProps}
           className="absolute inset-0 size-full object-cover"
         />
       ) : (
         <VideoClipThumbnail
-          src={video.thumbnailSrc}
+          src={posterUrl}
           className="absolute inset-0 size-full object-cover"
         />
       )}
@@ -49,19 +62,21 @@ export function TopicVideoTile({ video, onSelect }: TopicVideoTileProps) {
   );
 
   const className =
-    "relative flex min-h-0 min-h-[40%] flex-1 overflow-hidden rounded-none border-0 bg-[var(--dl-color-bg-surface)] p-0 shadow-none";
+    "relative flex min-h-0 min-h-[40%] flex-1 overflow-hidden rounded-none bg-[var(--dl-color-bg-surface)]";
 
-  if (onSelect) {
-    return (
-      <button
-        type="button"
-        className={className}
-        onClick={() => onSelect(video.id)}
-      >
-        {body}
-      </button>
-    );
-  }
-
-  return <div className={className}>{body}</div>;
+  return (
+    <div ref={containerRef} className={className}>
+      {onSelect ? (
+        <button
+          type="button"
+          className="relative flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-none border-0 bg-[var(--dl-color-bg-surface)] p-0 shadow-none"
+          onClick={() => onSelect(video.id)}
+        >
+          {body}
+        </button>
+      ) : (
+        body
+      )}
+    </div>
+  );
 }

--- a/components/organisms/AgitVideoViewer.tsx
+++ b/components/organisms/AgitVideoViewer.tsx
@@ -32,6 +32,7 @@ export function AgitVideoViewer({
   return (
     <>
       <BaseVideoViewer
+        key={initialClipId}
         initialClipId={initialClipId}
         videoList={videoList}
         onClose={onClose}

--- a/components/organisms/BaseVideoViewer.tsx
+++ b/components/organisms/BaseVideoViewer.tsx
@@ -5,6 +5,8 @@ import { DailyIcon, FeedPillIconButton } from "@/components/atoms";
 import { ScreenHeader } from "@/components/molecules";
 import type { VideoViewerItem } from "@/components/providers/VideoViewerProvider";
 import { extractDate } from "@/lib/video/formatOverlayClock";
+import { resolveRemotePlaybackUrl, VIDEO_PLAYBACK_ATTRS } from "@/lib/video/playback";
+import { safeVideoPlay } from "@/lib/video/safeVideoPlay";
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
@@ -36,43 +38,67 @@ export function BaseVideoViewer({
 }: BaseVideoViewerProps) {
   const list = useMemo(
     () => (videoList.length > 0 ? videoList : [{ clipId: initialClipId }]),
-    [videoList, initialClipId]
+    [videoList, initialClipId],
   );
   const initialIndex = Math.max(
     0,
-    list.findIndex((item) => item.clipId === initialClipId)
+    list.findIndex((item) => item.clipId === initialClipId),
   );
 
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [videoDetails, setVideoDetails] = useState<
     Record<string, { playbackUrl?: string; thumbnailUrl?: string; caption?: string }>
   >({});
+  const [failedUuids, setFailedUuids] = useState<Record<string, true>>({});
   const [isPlaying, setIsPlaying] = useState(true);
 
   const currentItem = list[currentIndex] ?? list[0];
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const fetchingRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const item = list[currentIndex];
-    if (!item) return;
+    if (!item) {
+      return;
+    }
 
     const uuid = item.videoUuid || item.clipId;
-    if (uuid && !videoDetails[uuid]) {
-      getVideoAction(uuid)
-        .then((result) => {
-          if (!result.ok) return;
-          setVideoDetails((prev) => ({
-            ...prev,
-            [uuid]: {
-              playbackUrl: result.data.rawPlaybackUrl,
-              thumbnailUrl: result.data.thumbnailUrl ?? undefined,
-              caption: result.data.caption ?? undefined,
-            },
-          }));
-        })
-        .catch(() => {});
+    const hasInlineUrl = resolveRemotePlaybackUrl(item.rawPlaybackUrl);
+    if (!uuid || hasInlineUrl || videoDetails[uuid] || failedUuids[uuid] || fetchingRef.current.has(uuid)) {
+      return;
     }
-  }, [currentIndex, list, videoDetails]);
+
+    fetchingRef.current.add(uuid);
+
+    getVideoAction(uuid)
+      .then((result) => {
+        if (!result.ok) {
+          setFailedUuids((prev) => ({ ...prev, [uuid]: true }));
+          return;
+        }
+
+        const playbackUrl = resolveRemotePlaybackUrl(result.data.rawPlaybackUrl);
+        if (!playbackUrl) {
+          setFailedUuids((prev) => ({ ...prev, [uuid]: true }));
+          return;
+        }
+
+        setVideoDetails((prev) => ({
+          ...prev,
+          [uuid]: {
+            playbackUrl,
+            thumbnailUrl: result.data.thumbnailUrl ?? undefined,
+            caption: result.data.caption ?? undefined,
+          },
+        }));
+      })
+      .catch(() => {
+        setFailedUuids((prev) => ({ ...prev, [uuid]: true }));
+      })
+      .finally(() => {
+        fetchingRef.current.delete(uuid);
+      });
+  }, [currentIndex, failedUuids, list, videoDetails]);
 
   const touchStartY = useRef<number | null>(null);
 
@@ -87,30 +113,52 @@ export function BaseVideoViewer({
 
     if (diff > 50 && currentIndex < list.length - 1) {
       setCurrentIndex((prev) => prev + 1);
+      setIsPlaying(true);
     } else if (diff < -50 && currentIndex > 0) {
       setCurrentIndex((prev) => prev - 1);
+      setIsPlaying(true);
     }
     touchStartY.current = null;
   };
 
   const activeUuid = currentItem.videoUuid || currentItem.clipId;
   const currentDetail = videoDetails[activeUuid];
-  const playbackUrl = currentItem.rawPlaybackUrl || currentDetail?.playbackUrl;
+  const playbackUrl =
+    resolveRemotePlaybackUrl(currentItem.rawPlaybackUrl) ??
+    resolveRemotePlaybackUrl(currentDetail?.playbackUrl);
   const coverSrc =
     currentItem.thumbnailUrl ||
     currentDetail?.thumbnailUrl ||
     "/plip/v13/runner-preview.png";
+  const fetchFailed = Boolean(activeUuid && failedUuids[activeUuid]);
+
+  useEffect(() => {
+    const node = videoRef.current;
+    if (!node || !playbackUrl || !isPlaying) {
+      node?.pause();
+      return;
+    }
+
+    safeVideoPlay(node);
+  }, [playbackUrl, isPlaying, currentIndex]);
 
   const togglePlay = useCallback(() => {
-    if (videoRef.current) {
-      if (isPlaying) {
-        videoRef.current.pause();
-      } else {
-        videoRef.current.play().catch(() => {});
-      }
-      setIsPlaying(!isPlaying);
+    const node = videoRef.current;
+    if (!node) {
+      return;
     }
+
+    if (isPlaying) {
+      node.pause();
+      setIsPlaying(false);
+      return;
+    }
+
+    safeVideoPlay(node);
+    setIsPlaying(true);
   }, [isPlaying]);
+
+  const viewerVideoProps = VIDEO_PLAYBACK_ATTRS.viewer;
 
   return (
     <section
@@ -124,11 +172,11 @@ export function BaseVideoViewer({
           ref={videoRef}
           src={playbackUrl}
           poster={coverSrc}
-          autoPlay
-          loop
-          playsInline
+          {...viewerVideoProps}
           className="absolute inset-0 h-full w-full object-cover"
           onClick={togglePlay}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
         />
       ) : (
         <Image
@@ -145,7 +193,6 @@ export function BaseVideoViewer({
       <div className="pointer-events-none absolute inset-0 bg-black/20" aria-hidden />
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/80" />
 
-      {/* Header Overlay */}
       <ScreenHeader
         tone="overlay"
         titleAlign="center"
@@ -159,8 +206,7 @@ export function BaseVideoViewer({
         trailing={headerTrailing}
       />
 
-      {/* Play/Pause Indicator */}
-      {!isPlaying && (
+      {!isPlaying && playbackUrl ? (
         <div
           className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-black/30"
           onClick={togglePlay}
@@ -169,9 +215,14 @@ export function BaseVideoViewer({
             ▶
           </div>
         </div>
-      )}
+      ) : null}
 
-      {/* Custom Overlay (Side reactions, Bottom info, Center clock & caption overlay etc.) */}
+      {!playbackUrl && fetchFailed ? (
+        <div className="pointer-events-none absolute inset-x-0 bottom-28 z-10 px-6 text-center text-xs font-medium text-white/70">
+          재생 URL을 불러오지 못했습니다.
+        </div>
+      ) : null}
+
       {typeof overlayChildren === "function"
         ? overlayChildren({ currentItem, currentDetail, currentIndex, totalCount: list.length })
         : overlayChildren}

--- a/components/organisms/DiaryVideoViewer.tsx
+++ b/components/organisms/DiaryVideoViewer.tsx
@@ -24,6 +24,7 @@ export function DiaryVideoViewer({
 
   return (
     <BaseVideoViewer
+      key={initialClipId}
       initialClipId={initialClipId}
       videoList={videoList}
       onClose={onClose}

--- a/components/organisms/TopicFeedSection.tsx
+++ b/components/organisms/TopicFeedSection.tsx
@@ -295,6 +295,7 @@ export function TopicFeedSection({ agitId, agit, initialWindow, initialVideos }:
                   showCaptureSlot={shouldShowTopicCaptureSlot(topic)}
                   topicTitle={topic.title}
                   agitName={resolvedAgit?.name}
+                  playbackEnabled={!isAtCoverSlide && topicIndex === effectiveIndex}
                 />
               ) : null}
             </div>

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -26,6 +26,7 @@ type TopicGallerySectionProps = {
   topicTitle?: string;
   agitName?: string;
   onSelectVideo?: (videoId: string) => void;
+  playbackEnabled?: boolean;
 };
 
 export function TopicGallerySection({
@@ -35,6 +36,7 @@ export function TopicGallerySection({
   topicTitle,
   agitName,
   onSelectVideo,
+  playbackEnabled = true,
 }: TopicGallerySectionProps) {
   const items = useMemo<GalleryPageItem[]>(
     () => (showCaptureSlot ? [...videos, CAPTURE_SLOT] : videos),
@@ -85,6 +87,7 @@ export function TopicGallerySection({
   }
 
   const { isOpen, activeClipId, videoList, openViewer, closeViewer } = useVideoViewer();
+  const galleryPlaybackEnabled = playbackEnabled && !isOpen;
 
   function handleSelectVideo(videoId: string) {
     if (onSelectVideo) {
@@ -105,7 +108,7 @@ export function TopicGallerySection({
     openViewer(videoId, formattedList, "agit");
   }
 
-  function renderPage(pageItems: GalleryPageItem[], key: string) {
+  function renderPage(pageItems: GalleryPageItem[], key: string, pageActive: boolean) {
     const pageVideos = pageItems.filter((item): item is UiTopicVideo => !isCaptureSlot(item));
     return (
       <TopicClipPage
@@ -114,6 +117,7 @@ export function TopicGallerySection({
         captureHref={captureHref}
         showCaptureSlot={pageItems.some(isCaptureSlot)}
         onSelectVideo={handleSelectVideo}
+        playbackEnabled={galleryPlaybackEnabled && pageActive}
       />
     );
   }
@@ -131,7 +135,7 @@ export function TopicGallerySection({
     >
       {pageCount <= 1 ? (
         <div className="flex h-full min-h-0 flex-col">
-          {renderPage(pages[0] ?? [], "topic-page-0")}
+          {renderPage(pages[0] ?? [], "topic-page-0", true)}
         </div>
       ) : (
         pages.map((pageItems, index) => (
@@ -140,7 +144,7 @@ export function TopicGallerySection({
             className="absolute inset-0 flex flex-col"
             style={{ transform: `translate3d(${(index - safeIndex) * 100}%, 0, 0)` }}
           >
-            {renderPage(pageItems, `topic-page-${index}`)}
+            {renderPage(pageItems, `topic-page-${index}`, index === safeIndex)}
           </div>
         ))
       )}

--- a/hooks/useVideoPlayback.ts
+++ b/hooks/useVideoPlayback.ts
@@ -1,0 +1,161 @@
+"use client";
+
+import { getVideoAction } from "@/actions/videoActions";
+import {
+  resolveRemotePlaybackUrl,
+  VIDEO_PLAYBACK_ATTRS,
+  type VideoPlaybackMode,
+} from "@/lib/video/playback";
+import { safeVideoPlay } from "@/lib/video/safeVideoPlay";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+const VISIBILITY_THRESHOLD = 0.35;
+
+type UseVideoPlaybackOptions = {
+  videoUuid: string;
+  rawPlaybackUrl?: string | null;
+  thumbnailUrl?: string;
+  mode: VideoPlaybackMode;
+  /** Parent slide/gallery is active (e.g. current topic in feed). */
+  enabled?: boolean;
+  /** Fetch video detail when no playable URL is available. */
+  fetchIfMissing?: boolean;
+};
+
+type UseVideoPlaybackResult = {
+  containerRef: RefObject<HTMLDivElement | null>;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  playbackUrl: string | null;
+  posterUrl: string | undefined;
+  shouldRenderVideo: boolean;
+  videoProps: React.VideoHTMLAttributes<HTMLVideoElement>;
+  pause: () => void;
+};
+
+export function useVideoPlayback({
+  videoUuid,
+  rawPlaybackUrl,
+  thumbnailUrl,
+  mode,
+  enabled = true,
+  fetchIfMissing = true,
+}: UseVideoPlaybackOptions): UseVideoPlaybackResult {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [fetchedUrls, setFetchedUrls] = useState<Record<string, string>>({});
+  const [isVisible, setIsVisible] = useState(mode === "viewer");
+  const shouldPlayRef = useRef(false);
+  const fetchingRef = useRef<Set<string>>(new Set());
+
+  const initialUrl = resolveRemotePlaybackUrl(rawPlaybackUrl);
+  const cachedUrl = resolveRemotePlaybackUrl(fetchedUrls[videoUuid]);
+  const playbackUrl = initialUrl ?? cachedUrl ?? null;
+
+  const fetchPlaybackUrl = useCallback(async (uuid: string) => {
+    if (fetchingRef.current.has(uuid)) {
+      return;
+    }
+
+    fetchingRef.current.add(uuid);
+    try {
+      const result = await getVideoAction(uuid);
+      if (!result.ok) {
+        return;
+      }
+
+      const url = resolveRemotePlaybackUrl(result.data.rawPlaybackUrl);
+      if (!url) {
+        return;
+      }
+
+      setFetchedUrls((prev) => ({ ...prev, [uuid]: url }));
+    } finally {
+      fetchingRef.current.delete(uuid);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (mode !== "feed") {
+      return;
+    }
+
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const visible = entry?.isIntersecting ?? false;
+        setIsVisible(visible);
+
+        if (visible && fetchIfMissing && enabled && !initialUrl && !cachedUrl) {
+          void fetchPlaybackUrl(videoUuid);
+        }
+      },
+      { threshold: VISIBILITY_THRESHOLD },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [cachedUrl, enabled, fetchIfMissing, fetchPlaybackUrl, initialUrl, mode, videoUuid]);
+
+  useEffect(() => {
+    if (
+      mode !== "viewer" ||
+      !fetchIfMissing ||
+      !enabled ||
+      !videoUuid ||
+      initialUrl ||
+      cachedUrl
+    ) {
+      return;
+    }
+
+    void fetchPlaybackUrl(videoUuid);
+  }, [cachedUrl, enabled, fetchIfMissing, fetchPlaybackUrl, initialUrl, mode, videoUuid]);
+
+  const shouldPlay = enabled && playbackUrl !== null && (mode === "viewer" || isVisible);
+
+  useEffect(() => {
+    shouldPlayRef.current = shouldPlay;
+    const node = videoRef.current;
+    if (!node) {
+      return;
+    }
+
+    if (shouldPlay) {
+      safeVideoPlay(node);
+      return;
+    }
+
+    node.pause();
+  }, [shouldPlay, playbackUrl]);
+
+  const pause = useCallback(() => {
+    videoRef.current?.pause();
+  }, []);
+
+  const handleCanPlay = useCallback(() => {
+    if (shouldPlayRef.current && videoRef.current) {
+      safeVideoPlay(videoRef.current);
+    }
+  }, []);
+
+  const attrs = VIDEO_PLAYBACK_ATTRS[mode];
+
+  return {
+    containerRef,
+    videoRef,
+    playbackUrl,
+    posterUrl: thumbnailUrl,
+    shouldRenderVideo: playbackUrl !== null,
+    pause,
+    videoProps: {
+      src: playbackUrl ?? undefined,
+      poster: thumbnailUrl,
+      ...attrs,
+      onCanPlay: handleCanPlay,
+    },
+  };
+}

--- a/lib/video/playback.ts
+++ b/lib/video/playback.ts
@@ -1,6 +1,28 @@
+import type { VideoHTMLAttributes } from "react";
+
 export function isStubPlaybackUrl(url: string): boolean {
   return url.includes("/stub-presigned-get/") || url.startsWith("/stub-media/");
 }
+
+/** Returns a browser-playable remote URL, filtering stub / empty values. */
+export function resolveRemotePlaybackUrl(
+  rawPlaybackUrl: string | null | undefined,
+): string | null {
+  if (!rawPlaybackUrl?.trim() || isStubPlaybackUrl(rawPlaybackUrl)) {
+    return null;
+  }
+  return rawPlaybackUrl.trim();
+}
+
+export type VideoPlaybackMode = "feed" | "viewer";
+
+export const VIDEO_PLAYBACK_ATTRS: Record<
+  VideoPlaybackMode,
+  Pick<VideoHTMLAttributes<HTMLVideoElement>, "muted" | "loop" | "playsInline" | "autoPlay">
+> = {
+  feed: { muted: true, loop: true, playsInline: true, autoPlay: true },
+  viewer: { muted: false, loop: true, playsInline: true, autoPlay: true },
+};
 
 export type PlaybackSource = {
   kind: "local" | "remote" | "none";
@@ -20,10 +42,11 @@ export function resolvePlaybackSource(
     };
   }
 
-  if (rawPlaybackUrl && !isStubPlaybackUrl(rawPlaybackUrl)) {
+  const remoteUrl = resolveRemotePlaybackUrl(rawPlaybackUrl);
+  if (remoteUrl) {
     return {
       kind: "remote",
-      url: rawPlaybackUrl,
+      url: remoteUrl,
       note: null,
     };
   }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 작업 내용

아지트 토픽 피드(`/agit/[agitId]`) 진입 시 viewport에 보이는 영상을 muted 자동재생하고, 영상 클릭 시 FullpageVideoViewer에서 해당 영상을 자동재생하도록 FE 재생 로직을 연동했습니다. stub URL 필터·가시성 기반 pause·공통 hook을 추가해 이후 다이어리 개별 영상 뷰어(Phase 2)에서도 재사용할 수 있게 했습니다.

## 관련 이슈

Close #143

## 변경 사항

### 1. 공통 재생 유틸 및 hook 추가

- **파일:** `lib/video/playback.ts`, `hooks/useVideoPlayback.ts`
- **설명:** stub URL을 제외한 재생 가능 URL 판별, feed/viewer 모드별 `<video>` 속성 분리, IntersectionObserver 기반 가시성 재생·`getVideoAction` fallback을 hook으로 공통화

```typescript
// lib/video/playback.ts
export const VIDEO_PLAYBACK_ATTRS = {
  feed: { muted: true, loop: true, playsInline: true, autoPlay: true },
  viewer: { muted: false, loop: true, playsInline: true, autoPlay: true },
};

// hooks/useVideoPlayback.ts
export function useVideoPlayback({ videoUuid, rawPlaybackUrl, mode, enabled, fetchIfMissing }) {
  const playbackUrl = resolveRemotePlaybackUrl(rawPlaybackUrl) ?? cachedUrl;
  // feed: viewport 가시 시 safeVideoPlay, 비가시 시 pause
  // viewer: 마운트 시 fetch fallback + safeVideoPlay
}
```

### 2. 토픽 피드 타일 자동재생

- **파일:** `components/molecules/TopicVideoTile.tsx`, `components/molecules/TopicClipPage.tsx`
- **설명:** `TopicVideoTile`이 `useVideoPlayback({ mode: "feed" })`를 사용해 rawPlaybackUrl 재생. URL 없으면 썸네일 fallback

```typescript
// components/molecules/TopicVideoTile.tsx
const { containerRef, videoRef, shouldRenderVideo, videoProps } = useVideoPlayback({
  videoUuid: video.id,
  rawPlaybackUrl: video.rawPlaybackUrl,
  mode: "feed",
  enabled: playbackEnabled,
});
```

### 3. 토픽·갤러리 재생 활성화 제어

- **파일:** `components/organisms/TopicFeedSection.tsx`, `components/organisms/TopicGallerySection.tsx`
- **설명:** 현재 토픽 슬라이드·갤러리 가로 페이지·뷰어 오픈 여부에 따라 `playbackEnabled` 전달. 비활성 슬라이드/페이지/뷰어 오픈 시 피드 영상 pause

```typescript
// components/organisms/TopicFeedSection.tsx
<TopicGallerySection
  playbackEnabled={!isAtCoverSlide && topicIndex === effectiveIndex}
/>

// components/organisms/TopicGallerySection.tsx
const galleryPlaybackEnabled = playbackEnabled && !isOpen;
playbackEnabled={galleryPlaybackEnabled && pageActive}
```

### 4. 풀스크린 뷰어 자동재생 강화

- **파일:** `components/organisms/BaseVideoViewer.tsx`, `components/organisms/AgitVideoViewer.tsx`, `components/organisms/DiaryVideoViewer.tsx`
- **설명:** stub URL 필터, `safeVideoPlay` 적용, fetch 실패 시 썸네일 유지 + 안내 문구. 클릭으로 뷰어 진입 시 `key={initialClipId}` remount로 자동재생 보장

```typescript
// components/organisms/BaseVideoViewer.tsx
const playbackUrl =
  resolveRemotePlaybackUrl(currentItem.rawPlaybackUrl) ??
  resolveRemotePlaybackUrl(currentDetail?.playbackUrl);

useEffect(() => {
  if (playbackUrl && isPlaying) safeVideoPlay(videoRef.current);
}, [playbackUrl, isPlaying, currentIndex]);
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)
  - [ ] `/agit/[agitId]` 진입 → viewport 내 영상 muted autoplay
  - [ ] 영상 클릭 → FullpageVideoViewer(AgitVideoViewer) 자동재생
  - [ ] 토픽 슬라이드/가로 페이지 전환 시 이전 영상 pause
  - [ ] 뷰어 오픈 시 피드 영상 pause
  - [ ] `rawPlaybackUrl` stub/없음 → 썸네일 fallback, 크래시 없음

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약` (`Feature: 토픽 자동 플레이`)
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인

## 참고

- Phase 2(다이어리 테마 개별 영상)는 `useVideoPlayback({ mode: "viewer" })` + `videoUuid` 보존으로 후속 작업 예정
- 실제 영상 blob 재생은 video-service `rawPlaybackUrl`(presigned URL) 및 S3 CORS에 의존
```
