### PR TITLE
[#154] Fix : 로그아웃 refresh token 동기화 및 AUTH_003 세션 종료

### DIFF
--- a/actions/authActions.ts
+++ b/actions/authActions.ts
@@ -2,7 +2,7 @@
 
 import { signOut } from "@/auth";
 import { ApiError } from "@/lib/api/apiFetch";
-import { getApiErrorCode } from "@/lib/auth/auth-errors";
+import { getApiErrorCode, AUTH_ERROR_CODES } from "@/lib/auth/auth-errors";
 import * as authService from "@/services/authService";
 import { getServerRefreshToken } from "@/lib/auth/server-token";
 import {
@@ -29,7 +29,16 @@ export async function logoutAction(): Promise<ActionResult<void>> {
   try {
     const refreshToken = await getServerRefreshToken();
     if (refreshToken) {
-      await authService.logout(refreshToken);
+      try {
+        await authService.logout(refreshToken);
+      } catch (error) {
+        const invalidRefresh =
+          error instanceof ApiError &&
+          getApiErrorCode(error.body) === AUTH_ERROR_CODES.REFRESH_TOKEN_INVALID;
+        if (!invalidRefresh) {
+          throw error;
+        }
+      }
     }
     await signOut({ redirect: false });
     return actionSuccess(undefined);

--- a/lib/api/withAuthRetry.ts
+++ b/lib/api/withAuthRetry.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "@/lib/api/apiFetch";
+import { persistSessionTokens } from "@/lib/auth/persist-session-tokens";
 import {
   applyRetryAuthHeaders,
   reissueTokensOncePerRequest,
@@ -24,6 +25,7 @@ export async function withAuthRetry<T>(request: () => Promise<T>): Promise<T> {
       }
 
       applyRetryAuthHeaders(refreshed);
+      await persistSessionTokens(refreshed);
       return await request();
     }
   });

--- a/lib/auth/auth-errors.ts
+++ b/lib/auth/auth-errors.ts
@@ -1,6 +1,7 @@
 export const AUTH_ERROR_CODES = {
   PENDING_RESTORE: "AUTH_010",
   SOCIAL_SIGNUP_REQUIRED: "SOCIAL_003",
+  REFRESH_TOKEN_INVALID: "AUTH_003",
 } as const;
 
 export function getApiErrorCode(body: unknown): string | undefined {

--- a/lib/auth/persist-session-tokens.ts
+++ b/lib/auth/persist-session-tokens.ts
@@ -1,0 +1,63 @@
+import { cookies, headers } from "next/headers";
+import { encode, getToken } from "next-auth/jwt";
+import type { JWT } from "next-auth/jwt";
+
+export type PersistableSessionTokens = {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: number;
+};
+
+function isProductionSecureCookie(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function getSessionCookieName(): string {
+  return isProductionSecureCookie() ? "__Secure-authjs.session-token" : "authjs.session-token";
+}
+
+async function readSessionJwt(): Promise<JWT | null> {
+  const secret = process.env.AUTH_SECRET?.trim();
+  if (!secret) {
+    return null;
+  }
+
+  const headerStore = await headers();
+  const cookie = headerStore.get("cookie") ?? "";
+
+  return getToken({
+    req: { headers: { cookie } },
+    secret,
+    secureCookie: isProductionSecureCookie(),
+  });
+}
+
+export async function persistSessionTokens(tokens: PersistableSessionTokens): Promise<void> {
+  const secret = process.env.AUTH_SECRET?.trim();
+  if (!secret) {
+    return;
+  }
+
+  const existing = (await readSessionJwt()) ?? {};
+  const updated: JWT = {
+    ...existing,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+  };
+
+  const sessionCookieName = getSessionCookieName();
+  const encoded = await encode({
+    token: updated,
+    secret,
+    salt: sessionCookieName,
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set(sessionCookieName, encoded, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: isProductionSecureCookie(),
+  });
+}

--- a/lib/auth/request-token-cache.ts
+++ b/lib/auth/request-token-cache.ts
@@ -5,7 +5,10 @@ import * as authService from "@/services/authService";
 export type RequestAuthTokens = {
   accessToken: string;
   refreshToken: string;
+  accessTokenExpiresAt: number;
 };
+
+const RETRY_REFRESH_TOKEN_KEY = "x-retry-refresh-token";
 
 const retryAuthHeaderStore = new AsyncLocalStorage<Record<string, string>>();
 
@@ -32,8 +35,14 @@ export const reissueTokensOncePerRequest = cache(async (): Promise<RequestAuthTo
   return {
     accessToken: refreshed.accessToken,
     refreshToken: refreshed.refreshToken,
+    accessTokenExpiresAt: refreshed.accessTokenExpiresAt,
   };
 });
+
+export function getRetryRefreshToken(): string | undefined {
+  const token = retryAuthHeaderStore.getStore()?.[RETRY_REFRESH_TOKEN_KEY];
+  return typeof token === "string" && token.length > 0 ? token : undefined;
+}
 
 export function applyRetryAuthHeaders(tokens: RequestAuthTokens): void {
   const store = retryAuthHeaderStore.getStore();
@@ -41,4 +50,5 @@ export function applyRetryAuthHeaders(tokens: RequestAuthTokens): void {
     return;
   }
   store.Authorization = `Bearer ${tokens.accessToken}`;
+  store[RETRY_REFRESH_TOKEN_KEY] = tokens.refreshToken;
 }

--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -3,7 +3,7 @@ import {
   FORWARDED_REFRESH_TOKEN_HEADER,
   FORWARDED_USER_UUID_HEADER,
 } from "@/lib/auth/forwarded-auth-headers";
-import { getRetryAuthHeaders } from "@/lib/auth/request-token-cache";
+import { getRetryAuthHeaders, getRetryRefreshToken } from "@/lib/auth/request-token-cache";
 import { headers } from "next/headers";
 import { getToken } from "next-auth/jwt";
 import type { JWT } from "next-auth/jwt";
@@ -70,6 +70,11 @@ export async function getServerAccessToken(): Promise<string | undefined> {
 }
 
 export async function getServerRefreshToken(): Promise<string | undefined> {
+  const retryRefreshToken = getRetryRefreshToken();
+  if (retryRefreshToken) {
+    return retryRefreshToken;
+  }
+
   const jwt = await getServerAuthJwtSafe();
   const token = jwt?.refreshToken;
   return typeof token === "string" && token.length > 0 ? token : undefined;


### PR DESCRIPTION
## 작업 내용

401 재발급(RTR) 후 NextAuth 세션 쿠키에 새 refresh token이 반영되지 않아 로그아웃 시 AUTH_003이 발생하고 세션이 남는 문제를 수정했습니다. 재발급 시 세션 쿠키를 동기화하고, refresh token이 이미 무효인 경우에도 클라이언트 세션을 종료합니다.

## 관련 이슈

Close #154

## 변경 사항

### 1. 재발급 후 세션 쿠키 동기화

- **파일:** `lib/auth/persist-session-tokens.ts`, `lib/api/withAuthRetry.ts`
- **설명:** RTR 성공 시 access/refresh token을 NextAuth JWT 쿠키에 encode하여 저장

```typescript
// lib/api/withAuthRetry.ts
applyRetryAuthHeaders(refreshed);
await persistSessionTokens(refreshed);
return await request();
```

### 2. 요청 스코프 refresh token 추적

- **파일:** `lib/auth/request-token-cache.ts`, `lib/auth/server-token.ts`
- **설명:** ALS에 재발급된 refresh token 저장, `getServerRefreshToken`이 우선 사용

### 3. AUTH_003 시에도 signOut

- **파일:** `actions/authActions.ts`, `lib/auth/auth-errors.ts`
- **설명:** 로그아웃 API가 refresh token invalid를 반환해도 세션 쿠키는 제거

## 테스트

- [x] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Fix : 작업 내용`
- [x] 커밋 메시지 형식: `Fix: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
