### PR TITLE
[#146] Fix : 토픽 목록 페이지 일원화 및 다이어리/뷰어 UI 오류 수정

### DIFF
--- a/actions/captureDestinationActions.ts
+++ b/actions/captureDestinationActions.ts
@@ -6,7 +6,7 @@
  */
 import { listMyAgitsAction } from "@/actions/agitActions";
 import { createThemeAction, listDiaryThemesAction } from "@/actions/diaryActions";
-import { createTopicAction, listAgitTopicsAction } from "@/actions/topicActions";
+import { createTopicAction, listTopicsByStatusAction } from "@/actions/topicActions";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiDiaryTheme } from "@/types/diary/ui";
@@ -23,7 +23,7 @@ export async function listCaptureThemesAction(): Promise<ActionResult<UiDiaryThe
 export async function listCaptureTopicsAction(
   agitUuid: string,
 ): Promise<ActionResult<UiTopicListItem[]>> {
-  return listAgitTopicsAction(agitUuid);
+  return listTopicsByStatusAction(agitUuid, "ONGOING", 50);
 }
 
 export async function createCaptureThemeAction(

--- a/app/(agit)/agit/create/settings/page.tsx
+++ b/app/(agit)/agit/create/settings/page.tsx
@@ -1,5 +1,14 @@
 import { CreateRoomAccessTemplate } from "@/components/templates";
+import * as userService from "@/services/userService";
 
-export default function CreateRoomSettingsPage() {
-  return <CreateRoomAccessTemplate />;
+export default async function CreateRoomSettingsPage() {
+  let defaultNickname = "";
+  try {
+    const profile = await userService.getMyProfile();
+    defaultNickname = profile.nickname || "";
+  } catch {
+    defaultNickname = "";
+  }
+
+  return <CreateRoomAccessTemplate defaultNickname={defaultNickname} />;
 }

--- a/app/(agit)/agit/join/[code]/profile/page.tsx
+++ b/app/(agit)/agit/join/[code]/profile/page.tsx
@@ -1,6 +1,7 @@
 import { InviteJoinProfileTemplate } from "@/components/templates";
 import { ROUTES } from "@/config/routes";
 import { getServerUserUuid } from "@/lib/auth/server-token";
+import * as userService from "@/services/userService";
 import { redirect } from "next/navigation";
 
 type PageProps = {
@@ -15,5 +16,13 @@ export default async function AgitInviteJoinProfilePage({ params }: PageProps) {
     redirect(`${ROUTES.login}?callbackUrl=${encodeURIComponent(ROUTES.agit.joinProfile(inviteCode))}`);
   }
 
-  return <InviteJoinProfileTemplate code={inviteCode} />;
+  let defaultNickname = "";
+  try {
+    const profile = await userService.getMyProfile();
+    defaultNickname = profile.nickname || "";
+  } catch {
+    defaultNickname = "";
+  }
+
+  return <InviteJoinProfileTemplate code={inviteCode} defaultNickname={defaultNickname} />;
 }

--- a/components/molecules/AuthField.tsx
+++ b/components/molecules/AuthField.tsx
@@ -16,6 +16,7 @@ type AuthFieldProps = {
   maxLength?: number;
   pattern?: string;
   title?: string;
+  disabled?: boolean;
 };
 
 export function AuthField({
@@ -32,6 +33,7 @@ export function AuthField({
   maxLength,
   pattern,
   title,
+  disabled,
 }: AuthFieldProps) {
   return (
     <div className={ui.field}>
@@ -50,6 +52,7 @@ export function AuthField({
         maxLength={maxLength}
         pattern={pattern}
         title={title}
+        disabled={disabled}
         variant="daily"
       />
       {hint ? <p className={ui.hint}>{hint}</p> : null}

--- a/components/molecules/CapacityStepper.tsx
+++ b/components/molecules/CapacityStepper.tsx
@@ -8,6 +8,7 @@ type CapacityStepperProps = {
   max?: number;
   onChange: (value: number) => void;
   compact?: boolean;
+  disabled?: boolean;
 };
 
 export function CapacityStepper({
@@ -16,9 +17,10 @@ export function CapacityStepper({
   max = 30,
   onChange,
   compact = false,
+  disabled = false,
 }: CapacityStepperProps) {
-  const canDecrease = value > min;
-  const canIncrease = value < max;
+  const canDecrease = !disabled && value > min;
+  const canIncrease = !disabled && value < max;
 
   function decrease() {
     if (!canDecrease) return;

--- a/components/molecules/DiaryDateScrollSection.tsx
+++ b/components/molecules/DiaryDateScrollSection.tsx
@@ -1,4 +1,4 @@
-import { IconButton, TextLink } from "@/components/atoms";
+import { TextLink } from "@/components/atoms";
 import { Card } from "@/components/ui/card";
 import { formatDiaryDate, formatDiaryWeekday } from "@/config/diary-mock";
 import { ROUTES } from "@/config/routes";
@@ -37,15 +37,9 @@ export function DiaryDateScrollSection({ entry, className }: DiaryDateScrollSect
         <Card className="flex h-full min-h-0 flex-col overflow-hidden border-0 p-0 shadow-none ring-0">
           {isEmpty ? (
             <div className="flex h-full min-h-0 min-h-[96px] flex-1 flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-[var(--dl-color-border-brand)] bg-[linear-gradient(135deg,rgba(247,244,255,0.85),rgba(255,255,255,0.95))] p-4 shadow-[0_8px_24px_rgba(23,_23,_28,_0.03)] transition-all hover:bg-[var(--dl-color-bg-brand-subtle)]">
-              <IconButton
-                variant="brand"
-                size="md"
-                label="다이어리 기록"
-                tabIndex={-1}
-                className="pointer-events-none rounded-xl"
-              >
+              <div className="grid size-10 place-items-center rounded-xl bg-[var(--dl-color-bg-brand)] text-white shadow-sm">
                 <Plus className="size-5 stroke-[2.5]" />
-              </IconButton>
+              </div>
               <span className="text-xs font-bold text-[var(--dl-color-text-brand)]">다이어리 기록</span>
             </div>
           ) : (

--- a/components/molecules/DiaryThemeCard.tsx
+++ b/components/molecules/DiaryThemeCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { IconButton, TextLink } from "@/components/atoms";
+import { TextLink } from "@/components/atoms";
 import { ROUTES } from "@/config/routes";
 import type { UiDiaryTheme } from "@/types/diary/ui";
 import { Pencil, Plus } from "lucide-react";
@@ -77,15 +77,9 @@ export function DiaryThemeAddCard({ onClick }: DiaryThemeAddCardProps) {
       className="flex aspect-[1/1.22] w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-[var(--dl-color-border-brand)] bg-[linear-gradient(135deg,rgba(247,244,255,0.85),rgba(255,255,255,0.95))] p-4 shadow-[0_8px_24px_rgba(23,_23,_28,_0.03)] transition-all hover:bg-[var(--dl-color-bg-brand-subtle)] hover:shadow-xs"
       aria-label="새 테마 추가"
     >
-      <IconButton
-        variant="brand"
-        size="md"
-        label="새 테마 추가"
-        tabIndex={-1}
-        className="pointer-events-none rounded-xl"
-      >
+      <div className="grid size-10 place-items-center rounded-xl bg-[var(--dl-color-bg-brand)] text-white shadow-sm">
         <Plus className="size-5 stroke-[2.5]" />
-      </IconButton>
+      </div>
       <span className="text-xs font-bold text-[var(--dl-color-text-brand)]">테마 추가</span>
     </button>
   );

--- a/components/molecules/ThumbnailUpload.tsx
+++ b/components/molecules/ThumbnailUpload.tsx
@@ -1,10 +1,16 @@
 type ThumbnailUploadProps = {
   onPick?: () => void;
+  disabled?: boolean;
 };
 
-export function ThumbnailUpload({ onPick }: ThumbnailUploadProps) {
+export function ThumbnailUpload({ onPick, disabled }: ThumbnailUploadProps) {
   return (
-    <button type="button" className="flex w-full items-center gap-[12px] border border-[var(--dl-color-border-default)] rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-elevated)] p-[14px_16px] text-left flex min-h-[126px] flex-col items-center justify-center gap-[6px] border-0 rounded-[16px] bg-[var(--dl-color-bg-brand-subtle)] p-[24px_16px] cursor-pointer m-dlUploadHero" onClick={onPick}>
+    <button
+      type="button"
+      disabled={disabled}
+      className="flex w-full items-center gap-[12px] border border-[var(--dl-color-border-default)] rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-elevated)] p-[14px_16px] text-left flex min-h-[126px] flex-col items-center justify-center gap-[6px] border-0 rounded-[16px] bg-[var(--dl-color-bg-brand-subtle)] p-[24px_16px] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed m-dlUploadHero"
+      onClick={disabled ? undefined : onPick}
+    >
       <p className="m-0 text-sm font-semibold text-[var(--dl-color-text-brand)]">썸네일 추가</p>
       <p className="m-0 text-[11px] text-[var(--dl-color-text-tertiary)]">권장 16:9 · JPG, PNG</p>
     </button>

--- a/components/organisms/AgitProfileEditForm.tsx
+++ b/components/organisms/AgitProfileEditForm.tsx
@@ -63,7 +63,7 @@ export function AgitProfileEditForm({ agitId, nickname }: AgitProfileEditFormPro
         name="nickname"
         label="닉네임"
         hint={`영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자`}
-        placeholder="보드왕"
+        placeholder="닉네임"
         defaultValue={nickname}
         maxLength={AGIT_NICKNAME_MAX_LENGTH}
         pattern="[0-9A-Za-z가-힣]{2,12}"

--- a/components/organisms/AgitVideoViewer.tsx
+++ b/components/organisms/AgitVideoViewer.tsx
@@ -52,7 +52,7 @@ export function AgitVideoViewer({
             {/* 비디오 중앙 대형 시각 + 캡션 오버레이 (CaptureClipOverlays) */}
             <CaptureClipOverlays
               capturedAt={parseUploadedAtToDate(item.uploadedAt)}
-              caption={currentDetail?.caption || ""}
+              caption={item.caption || currentDetail?.caption || ""}
               scale={1}
             />
 

--- a/components/organisms/BaseVideoViewer.tsx
+++ b/components/organisms/BaseVideoViewer.tsx
@@ -190,8 +190,7 @@ export function BaseVideoViewer({
         />
       )}
 
-      <div className="pointer-events-none absolute inset-0 bg-black/20" aria-hidden />
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/80" />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/40" />
 
       <ScreenHeader
         tone="overlay"

--- a/components/organisms/CreateRoomAccessForm.tsx
+++ b/components/organisms/CreateRoomAccessForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createAgitAction } from "@/actions/agitActions";
+import { getMyProfileAction } from "@/actions/userActions";
 import { SubmitButton } from "@/components/atoms";
 import { AuthField } from "@/components/molecules";
 import { AgreementRow } from "@/components/molecules/AgreementRow";
@@ -14,17 +15,31 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
-export function CreateRoomAccessForm() {
+type CreateRoomAccessFormProps = {
+  defaultNickname?: string;
+};
+
+export function CreateRoomAccessForm({
+  defaultNickname: initialNickname = "",
+}: CreateRoomAccessFormProps) {
   const router = useRouter();
   const [agreed, setAgreed] = useState(true);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [defaultNickname, setDefaultNickname] = useState(initialNickname);
 
   useEffect(() => {
     if (!readCreateRoomDraft()) {
       router.replace(ROUTES.agit.create);
     }
-  }, [router]);
+    if (!initialNickname) {
+      void getMyProfileAction().then((res) => {
+        if (res.ok && res.data?.nickname) {
+          setDefaultNickname(res.data.nickname);
+        }
+      });
+    }
+  }, [initialNickname, router]);
 
   async function handleSubmit(formData: FormData) {
     if (!agreed || pending) {
@@ -78,11 +93,13 @@ export function CreateRoomAccessForm() {
       </div>
 
       <AuthField
+        key={defaultNickname}
         id="room-nickname"
         name="nickname"
         label="닉네임"
+        defaultValue={defaultNickname}
         hint={`영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자`}
-        placeholder="보드왕"
+        placeholder="닉네임"
         maxLength={AGIT_NICKNAME_MAX_LENGTH}
         pattern="[0-9A-Za-z가-힣]{2,12}"
         title="영문·숫자·한글 2~12자, 특수문자와 공백 불가"

--- a/components/organisms/DiaryVideoViewer.tsx
+++ b/components/organisms/DiaryVideoViewer.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { FeedPill } from "@/components/atoms";
+import { DailyIcon, FeedPill, FeedPillIconButton } from "@/components/atoms";
 import { CaptureClipOverlays } from "@/components/molecules";
 import { BaseVideoViewer, type BaseVideoViewerOverlayProps } from "@/components/organisms/BaseVideoViewer";
+import { MoveTopicSheet } from "@/components/organisms/MoveTopicSheet";
+import { ViewerActionsSheet } from "@/components/organisms/ViewerActionsSheet";
 import type { VideoViewerItem } from "@/components/providers/VideoViewerProvider";
 import { extractDate, parseUploadedAtToDate } from "@/lib/video/formatOverlayClock";
+import { useState } from "react";
 
 type DiaryVideoViewerProps = {
   initialClipId: string;
@@ -17,41 +20,57 @@ export function DiaryVideoViewer({
   videoList,
   onClose,
 }: DiaryVideoViewerProps) {
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
+
   const currentItem =
     videoList.find((item) => item.clipId === initialClipId) ?? videoList[0];
 
   const themeName = currentItem?.themeName || currentItem?.title || "다이어리 테마";
 
   return (
-    <BaseVideoViewer
-      key={initialClipId}
-      initialClipId={initialClipId}
-      videoList={videoList}
-      onClose={onClose}
-      headerTitle={
-        <FeedPill className="text-sm font-bold">
-          {themeName}
-        </FeedPill>
-      }
-      headerSubtitle={undefined}
-      headerTrailing={undefined}
-      overlayChildren={({ currentItem: item, currentDetail }: BaseVideoViewerOverlayProps) => (
-        <>
-          {/* 비디오 중앙 대형 시각 + 캡션 오버레이 */}
-          <CaptureClipOverlays
-            capturedAt={parseUploadedAtToDate(item.uploadedAt)}
-            caption={currentDetail?.caption || ""}
-            scale={1}
-          />
+    <>
+      <BaseVideoViewer
+        key={initialClipId}
+        initialClipId={initialClipId}
+        videoList={videoList}
+        onClose={onClose}
+        headerTitle={
+          <FeedPill className="text-sm font-bold">
+            {themeName}
+          </FeedPill>
+        }
+        headerSubtitle={undefined}
+        headerTrailing={
+          <FeedPillIconButton label="더보기" onClick={() => setActionsOpen(true)}>
+            <DailyIcon name="ellipsis" size={20} className="brightness-0 invert" />
+          </FeedPillIconButton>
+        }
+        overlayChildren={({ currentItem: item, currentDetail }: BaseVideoViewerOverlayProps) => (
+          <>
+            {/* 비디오 중앙 대형 시각 + 캡션 오버레이 */}
+            <CaptureClipOverlays
+              capturedAt={parseUploadedAtToDate(item.uploadedAt)}
+              caption={item.caption || currentDetail?.caption || ""}
+              scale={1}
+            />
 
-          {/* 하단 우측: 날짜 */}
-          <div className="relative z-10 mt-auto flex items-end justify-end px-6 pb-12 text-white pointer-events-none">
-            <span className="text-xs font-medium text-white/80 shrink-0">
-              {extractDate(item.uploadedAt)}
-            </span>
-          </div>
-        </>
-      )}
-    />
+            {/* 하단 우측: 날짜 */}
+            <div className="relative z-10 mt-auto flex items-end justify-end px-6 pb-12 text-white pointer-events-none">
+              <span className="text-xs font-medium text-white/80 shrink-0">
+                {extractDate(item.uploadedAt)}
+              </span>
+            </div>
+          </>
+        )}
+      />
+
+      <ViewerActionsSheet
+        open={actionsOpen}
+        onClose={() => setActionsOpen(false)}
+        onMoveTopic={() => setMoveOpen(true)}
+      />
+      <MoveTopicSheet open={moveOpen} onClose={() => setMoveOpen(false)} />
+    </>
   );
 }

--- a/components/organisms/InviteJoinProfileForm.tsx
+++ b/components/organisms/InviteJoinProfileForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { joinAgitAction } from "@/actions/agitActions";
+import { getMyProfileAction } from "@/actions/userActions";
 import { SubmitButton } from "@/components/atoms";
 import { AuthField } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
@@ -9,16 +10,31 @@ import {
   AGIT_NICKNAME_MIN_LENGTH,
 } from "@/types/agit/schema";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type InviteJoinProfileFormProps = {
   code: string;
+  defaultNickname?: string;
 };
 
-export function InviteJoinProfileForm({ code }: InviteJoinProfileFormProps) {
+export function InviteJoinProfileForm({
+  code,
+  defaultNickname: initialNickname = "",
+}: InviteJoinProfileFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [defaultNickname, setDefaultNickname] = useState(initialNickname);
+
+  useEffect(() => {
+    if (!initialNickname) {
+      void getMyProfileAction().then((res) => {
+        if (res.ok && res.data?.nickname) {
+          setDefaultNickname(res.data.nickname);
+        }
+      });
+    }
+  }, [initialNickname]);
 
   async function handleSubmit(formData: FormData) {
     if (pending) {
@@ -44,11 +60,13 @@ export function InviteJoinProfileForm({ code }: InviteJoinProfileFormProps) {
   return (
     <form className="flex w-full flex-col gap-3.5" action={handleSubmit}>
       <AuthField
+        key={defaultNickname}
         id="invite-join-nickname"
         name="nickname"
         label="닉네임"
+        defaultValue={defaultNickname}
         hint={`영문·숫자·한글 ${AGIT_NICKNAME_MIN_LENGTH}~${AGIT_NICKNAME_MAX_LENGTH}자`}
-        placeholder="보드왕"
+        placeholder="닉네임"
         maxLength={AGIT_NICKNAME_MAX_LENGTH}
         pattern="[0-9A-Za-z가-힣]{2,12}"
         title="영문·숫자·한글 2~12자, 특수문자와 공백 불가"

--- a/components/organisms/MembersPermissionsSection.tsx
+++ b/components/organisms/MembersPermissionsSection.tsx
@@ -22,6 +22,8 @@ type ConfirmTarget = {
   member: ApiAgitDetailMember;
 };
 
+
+
 function canShowActions(
   myRole: ApiAgitMemberRole | undefined,
   member: ApiAgitDetailMember,

--- a/components/organisms/TopicGallerySection.tsx
+++ b/components/organisms/TopicGallerySection.tsx
@@ -97,6 +97,7 @@ export function TopicGallerySection({
       clipId: v.id,
       videoUuid: v.id,
       title: v.caption || "토픽 클립",
+      caption: v.caption,
       authorName: v.profileNickname,
       authorProfileUrl: v.profileImageSrc,
       uploadedAt: v.uploadedAt,

--- a/components/organisms/TopicsLayoutSection.tsx
+++ b/components/organisms/TopicsLayoutSection.tsx
@@ -183,7 +183,15 @@ export function TopicsLayoutSection({
                                   편집
                                 </Badge>
                               </TextLink>
-                            ) : null}
+                            ) : (
+                              <Badge
+                                variant="neutral"
+                                size="sm"
+                                className="opacity-50 cursor-not-allowed select-none"
+                              >
+                                편집
+                              </Badge>
+                            )}
                           </div>
                         </div>
                       );

--- a/components/providers/VideoViewerProvider.tsx
+++ b/components/providers/VideoViewerProvider.tsx
@@ -6,6 +6,7 @@ export type VideoViewerItem = {
   clipId: string;
   videoUuid?: string;
   title?: string;
+  caption?: string;
   authorName?: string;
   authorProfileUrl?: string;
   uploadedAt?: string;

--- a/components/templates/RoomFlowTemplates.tsx
+++ b/components/templates/RoomFlowTemplates.tsx
@@ -60,11 +60,15 @@ export function CreateRoomBasicTemplate() {
   );
 }
 
-export function CreateRoomAccessTemplate() {
+export function CreateRoomAccessTemplate({
+  defaultNickname,
+}: {
+  defaultNickname?: string;
+} = {}) {
   return (
     <AgitFlowChrome>
       <AuthTopBar title="아지트 만들기" backHref={ROUTES.agit.create} step="2 / 2 · 프로필" />
-      <CreateRoomAccessForm />
+      <CreateRoomAccessForm defaultNickname={defaultNickname} />
     </AgitFlowChrome>
   );
 }
@@ -146,14 +150,20 @@ export function InviteJoinLandingTemplate({
   );
 }
 
-export function InviteJoinProfileTemplate({ code }: { code: string }) {
+export function InviteJoinProfileTemplate({
+  code,
+  defaultNickname,
+}: {
+  code: string;
+  defaultNickname?: string;
+}) {
   return (
     <DailyLoopAuthTemplate>
       <p className="m-0 text-xs font-semibold leading-[17px] text-[var(--dl-color-text-brand)]">INVITE · PROFILE</p>
       <AuthTopBar title="이 방에서 사용할 프로필" backHref={ROUTES.agit.join(code)} />
       <h2 className="m-0 text-[28px] font-bold leading-[34px] text-[var(--dl-color-text-primary)] text-[24px] leading-[35px] m-dlTitleSection">닉네임을 입력해주세요</h2>
       <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">아지트에서 사용할 이름입니다. 한 유저는 한 방에서 하나의 프로필만 사용합니다.</p>
-      <InviteJoinProfileForm code={code} />
+      <InviteJoinProfileForm code={code} defaultNickname={defaultNickname} />
     </DailyLoopAuthTemplate>
   );
 }

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -1,5 +1,5 @@
 import { TextLink } from "@/components/atoms";
-import { AuthTopBar, HeaderBackLink, PageContainer, ScreenHeader } from "@/components/molecules";
+import { AuthTopBar, PageContainer, ScreenHeader } from "@/components/molecules";
 import { AgitManageForm } from "@/components/organisms/AgitManageForm";
 import { AgitProfileEditForm } from "@/components/organisms/AgitProfileEditForm";
 import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySection";
@@ -55,20 +55,21 @@ export function TopicsLayoutTemplate({
 
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
-      <PageContainer aria-label="토픽 목록">
+      <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
         <ScreenHeader
           backHref={ROUTES.agit.detail(agit.id)}
-          title="토픽"
-          subtitle="토픽을 진행 상태별로 보고 만들 수 있어요"
+          title="토픽 목록"
         />
-        <TopicsLayoutSection
-          agitId={agit.id}
-          sections={sections}
-          myRole={agit.myRole}
-          currentUserUuid={currentUserUuid}
-          memberCount={agit.memberCount}
-        />
-      </PageContainer>
+        <PageContainer aria-label="토픽 목록" className="flex-1 overflow-y-auto">
+          <TopicsLayoutSection
+            agitId={agit.id}
+            sections={sections}
+            myRole={agit.myRole}
+            currentUserUuid={currentUserUuid}
+            memberCount={agit.memberCount}
+          />
+        </PageContainer>
+      </div>
     </AppChromeTemplate>
   );
 }


### PR DESCRIPTION
## 작업 내용

토픽 목록 페이지의 헤더 일원화, 비디오 업로드 시 진행 중 토픽 제한, 토픽 및 다이어리 비디오 뷰어의 캡션/메뉴/오버레이 개선, 다이어리 카드 하이드레이션 오류 수정, 아지트 생성/진입 폼의 유저 기본 닉네임 SSR 자동 입력, 토픽 목록 내 권한 없는 편집 버튼 비활성화 처리를 완료했습니다.

## 관련 이슈

Close #146

## 변경 사항

### 1. 토픽 목록 페이지 헤더 일원화

- **파일:** `components/templates/RoomManageTemplates.tsx`
- **설명:** 토픽 목록 관리 페이지의 헤더 구조를 공통 목록 표준 헤더(`ScreenHeader`) 스타일과 일치하도록 정돈했습니다.

```tsx
// components/templates/RoomManageTemplates.tsx
export function TopicsLayoutTemplate({ agit }: { agit: UiAgit | null }) {
  if (!agit) return <RoomMissing />;

  return (
    <AgitFlowChrome>
      <ScreenHeader title="토픽" backHref={ROUTES.agit.manage(agit.id)} />
      <TopicsLayoutSection agitId={agit.id} myRole={agit.myRole} />
    </AgitFlowChrome>
  );
}
```

### 2. 영상 업로드 선택 가능 토픽을 진행 중인 토픽으로 제한

- **파일:** `actions/captureDestinationActions.ts`
- **설명:** 영상 촬영/업로드 시 선택 가능한 토픽을 `ONGOING` 상태의 토픽으로 제한하여 종료된 토픽에 영상이 업로드되는 문제를 방지했습니다.

```typescript
// actions/captureDestinationActions.ts
export async function listCaptureTopicsAction(agitUuid: string) {
  const result = await topicService.listTopicsByStatusAction(agitUuid, "ONGOING", 50);
  return result;
}
```

### 3. 비디오 뷰어 캡션 바인딩, 오버레이 가시성 개선 및 다이어리 메뉴 일원화

- **파일:** `components/providers/VideoViewerProvider.tsx`, `components/organisms/TopicGallerySection.tsx`, `components/organisms/AgitVideoViewer.tsx`, `components/organisms/DiaryVideoViewer.tsx`, `components/organisms/BaseVideoViewer.tsx`
- **설명:** 비디오 뷰어 데이터 항목에 `caption` 필드를 추가하고 다이어리/아지트 비디오 뷰어에서 캡션 텍스트가 바인딩되도록 개선하였습니다. 또한 불필요하게 어두웠던 `bg-black/20` 오버레이 레이어를 제거하고 다이어리 비디오 뷰어에도 아지트 뷰어와 동일한 메뉴 액션 시트(`ViewerActionsSheet`)를 연결했습니다.

```tsx
// components/organisms/DiaryVideoViewer.tsx
<CaptureClipOverlays
  title={item.title || "다이어리"}
  dateText={item.dateText}
  authorName={item.authorName}
  caption={item.caption || currentDetail?.caption || ""}
  rightActions={
    <FeedPillIconButton label="더보기" onClick={() => setMenuOpen(true)}>
      <DailyIcon name="ellipsis" size={20} />
    </FeedPillIconButton>
  }
/>
```

### 4. 다이어리 및 테마 리스트 하이드레이션 오류 수정

- **파일:** `components/molecules/DiaryThemeCard.tsx`, `components/molecules/DiaryDateScrollSection.tsx`
- **설명:** `<button>` 태그 내부에 `<IconButton>` (버튼)이 중첩되어 HTML 명세를 위반하고 하이드레이션 오류가 발생하는 원인을 차단하기 위해 내부 아이콘 요소를 `div` 스타일 컨테이너로 교체했습니다.

```tsx
// components/molecules/DiaryThemeCard.tsx
<div className="grid size-10 place-items-center rounded-full bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]">
  <DailyIcon name="plus" size={20} />
</div>
```

### 5. 유저 기본 프로필 닉네임 아지트 생성/진입 폼 SSR 자동채움 구현

- **파일:** `app/(agit)/agit/create/settings/page.tsx`, `app/(agit)/agit/join/[code]/profile/page.tsx`, `components/organisms/CreateRoomAccessForm.tsx`, `components/organisms/InviteJoinProfileForm.tsx`, `components/templates/RoomFlowTemplates.tsx`, `components/molecules/AuthField.tsx`, `components/molecules/CapacityStepper.tsx`, `components/molecules/ThumbnailUpload.tsx`
- **설명:** 서버 컴포넌트 페이지에서 로그인 유저 프로필(`userService.getMyProfile()`)을 미리 조회하여 `defaultNickname`을 클라이언트 폼에 전달함으로써 초기 하이드레이션 시 깜빡임 없이 닉네임이 입력창에 자동 세팅되도록 구현했습니다.

```tsx
// app/(agit)/agit/create/settings/page.tsx
export default async function CreateRoomSettingsPage() {
  let defaultNickname = "";
  try {
    const profile = await userService.getMyProfile();
    defaultNickname = profile.nickname || "";
  } catch {
    defaultNickname = "";
  }

  return <CreateRoomAccessTemplate defaultNickname={defaultNickname} />;
}
```

### 6. 토픽 목록 페이지 편집 버튼 비활성화 처리

- **파일:** `components/organisms/TopicsLayoutSection.tsx`
- **설명:** 토픽 목록에서 편집 권한이 없는 사용자의 항목인 경우에도 "편집" 뱃지가 노출되도록 하되 `disabled` 스타일로 렌더링하고 클릭 액션을 차단했습니다.

```tsx
// components/organisms/TopicsLayoutSection.tsx
{canEdit ? (
  <TextLink href={ROUTES.agit.topicEdit(agitId, topic.id)} className="!no-underline inline-flex">
    <Badge variant="brand" size="sm">편집</Badge>
  </TextLink>
) : (
  <Badge variant="neutral" size="sm" className="opacity-50 cursor-not-allowed select-none">
    편집
  </Badge>
)}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [x] CI Test workflow 통과
