### PR TITLE
Fix: Vercel SSR 리전을 서울(icn1)로 고정 (#150)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["icn1"],
   "rewrites": [
     {
       "source": "/api/((?!auth).*)",


### PR DESCRIPTION
## Summary
- Closes #150
- `vercel.json` 최상위에 `"regions": ["icn1"]`을 넣어 Next.js 서버 함수가 미국(iad1)이 아니라 서울에서 실행되도록 한다.
- 아지트 토픽 피드 SSR이 한국 게이트웨이를 호출할 때 대서양 왕복이 쌓여 TTFB가 ~32초까지 늘어나던 문제를 줄인다.

## Test plan
- [ ] Preview/Production 배포 후 `/agit/[agitId]` 요청 응답 헤더 `x-vercel-id`가 `icn1::icn1::…` 형태인지 확인
- [ ] 같은 토픽 피드 문서 요청 TTFB가 기존(~32s wait) 대비 크게 줄어드는지 HAR로 확인
- [ ] 토픽 피드·토픽 목록·로그인 등 기존 페이지가 정상 동작하는지 확인
- [ ] `/api/*` rewrite(`fo-api.plip.life`)가 그대로 동작하는지 확인