### PR TITLE
Fix/142 topic auth reissue

### DIFF
--- a/actions/captureDestinationActions.ts
+++ b/actions/captureDestinationActions.ts
@@ -48,26 +48,5 @@ export async function createCaptureTopicAction(
   title: string,
   startDate: string,
 ): Promise<ActionResult<UiTopicListItem>> {
-  const before = await listAgitTopicsAction(agitUuid);
-  if (!before.ok) {
-    return before;
-  }
-  const beforeIds = new Set(before.data.map((item) => item.id));
-
-  const created = await createTopicAction(agitUuid, { title, startDate });
-  if (!created.ok) {
-    return created;
-  }
-
-  const after = await listAgitTopicsAction(agitUuid);
-  if (!after.ok) {
-    return actionFailure(after.error);
-  }
-
-  const newTopic = after.data.find((item) => !beforeIds.has(item.id));
-  if (!newTopic) {
-    return actionFailure("새 토픽을 목록에서 찾지 못했습니다.");
-  }
-
-  return actionSuccess(newTopic);
+  return createTopicAction(agitUuid, { title, startDate });
 }

--- a/actions/topicActions.ts
+++ b/actions/topicActions.ts
@@ -60,7 +60,7 @@ export async function listTopicsByStatusAction(
 export async function createTopicAction(
   agitId: string,
   input: { title: unknown; startDate: unknown },
-): Promise<ActionResult<void>> {
+): Promise<ActionResult<UiTopicListItem>> {
   const loginError = await requireLogin();
   if (loginError) {
     return actionFailure(loginError);
@@ -72,12 +72,12 @@ export async function createTopicAction(
   }
 
   try {
-    await topicService.createTopic({
+    const created = await topicService.createTopic({
       agitUuid: agitId,
       title: parsed.title,
       startAt: parsed.startAt,
     });
-    return actionSuccess(undefined);
+    return actionSuccess(topicService.toUiTopicListItem(created));
   } catch (error) {
     return toActionError(error);
   }

--- a/app/(agit)/agit/[agitId]/feed/page.tsx
+++ b/app/(agit)/agit/[agitId]/feed/page.tsx
@@ -3,7 +3,6 @@ import { ROUTES } from "@/config/routes";
 import { toKstDateString } from "@/lib/topic/selectAgitTopic";
 import { getAgitAndMembers } from "@/services/agitService";
 import { getTopicFeedWindow, getTopicVideos } from "@/services/topicService";
-import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
 import { redirect } from "next/navigation";
 
@@ -12,22 +11,26 @@ type PageProps = {
   searchParams: Promise<{ topic?: string }>;
 };
 
+const EMPTY_WINDOW: UiTopicFeedWindow = {
+  topics: [],
+  currentId: null,
+  hasMoreBefore: false,
+  hasMoreAfter: false,
+};
+
 export default async function AgitTopicFeedPage({ params, searchParams }: PageProps) {
   const { agitId } = await params;
   const { topic: topicUuid } = await searchParams;
 
-  let agit: UiAgit | null = null;
-  let initialWindow: UiTopicFeedWindow = {
-    topics: [],
-    currentId: null,
-    hasMoreBefore: false,
-    hasMoreAfter: false,
-  };
+  const detail = await getAgitAndMembers(agitId).catch(() => null);
+  if (!detail) {
+    redirect(ROUTES.agit.root);
+  }
+
+  let initialWindow: UiTopicFeedWindow = EMPTY_WINDOW;
   const initialVideos: Record<string, UiTopicVideo[]> = {};
 
   try {
-    const detail = await getAgitAndMembers(agitId);
-    agit = detail.agit;
     initialWindow = await getTopicFeedWindow({
       agitUuid: agitId,
       topicUuid,
@@ -36,19 +39,25 @@ export default async function AgitTopicFeedPage({ params, searchParams }: PagePr
       after: 3,
     });
     const center = initialWindow.topics.findIndex((item) => item.id === initialWindow.currentId);
-    const loadIds = [initialWindow.topics[center - 1]?.id, initialWindow.topics[center]?.id, initialWindow.topics[center + 1]?.id].filter(
-      (id): id is string => Boolean(id),
-    );
+    const loadIds = [
+      initialWindow.topics[center - 1]?.id,
+      initialWindow.topics[center]?.id,
+      initialWindow.topics[center + 1]?.id,
+    ].filter((id): id is string => Boolean(id));
     await Promise.all(
       loadIds.map(async (id) => {
         initialVideos[id] = await getTopicVideos(id, detail.members);
       }),
     );
   } catch {
-    redirect(ROUTES.agit.topics(agitId));
+    initialWindow = EMPTY_WINDOW;
   }
 
   return (
-    <AgitTopicFeedTemplate agit={agit} initialWindow={initialWindow} initialVideos={initialVideos} />
+    <AgitTopicFeedTemplate
+      agit={detail.agit}
+      initialWindow={initialWindow}
+      initialVideos={initialVideos}
+    />
   );
 }

--- a/app/(agit)/agit/[agitId]/page.tsx
+++ b/app/(agit)/agit/[agitId]/page.tsx
@@ -3,7 +3,6 @@ import { ROUTES } from "@/config/routes";
 import { toKstDateString } from "@/lib/topic/selectAgitTopic";
 import { getAgitAndMembers } from "@/services/agitService";
 import { getTopicFeedWindow, getTopicVideos } from "@/services/topicService";
-import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicFeedWindow, UiTopicVideo } from "@/types/topic/ui";
 import { redirect } from "next/navigation";
 
@@ -11,21 +10,25 @@ type AgitDetailPageProps = {
   params: Promise<{ agitId: string }>;
 };
 
+const EMPTY_WINDOW: UiTopicFeedWindow = {
+  topics: [],
+  currentId: null,
+  hasMoreBefore: false,
+  hasMoreAfter: false,
+};
+
 export default async function AgitDetailPage({ params }: AgitDetailPageProps) {
   const { agitId } = await params;
 
-  let agit: UiAgit | null = null;
-  let initialWindow: UiTopicFeedWindow = {
-    topics: [],
-    currentId: null,
-    hasMoreBefore: false,
-    hasMoreAfter: false,
-  };
+  const detail = await getAgitAndMembers(agitId).catch(() => null);
+  if (!detail) {
+    redirect(ROUTES.agit.root);
+  }
+
+  let initialWindow: UiTopicFeedWindow = EMPTY_WINDOW;
   const initialVideos: Record<string, UiTopicVideo[]> = {};
 
   try {
-    const detail = await getAgitAndMembers(agitId);
-    agit = detail.agit;
     initialWindow = await getTopicFeedWindow({
       agitUuid: agitId,
       date: toKstDateString(new Date()),
@@ -42,15 +45,15 @@ export default async function AgitDetailPage({ params }: AgitDetailPageProps) {
     await Promise.all(
       loadIds.map(async (id) => {
         initialVideos[id] = await getTopicVideos(id, detail.members);
-      })
+      }),
     );
   } catch {
-    redirect(ROUTES.agit.root);
+    initialWindow = EMPTY_WINDOW;
   }
 
   return (
     <AgitTopicFeedTemplate
-      agit={agit}
+      agit={detail.agit}
       initialWindow={initialWindow}
       initialVideos={initialVideos}
     />

--- a/auth.ts
+++ b/auth.ts
@@ -214,7 +214,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       }
 
       if (matchesPrefix(pathname, PROTECTED_PREFIXES) && !isLoggedIn) {
-        return false;
+        const signInUrl = request.nextUrl.clone();
+        signInUrl.pathname = "/login";
+        signInUrl.searchParams.set("callbackUrl", request.nextUrl.href);
+        return Response.redirect(signInUrl);
       }
 
       return true;
@@ -330,12 +333,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         typeof token.refreshToken === "string" && token.refreshToken.length > 0
           ? token.refreshToken
           : undefined;
+      const userUuid =
+        typeof token.userUuid === "string" && token.userUuid.length > 0
+          ? token.userUuid
+          : undefined;
 
       return {
         expires: session.expires,
         isLoggedIn: Boolean(accessToken),
         accessToken,
         refreshToken,
+        userUuid,
       };
     },
   },

--- a/lib/api/withAuthRetry.ts
+++ b/lib/api/withAuthRetry.ts
@@ -1,13 +1,14 @@
 import { ApiError } from "@/lib/api/apiFetch";
 import { clearDevAccessToken } from "@/lib/api/devAccessToken";
 import {
-  clearRequestAccessTokenOverride,
-  getRequestAccessTokenOverride,
-  setRequestAccessTokenOverride,
+  getRequestAuthTokenOverride,
+  withReissueSingleFlight,
 } from "@/lib/auth/request-token-cache";
 import * as authService from "@/services/authService";
 
 export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
+  const hadOverride = Boolean(getRequestAuthTokenOverride());
+
   try {
     return await request();
   } catch (error) {
@@ -17,29 +18,29 @@ export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
 
     clearDevAccessToken();
 
-    const override = getRequestAccessTokenOverride();
-    if (override) {
-      clearRequestAccessTokenOverride();
-      throw error;
-    }
-
     if (typeof window !== "undefined") {
       throw error;
     }
 
-    const { getServerAuthJwt } = await import("@/lib/auth/server-token");
-    const jwt = await getServerAuthJwt();
-    const refreshToken = jwt?.refreshToken;
-    if (typeof refreshToken !== "string" || !refreshToken) {
+    if (hadOverride) {
       throw error;
     }
 
-    try {
+    await withReissueSingleFlight(async () => {
+      const overrideRefresh = getRequestAuthTokenOverride()?.refreshToken;
+      const { getServerRefreshToken } = await import("@/lib/auth/server-token");
+      const refreshToken = overrideRefresh ?? (await getServerRefreshToken());
+      if (typeof refreshToken !== "string" || !refreshToken) {
+        throw error;
+      }
+
       const refreshed = await authService.reissueToken(refreshToken);
-      setRequestAccessTokenOverride(refreshed.accessToken);
-      return await request();
-    } finally {
-      clearRequestAccessTokenOverride();
-    }
+      return {
+        accessToken: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken,
+      };
+    });
+
+    return await request();
   }
 }

--- a/lib/auth/forwarded-auth-headers.ts
+++ b/lib/auth/forwarded-auth-headers.ts
@@ -1,0 +1,4 @@
+/** 미들웨어 → RSC 내부 요청 헤더. 브라우저 응답에는 넣지 않는다. */
+export const FORWARDED_ACCESS_TOKEN_HEADER = "x-plip-access-token";
+export const FORWARDED_REFRESH_TOKEN_HEADER = "x-plip-refresh-token";
+export const FORWARDED_USER_UUID_HEADER = "x-plip-user-uuid";

--- a/lib/auth/request-token-cache.ts
+++ b/lib/auth/request-token-cache.ts
@@ -1,14 +1,37 @@
-/** 401 reissue 후 동일 요청 체인에서 Bearer 재시도용 (세션 쿠키 갱신 전) */
-let requestAccessTokenOverride: string | undefined;
+/** 401 reissue 후 동일 요청 체인에서 Bearer·refresh 재시도용 (세션 쿠키 갱신 전) */
+export type RequestAuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+};
 
-export function setRequestAccessTokenOverride(token: string | undefined): void {
-  requestAccessTokenOverride = token;
+let requestAuthTokenOverride: RequestAuthTokens | undefined;
+let reissueInFlight: Promise<RequestAuthTokens> | undefined;
+
+export function setRequestAuthTokenOverride(tokens: RequestAuthTokens): void {
+  requestAuthTokenOverride = tokens;
 }
 
-export function getRequestAccessTokenOverride(): string | undefined {
-  return requestAccessTokenOverride;
+export function getRequestAuthTokenOverride(): RequestAuthTokens | undefined {
+  return requestAuthTokenOverride;
 }
 
-export function clearRequestAccessTokenOverride(): void {
-  requestAccessTokenOverride = undefined;
+export function withReissueSingleFlight(
+  reissue: () => Promise<RequestAuthTokens>,
+): Promise<RequestAuthTokens> {
+  if (requestAuthTokenOverride) {
+    return Promise.resolve(requestAuthTokenOverride);
+  }
+
+  if (!reissueInFlight) {
+    reissueInFlight = reissue()
+      .then((tokens) => {
+        requestAuthTokenOverride = tokens;
+        return tokens;
+      })
+      .finally(() => {
+        reissueInFlight = undefined;
+      });
+  }
+
+  return reissueInFlight;
 }

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -1,6 +1,28 @@
-import { getRequestAccessTokenOverride } from "@/lib/auth/request-token-cache";
+import {
+  FORWARDED_ACCESS_TOKEN_HEADER,
+  FORWARDED_REFRESH_TOKEN_HEADER,
+  FORWARDED_USER_UUID_HEADER,
+} from "@/lib/auth/forwarded-auth-headers";
+import { getRequestAuthTokenOverride } from "@/lib/auth/request-token-cache";
 import { headers } from "next/headers";
 import { getToken } from "next-auth/jwt";
+import type { JWT } from "next-auth/jwt";
+
+function readForwardedAuthJwt(headerStore: Headers): JWT | null {
+  const accessToken = headerStore.get(FORWARDED_ACCESS_TOKEN_HEADER) ?? "";
+  const refreshToken = headerStore.get(FORWARDED_REFRESH_TOKEN_HEADER) ?? "";
+  const userUuid = headerStore.get(FORWARDED_USER_UUID_HEADER) ?? "";
+
+  if (!accessToken && !refreshToken && !userUuid) {
+    return null;
+  }
+
+  return {
+    accessToken: accessToken || undefined,
+    refreshToken: refreshToken || undefined,
+    userUuid: userUuid || undefined,
+  };
+}
 
 export async function getServerAuthJwt() {
   if (typeof window !== "undefined") {
@@ -8,6 +30,11 @@ export async function getServerAuthJwt() {
   }
 
   const headerStore = await headers();
+  const forwarded = readForwardedAuthJwt(headerStore);
+  if (forwarded) {
+    return forwarded;
+  }
+
   const cookie = headerStore.get("cookie") ?? "";
 
   return getToken({
@@ -31,7 +58,7 @@ export async function getServerUserUuid(): Promise<string | undefined> {
 }
 
 export async function getServerAccessToken(): Promise<string | undefined> {
-  const override = getRequestAccessTokenOverride();
+  const override = getRequestAuthTokenOverride()?.accessToken;
   if (override) {
     return override;
   }
@@ -42,29 +69,35 @@ export async function getServerAccessToken(): Promise<string | undefined> {
 }
 
 export async function getServerRefreshToken(): Promise<string | undefined> {
+  const override = getRequestAuthTokenOverride()?.refreshToken;
+  if (override) {
+    return override;
+  }
+
   const jwt = await getServerAuthJwtSafe();
   const token = jwt?.refreshToken;
   return typeof token === "string" && token.length > 0 ? token : undefined;
 }
 
 export async function getSessionAuthHeaders(): Promise<Record<string, string>> {
-  const override = getRequestAccessTokenOverride();
-  if (override) {
-    return { Authorization: `Bearer ${override}` };
-  }
-
+  const override = getRequestAuthTokenOverride();
   const jwt = await getServerAuthJwtSafe();
-  if (!jwt) {
-    return {};
-  }
+
+  const accessToken =
+    override?.accessToken ??
+    (typeof jwt?.accessToken === "string" && jwt.accessToken.length > 0
+      ? jwt.accessToken
+      : undefined);
+  const userUuid =
+    typeof jwt?.userUuid === "string" && jwt.userUuid.length > 0 ? jwt.userUuid : undefined;
 
   const sessionHeaders: Record<string, string> = {};
-  if (typeof jwt.accessToken === "string" && jwt.accessToken) {
-    sessionHeaders.Authorization = `Bearer ${jwt.accessToken}`;
+  if (accessToken) {
+    sessionHeaders.Authorization = `Bearer ${accessToken}`;
   }
-  if (typeof jwt.userUuid === "string" && jwt.userUuid) {
+  if (userUuid) {
     // Canonical gateway / video header (legacy X-User-Uuid still accepted by video filter)
-    sessionHeaders["X-User-UUID"] = jwt.userUuid;
+    sessionHeaders["X-User-UUID"] = userUuid;
   }
   return sessionHeaders;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,33 @@
-export { auth as middleware } from "@/auth";
+import { auth } from "@/auth";
+import {
+  FORWARDED_ACCESS_TOKEN_HEADER,
+  FORWARDED_REFRESH_TOKEN_HEADER,
+  FORWARDED_USER_UUID_HEADER,
+} from "@/lib/auth/forwarded-auth-headers";
+import { NextResponse } from "next/server";
+
+export default auth((req) => {
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.delete(FORWARDED_ACCESS_TOKEN_HEADER);
+  requestHeaders.delete(FORWARDED_REFRESH_TOKEN_HEADER);
+  requestHeaders.delete(FORWARDED_USER_UUID_HEADER);
+
+  const accessToken = req.auth?.accessToken;
+  const refreshToken = req.auth?.refreshToken;
+  const userUuid = req.auth?.userUuid;
+
+  if (typeof accessToken === "string" && accessToken.length > 0) {
+    requestHeaders.set(FORWARDED_ACCESS_TOKEN_HEADER, accessToken);
+  }
+  if (typeof refreshToken === "string" && refreshToken.length > 0) {
+    requestHeaders.set(FORWARDED_REFRESH_TOKEN_HEADER, refreshToken);
+  }
+  if (typeof userUuid === "string" && userUuid.length > 0) {
+    requestHeaders.set(FORWARDED_USER_UUID_HEADER, userUuid);
+  }
+
+  return NextResponse.next({ request: { headers: requestHeaders } });
+});
 
 export const config = {
   matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|plip).*)"],

--- a/types/auth/authjs.d.ts
+++ b/types/auth/authjs.d.ts
@@ -6,6 +6,7 @@ declare module "next-auth" {
     isLoggedIn: boolean;
     accessToken?: string;
     refreshToken?: string;
+    userUuid?: string;
     user?: DefaultSession["user"];
   }
 


### PR DESCRIPTION
## 작업 내용

plip-user refresh는 1회용인데, access 만료 시 미들웨어 reissue와 RSC `getToken()`이 같은 요청에서 옛 refresh로 연속 reissue를 쳐 AUTH_003이 났습니다. 미들웨어가 재발급 토큰을 RSC 요청 헤더로 넘기고, `withAuthRetry`는 요청 단위 단일 재발급으로 고정했습니다. 입장 페이지는 topic 실패를 홈 redirect로 위장하지 않고, 촬영 토픽 생성의 list→create→list 3연타도 제거했습니다.

## 관련 이슈

Close #142

## 변경 사항

### 1. 미들웨어에서 재발급 토큰을 RSC로 전달

- **파일:** `middleware.ts`, `auth.ts`, `types/auth/authjs.d.ts`, `lib/auth/forwarded-auth-headers.ts`, `lib/auth/server-token.ts`
- **설명:** `auth` 래퍼가 `req.auth`의 access/refresh/`userUuid`를 내부 요청 헤더로 복사합니다. session 콜백에 `userUuid`를 넣고, RSC는 이 헤더를 `getToken()`보다 우선합니다. 클라이언트에서 헤더를 주입하지 못하도록 기존 값을 지운 뒤 세션 값만 다시 넣습니다. `authorized`가 `false`를 반환하면 래퍼가 로그인 리다이렉트를 건너뛰므로, 비로그인 보호 경로는 `Response.redirect`로 바꿨습니다.

```typescript
export default auth((req) => {
  const requestHeaders = new Headers(req.headers);
  requestHeaders.delete(FORWARDED_ACCESS_TOKEN_HEADER);
  requestHeaders.delete(FORWARDED_REFRESH_TOKEN_HEADER);
  requestHeaders.delete(FORWARDED_USER_UUID_HEADER);

  if (typeof req.auth?.accessToken === "string" && req.auth.accessToken.length > 0) {
    requestHeaders.set(FORWARDED_ACCESS_TOKEN_HEADER, req.auth.accessToken);
  }
  // refresh, userUuid 동일
  return NextResponse.next({ request: { headers: requestHeaders } });
});
```

### 2. withAuthRetry를 요청 단위 단일 재발급으로 고정

- **파일:** `lib/auth/request-token-cache.ts`, `lib/api/withAuthRetry.ts`
- **설명:** override를 `{ accessToken, refreshToken }`로 넓히고 성공 후에도 지우지 않습니다. 진행 중인 reissue는 await(single-flight)하고, 재시도 후에도 401이면 throw합니다.

```typescript
export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
  const hadOverride = Boolean(getRequestAuthTokenOverride());
  try {
    return await request();
  } catch (error) {
    if (!(error instanceof ApiError) || error.status !== 401) throw error;
    if (typeof window !== "undefined" || hadOverride) throw error;
    await withReissueSingleFlight(async () => {
      const refreshToken =
        getRequestAuthTokenOverride()?.refreshToken ?? (await getServerRefreshToken());
      const refreshed = await authService.reissueToken(refreshToken);
      return { accessToken: refreshed.accessToken, refreshToken: refreshed.refreshToken };
    });
    return await request();
  }
}
```

### 3. 입장 페이지에서 topic 실패를 통째 redirect하지 않음

- **파일:** `app/(agit)/agit/[agitId]/page.tsx`, `app/(agit)/agit/[agitId]/feed/page.tsx`
- **설명:** agit 로드 실패만 `redirect(ROUTES.agit.root)`입니다. topic feed/videos 실패는 빈 `initialWindow`로 템플릿을 그립니다.

```typescript
const detail = await getAgitAndMembers(agitId).catch(() => null);
if (!detail) {
  redirect(ROUTES.agit.root);
}

let initialWindow: UiTopicFeedWindow = EMPTY_WINDOW;
try {
  initialWindow = await getTopicFeedWindow({ /* ... */ });
} catch {
  initialWindow = EMPTY_WINDOW;
}
```

### 4. 토픽 생성 3연타 제거

- **파일:** `actions/topicActions.ts`, `actions/captureDestinationActions.ts`
- **설명:** `createTopicAction`이 `UiTopicListItem`을 반환합니다. `createCaptureTopicAction`은 create 한 번만 호출합니다. `TopicCreateForm`은 `ok`만 보므로 시그니처만 맞춥니다.

```typescript
const created = await topicService.createTopic({ agitUuid: agitId, title, startAt });
return actionSuccess(topicService.toUiTopicListItem(created));

export async function createCaptureTopicAction(...) {
  return createTopicAction(agitUuid, { title, startDate });
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`) — access 만료(또는 만료 1분 전) 후 `/agit/{id}` 입장, 토픽 생성, 촬영 인라인 토픽 생성이 401/AUTH_003 없이 통과하는지

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인