### PR TITLE
[#144] Feature : 다이어리 테마 영상 개별 뷰어 재생 연동

### DIFF
--- a/components/molecules/DiaryThemeClipGroup.tsx
+++ b/components/molecules/DiaryThemeClipGroup.tsx
@@ -4,6 +4,7 @@ import { TextLink } from "@/components/atoms";
 import { VideoClipThumbnail } from "@/components/molecules/VideoClipThumbnail";
 import { useVideoViewer } from "@/components/providers/VideoViewerProvider";
 import { formatDiaryDate } from "@/config/diary-mock";
+import { toDiaryVideoViewerItems } from "@/lib/diary/toVideoViewerItems";
 import { ROUTES } from "@/config/routes";
 import type { UiDiaryClip } from "@/types/diary/ui";
 
@@ -25,18 +26,43 @@ const THUMB_IMAGE_CLASS = "aspect-[1_/_1] h-full w-full rounded-[0] object-cover
 function DiaryClipThumb({
   thumbnailSrc,
   onClick,
+  disabled,
 }: {
   thumbnailSrc?: string;
   onClick?: () => void;
+  disabled?: boolean;
 }) {
   return (
-    <div className={THUMB_SLOT_CLASS} onClick={onClick}>
+    <div
+      className={`${THUMB_SLOT_CLASS}${disabled ? " cursor-default" : ""}`}
+      onClick={disabled ? undefined : onClick}
+      role={disabled ? undefined : "button"}
+      tabIndex={disabled ? undefined : 0}
+      onKeyDown={
+        disabled
+          ? undefined
+          : (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onClick?.();
+              }
+            }
+      }
+    >
       <VideoClipThumbnail src={thumbnailSrc} className={THUMB_IMAGE_CLASS} />
     </div>
   );
 }
 
