### PR TITLE
[#152] Fix : 소셜 로그인 세션 오염 및 session-tokens 검증

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -11,6 +11,7 @@ import { ApiError } from "@/lib/api/apiFetch";
 import { AUTH_ERROR_CODES, getApiErrorCode } from "@/lib/auth/auth-errors";
 import { saveSocialSignupPendingToken } from "@/lib/auth/social-signup-pending";
 import { isSocialProvider } from "@/lib/auth/social-providers";
+import { validateSessionTokens } from "@/lib/auth/validate-session-tokens";
 import type { SocialProvider } from "@/types/auth/ui";
 import * as authService from "@/services/authService";
 
@@ -149,6 +150,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         const expiresAt = Number(accessTokenExpiresAt);
         if (!userUuid || !accessToken || !refreshToken || !Number.isFinite(expiresAt)) {
+          return null;
+        }
+
+        const isValid = await validateSessionTokens(userUuid, accessToken);
+        if (!isValid) {
           return null;
         }
 

--- a/lib/api/actorHeaders.ts
+++ b/lib/api/actorHeaders.ts
@@ -1,22 +1,30 @@
 import { getDevAccessToken } from "@/lib/api/devAccessToken";
-import { getDevUserUuid } from "@/lib/api/env";
 import { getSessionAuthHeaders } from "@/lib/auth/server-token";
 
-/** RSC/API 레이어 전용. NextAuth JWT 우선, 미로그인 dev 환경 fallback. */
+/** RSC/API 레이어 전용. NextAuth JWT 우선, 명시적 dev env 설정 시에만 fallback. */
 export async function getActorUserHeaders(): Promise<Record<string, string>> {
   const sessionHeaders = await getSessionAuthHeaders();
   if (sessionHeaders.Authorization) {
     return sessionHeaders;
   }
 
-  const headers: Record<string, string> = {
-    "X-User-Uuid": getDevUserUuid(),
-  };
-
-  const devToken = await getDevAccessToken();
-  if (devToken) {
-    headers.Authorization = `Bearer ${devToken}`;
+  if (process.env.NODE_ENV === "production") {
+    return sessionHeaders;
   }
 
-  return headers;
+  const devUserUuid = process.env.DEV_USER_UUID?.trim();
+  if (!devUserUuid) {
+    return sessionHeaders;
+  }
+
+  const devToken = await getDevAccessToken();
+  if (!devToken) {
+    return sessionHeaders;
+  }
+
+  return {
+    ...sessionHeaders,
+    Authorization: `Bearer ${devToken}`,
+    "X-User-UUID": devUserUuid,
+  };
 }

--- a/lib/api/devAccessToken.ts
+++ b/lib/api/devAccessToken.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { API_ENDPOINTS } from "@/config/api-endpoints";
 import { ApiError, apiFetch } from "@/lib/api/apiFetch";
 import { getApiUrl, getDevLoginEmail, getDevLoginPassword } from "@/lib/api/env";
@@ -6,35 +7,13 @@ type LocalLoginResponse = {
   accessToken?: string;
 };
 
-let cachedAccessToken: string | undefined;
-let pendingLogin: Promise<string | undefined> | undefined;
-
-export function clearDevAccessToken(): void {
-  cachedAccessToken = undefined;
-  pendingLogin = undefined;
-}
-
-export async function getDevAccessToken(): Promise<string | undefined> {
-  if (cachedAccessToken) {
-    return cachedAccessToken;
-  }
-  if (pendingLogin) {
-    return pendingLogin;
-  }
-
+export const getDevAccessToken = cache(async (): Promise<string | undefined> => {
   const email = getDevLoginEmail();
   const password = getDevLoginPassword();
   if (!email || !password) {
     return undefined;
   }
 
-  pendingLogin = requestDevAccessToken(email, password).finally(() => {
-    pendingLogin = undefined;
-  });
-  return pendingLogin;
-}
-
-async function requestDevAccessToken(email: string, password: string): Promise<string | undefined> {
   try {
     const data = await apiFetch<LocalLoginResponse>(API_ENDPOINTS.auth.loginLocal, {
       method: "POST",
@@ -43,10 +22,8 @@ async function requestDevAccessToken(email: string, password: string): Promise<s
       auth: false,
     });
     const token = data.accessToken?.trim();
-    cachedAccessToken = token || undefined;
-    return cachedAccessToken;
+    return token || undefined;
   } catch (error) {
-    cachedAccessToken = undefined;
     if (error instanceof ApiError) {
       throw new ApiError(
         `개발용 로그인에 실패했습니다 (${error.status}): ${error.message}`,
@@ -56,4 +33,4 @@ async function requestDevAccessToken(email: string, password: string): Promise<s
     }
     throw error;
   }
-}
+});

--- a/lib/api/userApi.ts
+++ b/lib/api/userApi.ts
@@ -16,6 +16,19 @@ import type {
   ApiUserWithdrawResponse,
 } from "@/types/user/api";
 
+export async function getMyProfileWithAccessToken(
+  accessToken: string,
+): Promise<ApiUserProfileResponse> {
+  return apiFetch<ApiUserProfileResponse>(API_ENDPOINTS.users.me, {
+    method: "GET",
+    baseUrl: getApiUrl(),
+    auth: false,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}
+
 export async function getMyProfile(): Promise<ApiUserProfileResponse> {
   return withAuthRetry(async () =>
     apiFetch<ApiUserProfileResponse>(API_ENDPOINTS.users.me, {

--- a/lib/api/withAuthRetry.ts
+++ b/lib/api/withAuthRetry.ts
@@ -1,46 +1,30 @@
 import { ApiError } from "@/lib/api/apiFetch";
-import { clearDevAccessToken } from "@/lib/api/devAccessToken";
 import {
-  getRequestAuthTokenOverride,
-  withReissueSingleFlight,
+  applyRetryAuthHeaders,
+  reissueTokensOncePerRequest,
+  runWithRetryAuthScope,
 } from "@/lib/auth/request-token-cache";
-import * as authService from "@/services/authService";
 
 export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
-  const hadOverride = Boolean(getRequestAuthTokenOverride());
-
-  try {
-    return await request();
-  } catch (error) {
-    if (!(error instanceof ApiError) || error.status !== 401) {
-      throw error;
-    }
-
-    clearDevAccessToken();
-
-    if (typeof window !== "undefined") {
-      throw error;
-    }
-
-    if (hadOverride) {
-      throw error;
-    }
-
-    await withReissueSingleFlight(async () => {
-      const overrideRefresh = getRequestAuthTokenOverride()?.refreshToken;
-      const { getServerRefreshToken } = await import("@/lib/auth/server-token");
-      const refreshToken = overrideRefresh ?? (await getServerRefreshToken());
-      if (typeof refreshToken !== "string" || !refreshToken) {
+  return runWithRetryAuthScope(async () => {
+    try {
+      return await request();
+    } catch (error) {
+      if (!(error instanceof ApiError) || error.status !== 401) {
         throw error;
       }
 
-      const refreshed = await authService.reissueToken(refreshToken);
-      return {
-        accessToken: refreshed.accessToken,
-        refreshToken: refreshed.refreshToken,
-      };
-    });
+      if (typeof window !== "undefined") {
+        throw error;
+      }
 
-    return await request();
-  }
+      const refreshed = await reissueTokensOncePerRequest();
+      if (!refreshed) {
+        throw error;
+      }
+
+      applyRetryAuthHeaders(refreshed);
+      return await request();
+    }
+  });
 }

--- a/lib/auth/request-token-cache.ts
+++ b/lib/auth/request-token-cache.ts
@@ -1,37 +1,44 @@
-/** 401 reissue 후 동일 요청 체인에서 Bearer·refresh 재시도용 (세션 쿠키 갱신 전) */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { cache } from "react";
+import * as authService from "@/services/authService";
+
 export type RequestAuthTokens = {
   accessToken: string;
   refreshToken: string;
 };
 
-let requestAuthTokenOverride: RequestAuthTokens | undefined;
-let reissueInFlight: Promise<RequestAuthTokens> | undefined;
+const retryAuthHeaderStore = new AsyncLocalStorage<Record<string, string>>();
 
-export function setRequestAuthTokenOverride(tokens: RequestAuthTokens): void {
-  requestAuthTokenOverride = tokens;
+export function getRetryAuthHeaders(): Record<string, string> | undefined {
+  const store = retryAuthHeaderStore.getStore();
+  if (!store || Object.keys(store).length === 0) {
+    return undefined;
+  }
+  return store;
 }
 
-export function getRequestAuthTokenOverride(): RequestAuthTokens | undefined {
-  return requestAuthTokenOverride;
+export async function runWithRetryAuthScope<T>(fn: () => Promise<T>): Promise<T> {
+  return retryAuthHeaderStore.run({}, fn);
 }
 
-export function withReissueSingleFlight(
-  reissue: () => Promise<RequestAuthTokens>,
-): Promise<RequestAuthTokens> {
-  if (requestAuthTokenOverride) {
-    return Promise.resolve(requestAuthTokenOverride);
+export const reissueTokensOncePerRequest = cache(async (): Promise<RequestAuthTokens | null> => {
+  const { getServerRefreshToken } = await import("@/lib/auth/server-token");
+  const refreshToken = await getServerRefreshToken();
+  if (typeof refreshToken !== "string" || !refreshToken) {
+    return null;
   }
 
-  if (!reissueInFlight) {
-    reissueInFlight = reissue()
-      .then((tokens) => {
-        requestAuthTokenOverride = tokens;
-        return tokens;
-      })
-      .finally(() => {
-        reissueInFlight = undefined;
-      });
-  }
+  const refreshed = await authService.reissueToken(refreshToken);
+  return {
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken,
+  };
+});
 
-  return reissueInFlight;
+export function applyRetryAuthHeaders(tokens: RequestAuthTokens): void {
+  const store = retryAuthHeaderStore.getStore();
+  if (!store) {
+    return;
+  }
+  store.Authorization = `Bearer ${tokens.accessToken}`;
 }

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -3,7 +3,7 @@ import {
   FORWARDED_REFRESH_TOKEN_HEADER,
   FORWARDED_USER_UUID_HEADER,
 } from "@/lib/auth/forwarded-auth-headers";
-import { getRequestAuthTokenOverride } from "@/lib/auth/request-token-cache";
+import { getRetryAuthHeaders } from "@/lib/auth/request-token-cache";
 import { headers } from "next/headers";
 import { getToken } from "next-auth/jwt";
 import type { JWT } from "next-auth/jwt";
@@ -58,9 +58,10 @@ export async function getServerUserUuid(): Promise<string | undefined> {
 }
 
 export async function getServerAccessToken(): Promise<string | undefined> {
-  const override = getRequestAuthTokenOverride()?.accessToken;
-  if (override) {
-    return override;
+  const retryHeaders = getRetryAuthHeaders();
+  const retryToken = retryHeaders?.Authorization?.replace(/^Bearer\s+/i, "").trim();
+  if (retryToken) {
+    return retryToken;
   }
 
   const jwt = await getServerAuthJwtSafe();
@@ -69,22 +70,17 @@ export async function getServerAccessToken(): Promise<string | undefined> {
 }
 
 export async function getServerRefreshToken(): Promise<string | undefined> {
-  const override = getRequestAuthTokenOverride()?.refreshToken;
-  if (override) {
-    return override;
-  }
-
   const jwt = await getServerAuthJwtSafe();
   const token = jwt?.refreshToken;
   return typeof token === "string" && token.length > 0 ? token : undefined;
 }
 
 export async function getSessionAuthHeaders(): Promise<Record<string, string>> {
-  const override = getRequestAuthTokenOverride();
   const jwt = await getServerAuthJwtSafe();
+  const retryHeaders = getRetryAuthHeaders();
 
   const accessToken =
-    override?.accessToken ??
+    retryHeaders?.Authorization?.replace(/^Bearer\s+/i, "").trim() ||
     (typeof jwt?.accessToken === "string" && jwt.accessToken.length > 0
       ? jwt.accessToken
       : undefined);

--- a/lib/auth/validate-session-tokens.ts
+++ b/lib/auth/validate-session-tokens.ts
@@ -1,0 +1,13 @@
+import { getMyProfileWithAccessToken } from "@/lib/api/userApi";
+
+export async function validateSessionTokens(
+  userUuid: string,
+  accessToken: string,
+): Promise<boolean> {
+  try {
+    const profile = await getMyProfileWithAccessToken(accessToken);
+    return profile.userUuid === userUuid;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## 작업 내용

공유 Next.js 서버에서 발생 가능한 세션 bleed를 제거하고, session-tokens Credentials provider에 백엔드 토큰 검증을 추가했습니다. dev fallback 고정 UUID 사용도 명시적 env 설정 시에만 동작하도록 변경했습니다.

## 관련 이슈

Close #152

## 변경 사항

### 1. 요청 스코프 토큰 재발급 격리

- **파일:** lib/auth/request-token-cache.ts, lib/api/withAuthRetry.ts, lib/auth/server-token.ts
- **설명:** 모듈 전역 변수 대신 AsyncLocalStorage + React cache로 요청별 토큰 재발급 격리

### 2. dev fallback 제한

- **파일:** lib/api/actorHeaders.ts, lib/api/devAccessToken.ts
- **설명:** 고정 DEV_USER_UUID fallback 제거, DEV_USER_UUID + DEV_LOGIN_EMAIL/PASSWORD 명시 시에만 dev 인증 사용

### 3. session-tokens 백엔드 검증

- **파일:** auth.ts, lib/auth/validate-session-tokens.ts, lib/api/userApi.ts
- **설명:** session-tokens authorize 시 GET /users/me로 accessToken·userUuid 일치 검증

## 테스트

- [x] npm run lint (변경 파일)
- [x] npm run typecheck
- [ ] npm run build
- [ ] 로컬 수동 확인 (npm run dev)

## 머지 전 체크

- [x] PR 제목 형식: [#N] Type : 작업 내용
- [x] 커밋 메시지 형식: Type: 변경 요약
- [x] base branch: develop