-function ThumbGrid({ clips, clipCount, date, themeName }: { clips?: UiDiaryClip[]; clipCount: number; date: string; themeName?: string }) {
+function ThumbGrid({
+  clips,
+  clipCount,
+  themeName,
+}: {
+  clips?: UiDiaryClip[];
+  clipCount: number;
+  themeName: string;
+}) {
   const { openViewer } = useVideoViewer();
   const slotCount = Math.max(clipCount, clips?.length ?? 0);
 
@@ -44,30 +70,32 @@ function ThumbGrid({ clips, clipCount, date, themeName }: { clips?: UiDiaryClip[
     return null;
   }
 
-  const handleThumbClick = (clipId: string) => {
-    const list = (clips ?? []).map((c) => ({
-      clipId: c.id,
-      videoUuid: c.id,
-      title: themeName || "다이어리 영상",
-      themeName,
-      uploadedAt: formatDiaryDate(date),
-      thumbnailUrl: c.thumbnailSrc,
-    }));
+  function handleThumbClick(clip: UiDiaryClip) {
+    if (!clip.videoUuid?.trim()) {
+      return;
+    }
 
-    openViewer(clipId, list, "diary");
-  };
+    const list = toDiaryVideoViewerItems(clips ?? [], themeName);
+    if (list.length === 0) {
+      return;
+    }
+
+    openViewer(clip.id, list, "diary");
+  }
 
   return (
     <div className={THUMB_GRID_CLASS}>
       {Array.from({ length: slotCount }, (_, index) => {
         const clip = clips?.[index];
         const slotKey = clip?.id ?? `slot-${index}`;
+        const canOpen = Boolean(clip?.videoUuid?.trim());
 
         return (
           <DiaryClipThumb
             key={slotKey}
             thumbnailSrc={clip?.thumbnailSrc}
-            onClick={() => clip && handleThumbClick(clip.id)}
+            disabled={!canOpen}
+            onClick={() => clip && handleThumbClick(clip)}
           />
         );
       })}
@@ -94,7 +122,7 @@ export function DiaryThemeClipGroup({
         <h3 className="m-0 text-sm font-semibold text-[#1f1c29]">{title}</h3>
       )}
 
-      <ThumbGrid clips={clips} clipCount={clipCount} date={date} themeName={themeName} />
+      <ThumbGrid clips={clips} clipCount={clipCount} themeName={themeName} />
     </section>
   );
 }

--- a/components/organisms/DiaryVideoViewerModal.tsx
+++ b/components/organisms/DiaryVideoViewerModal.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { DailyIcon, IconButton } from "@/components/atoms";
 import { getVideoAction } from "@/actions/videoActions";
+import { DailyIcon, IconButton } from "@/components/atoms";
 import { extractDate } from "@/lib/video/formatOverlayClock";
+import { resolveRemotePlaybackUrl } from "@/lib/video/playback";
+import { safeVideoPlay } from "@/lib/video/safeVideoPlay";
+import { useEffect, useRef, useState } from "react";
 
 type DiaryVideoViewerModalProps = {
   open: boolean;
@@ -24,6 +26,7 @@ export function DiaryVideoViewerModal({
   thumbnailUrl,
   onClose,
 }: DiaryVideoViewerModalProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
   const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -31,7 +34,7 @@ export function DiaryVideoViewerModal({
   useEffect(() => {
     let isMounted = true;
 
-    if (!open || !videoUuid) {
+    if (!open || !videoUuid?.trim()) {
       Promise.resolve().then(() => {
         if (isMounted) {
           setPlaybackUrl(null);
@@ -46,18 +49,23 @@ export function DiaryVideoViewerModal({
       if (isMounted) {
         setLoading(true);
         setError(null);
+        setPlaybackUrl(null);
       }
     });
 
     getVideoAction(videoUuid)
       .then((res) => {
         if (!isMounted) return;
-        if (res.ok && res.data.rawPlaybackUrl) {
-          setPlaybackUrl(res.data.rawPlaybackUrl);
-        } else if (res.ok && !res.data.rawPlaybackUrl) {
-          setError("재생 가능한 영상 주소가 아직 준비되지 않았습니다.");
-        } else if (!res.ok) {
+        if (!res.ok) {
           setError(res.error || "영상 상세 정보를 불러오지 못했습니다.");
+          return;
+        }
+
+        const url = resolveRemotePlaybackUrl(res.data.rawPlaybackUrl);
+        if (url) {
+          setPlaybackUrl(url);
+        } else {
+          setError("재생 가능한 영상 주소가 아직 준비되지 않았습니다.");
         }
       })
       .catch(() => {
@@ -100,12 +108,18 @@ export function DiaryVideoViewerModal({
       <div className="relative flex h-full w-full max-w-lg flex-col items-center justify-center overflow-hidden">
         {playbackUrl ? (
           <video
+            ref={videoRef}
             src={playbackUrl}
             controls
             autoPlay
             playsInline
             className="h-full w-full object-contain"
             poster={thumbnailUrl}
+            onCanPlay={() => {
+              if (videoRef.current) {
+                safeVideoPlay(videoRef.current);
+              }
+            }}
           />
         ) : thumbnailUrl ? (
           <div className="relative h-full w-full flex items-center justify-center bg-black">

--- a/components/organisms/RecordCalendar.tsx
+++ b/components/organisms/RecordCalendar.tsx
@@ -90,8 +90,11 @@ export function RecordCalendar({ agitId }: RecordCalendarProps) {
   const hasClips = totalVideoCount > 0;
 
   function handleOpenClip(clipId: string, videoUuid?: string, caption?: string, thumbnail?: string) {
+    if (!videoUuid?.trim()) {
+      return;
+    }
     setActiveClipId(clipId);
-    setActiveVideoUuid(videoUuid || clipId);
+    setActiveVideoUuid(videoUuid);
     setActiveCaption(caption);
     setActiveThumbnail(thumbnail);
     setViewerOpen(true);
@@ -189,7 +192,10 @@ export function RecordCalendar({ agitId }: RecordCalendarProps) {
                     <button
                       key={clip.id}
                       type="button"
-                      onClick={() => handleOpenClip(clip.id, clip.id, "", clip.thumbnailSrc)}
+                      onClick={() =>
+                        clip?.videoUuid &&
+                        handleOpenClip(clip.id, clip.videoUuid, clip.caption, clip.thumbnailSrc)
+                      }
                       className="group relative aspect-square overflow-hidden rounded-xl bg-black/10 cursor-pointer border-0 p-0"
                     >
                       {clip.thumbnailSrc ? (

--- a/lib/diary/toVideoViewerItems.ts
+++ b/lib/diary/toVideoViewerItems.ts
@@ -1,0 +1,19 @@
+import type { VideoViewerItem } from "@/components/providers/VideoViewerProvider";
+import type { UiDiaryClip } from "@/types/diary/ui";
+
+/** 다이어리 클립 목록 → 풀스크린 뷰어용 VideoViewerItem (재생 가능 clip만) */
+export function toDiaryVideoViewerItems(
+  clips: UiDiaryClip[],
+  themeName: string,
+): VideoViewerItem[] {
+  return clips
+    .filter((clip) => Boolean(clip.videoUuid?.trim()))
+    .map((clip) => ({
+      clipId: clip.id,
+      videoUuid: clip.videoUuid,
+      title: clip.caption || themeName || "다이어리 영상",
+      themeName,
+      uploadedAt: clip.createdAt ?? clip.date,
+      thumbnailUrl: clip.thumbnailSrc,
+    }));
+}

--- a/services/diaryService.ts
+++ b/services/diaryService.ts
@@ -59,9 +59,12 @@ function mapVideoSummary(
 
   return {
     id: clipId,
+    videoUuid: legacyVideo.videoUuid,
     themeId,
     date,
     thumbnailSrc: toClipThumbnail(legacyVideo.thumbnailUrl ?? legacyVideo.thumbnailPath),
+    caption: legacyVideo.caption?.trim() || undefined,
+    createdAt: legacyVideo.createdAt,
   };
 }
 

--- a/types/diary/ui.ts
+++ b/types/diary/ui.ts
@@ -7,9 +7,13 @@ export type UiDiaryTheme = {
 
 export type UiDiaryClip = {
   id: string;
+  /** video-service UUID — 재생 API용 */
+  videoUuid: string;
   themeId: string;
   date: string;
   thumbnailSrc?: string;
+  caption?: string;
+  createdAt?: string;
 };
 
 export type UiDiaryDateEntry = {
@@ -47,9 +51,4 @@ export type UiDiaryThemeTimelinePage = {
 export type UiDiaryDateWindow = {
   focusDate: string;
   days: Record<string, UiDiaryDateThemeGroup[]>;
-};
-
-export type UiDiaryMenuNav = {
-  themeId: string;
-  date: string;
 };

--- a/types/diary/ui.ts
+++ b/types/diary/ui.ts
@@ -52,3 +52,8 @@ export type UiDiaryDateWindow = {
   focusDate: string;
   days: Record<string, UiDiaryDateThemeGroup[]>;
 };
+
+export type UiDiaryMenuNav = {
+  themeId: string;
+  date: string;
+};


### PR DESCRIPTION
## PR 본문

## 작업 내용

다이어리 테마 상세·날짜 상세 목록에서는 썸네일만 표시하고, 썸네일 클릭 시 FullpageVideoViewer(DiaryVideoViewer)에서 해당 영상을 자동재생하도록 FE 재생 경로를 연동했습니다. diary video id와 video-service UUID가 혼용되던 문제를 수정해 `getVideoAction`이 올바른 `videoUuid`로 호출되게 했습니다. (#142 Phase 1의 `BaseVideoViewer` 재생 로직을 다이어리에서 재사용)

## 관련 이슈

Close #144

## 변경 사항

### 1. UiDiaryClip 타입 및 diaryService 매핑 보강

- **파일:** `types/diary/ui.ts`, `services/diaryService.ts`
- **설명:** diary video PK(`id`)와 재생용 UUID(`videoUuid`)를 분리. `caption`, `createdAt`도 UI 모델에 포함

```typescript
// types/diary/ui.ts
export type UiDiaryClip = {
  id: string;           // diary video PK
  videoUuid: string;    // video-service UUID
  themeId: string;
  date: string;
  thumbnailSrc?: string;
  caption?: string;
  createdAt?: string;
};
```

### 2. 다이어리 → 뷰어 변환 공통 함수

- **파일:** `lib/diary/toVideoViewerItems.ts`
- **설명:** `VideoViewerItem` 변환 로직 공통화. `videoUuid` 없는 clip은 제외

```typescript
export function toDiaryVideoViewerItems(clips: UiDiaryClip[], themeName: string) {
  return clips
    .filter((clip) => Boolean(clip.videoUuid?.trim()))
    .map((clip) => ({
      clipId: clip.id,
      videoUuid: clip.videoUuid,
      title: clip.caption || themeName || "다이어리 영상",
      themeName,
      uploadedAt: clip.createdAt ?? clip.date,
      thumbnailUrl: clip.thumbnailSrc,
    }));
}
```

### 3. 테마 클립 그룹 — 목록 썸네일 / 클릭 시 뷰어

- **파일:** `components/molecules/DiaryThemeClipGroup.tsx`
- **설명:** 목록은 `VideoClipThumbnail`만(자동재생 없음). 클릭 시 `openViewer(..., "diary")` + 올바른 `videoUuid` 전달. `videoUuid` 없으면 클릭 비활성

```typescript
function handleThumbClick(clip: UiDiaryClip) {
  if (!clip.videoUuid?.trim()) return;
  const list = toDiaryVideoViewerItems(clips ?? [], themeName);
  openViewer(clip.id, list, "diary");
}
```

### 4. 기록 캘린더·뷰어 모달 videoUuid 수정

- **파일:** `components/organisms/RecordCalendar.tsx`, `components/organisms/DiaryVideoViewerModal.tsx`
- **설명:** `clip.id`(diary PK)를 UUID로 넘기던 버그 수정. Modal에 stub URL 필터(`resolveRemotePlaybackUrl`) 및 `safeVideoPlay` 적용

```typescript
// RecordCalendar.tsx
onClick={() =>
  clip?.videoUuid &&
  handleOpenClip(clip.id, clip.videoUuid, clip.caption, clip.thumbnailSrc)
}
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)
  - [ ] `/diary/themes/[themeId]` — 썸네일만 표시, autoplay 없음
  - [ ] 썸네일 클릭 → DiaryVideoViewer 풀스크린 자동재생
  - [ ] `/diary/[date]` 날짜 상세에서도 동일 동작
  - [ ] 아지트 기록 캘린더 → DiaryVideoViewerModal 재생 확인
  - [ ] `rawPlaybackUrl` stub/없음 → 썸네일 fallback, 크래시 없음

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인

## 참고

- Phase 1(#143): 아지트 토픽 피드 자동재생 + `BaseVideoViewer` 공통 재생 로직
- 다이어리는 목록 autoplay 없음, **개별 뷰어에서만** Phase 1 `BaseVideoViewer` 재사용
- 실제 blob 재생은 video-service `rawPlaybackUrl`(presigned URL) 및 S3 CORS에 의존
```

---