### PR TITLE
[#156] Feature : 아지트 가입·업로드 UX 및 시각/헤더 수정

### DIFF
--- a/components/atoms/DailyIcon.tsx
+++ b/components/atoms/DailyIcon.tsx
@@ -1,5 +1,6 @@
 const ICON_SRC = {
   users: "/plip/daily-loop/icon-users.svg",
+  crownBrand: "/plip/daily-loop/icon-crown-brand.svg",
   video: "/plip/daily-loop/icon-video.svg",
   plus: "/plip/daily-loop/icon-plus.svg",
   minus: "/plip/daily-loop/icon-minus.svg",

--- a/components/molecules/CaptureClipOverlays.tsx
+++ b/components/molecules/CaptureClipOverlays.tsx
@@ -1,20 +1,13 @@
 import { formatOverlayClock } from "@/lib/video/formatOverlayClock";
-import { OVERLAY_CAPTION_GAP_PX, OVERLAY_CAPTION_PX } from "@/lib/video/constants";
 
 type CaptureClipOverlaysProps = {
   capturedAt: Date | null;
   caption: string;
-  /** 1 = fullscreen/capture size. Preview passes frameHeight / viewportHeight. */
-  scale?: number;
 };
 
-export function CaptureClipOverlays({ capturedAt, caption, scale = 1 }: CaptureClipOverlaysProps) {
+export function CaptureClipOverlays({ capturedAt, caption }: CaptureClipOverlaysProps) {
   const overlayTime = capturedAt ? formatOverlayClock(capturedAt) : "";
   const trimmedCaption = caption.trim();
-  const safeScale = scale > 0 ? scale : 1;
-  const captionSize = OVERLAY_CAPTION_PX * safeScale;
-  const gap = OVERLAY_CAPTION_GAP_PX * safeScale;
-  const inset = 24 * safeScale;
 
   if (!overlayTime && !trimmedCaption) {
     return null;
@@ -22,33 +15,21 @@ export function CaptureClipOverlays({ capturedAt, caption, scale = 1 }: CaptureC
 
   return (
     <div className="pointer-events-none absolute inset-0 z-[1] [container-type:size]">
-      <div
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center"
-        style={{ width: `min(100% - ${inset * 2}px, ${352 * safeScale}px)` }}
-      >
-        {trimmedCaption ? (
-          <>
-            {overlayTime ? (
-              <p
-                className="absolute inset-x-0 m-0 font-black leading-none text-white [text-shadow:0_1px_4px_rgba(0,0,0,0.55)] whitespace-nowrap"
-                style={{ bottom: `calc(100% + ${gap}px)`, fontSize: "clamp(32px, 15cqmin, 72px)" }}
-              >
-                {overlayTime}
-              </p>
-            ) : null}
-            <p
-              className="absolute left-1/2 top-full -translate-x-1/2 mt-1 m-0 font-light text-white/80 opacity-80 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)] whitespace-nowrap pointer-events-none"
-              style={{ fontSize: Math.min(captionSize, 13), lineHeight: 1.2 }}
-            >
-              {trimmedCaption}
-            </p>
-          </>
-        ) : overlayTime ? (
-          <p
-            className="m-0 font-black leading-none text-white [text-shadow:0_1px_4px_rgba(0,0,0,0.55)] whitespace-nowrap"
-            style={{ fontSize: "clamp(32px, 15cqmin, 72px)" }}
-          >
+      <div className="absolute left-1/2 top-1/2 w-[min(88cqw,100%)] -translate-x-1/2 -translate-y-1/2 text-center">
+        {overlayTime ? (
+          <p className="relative z-[1] m-0 font-black leading-none text-white [font-size:clamp(1.15rem,15cqmin,4.5rem)] [text-shadow:0_1px_4px_rgba(0,0,0,0.55)] whitespace-nowrap">
             {overlayTime}
+          </p>
+        ) : null}
+        {trimmedCaption ? (
+          <p
+            className={
+              overlayTime
+                ? "absolute left-1/2 top-full m-0 mt-[0.35em] w-full -translate-x-1/2 font-light text-white/80 [font-size:clamp(0.65rem,4.2cqmin,0.95rem)] leading-tight [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]"
+                : "m-0 font-light text-white/80 [font-size:clamp(0.65rem,4.2cqmin,0.95rem)] leading-tight [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]"
+            }
+          >
+            {trimmedCaption}
           </p>
         ) : null}
       </div>

--- a/components/molecules/PageContainer.tsx
+++ b/components/molecules/PageContainer.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
-import type { ElementType, ReactNode } from "react";
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
+import { forwardRef } from "react";
 
 type PageContainerProps = {
   children: ReactNode;
@@ -7,31 +8,39 @@ type PageContainerProps = {
   className?: string;
   gap?: "default" | "tight" | "none";
   "aria-label"?: string;
-};
+} & Omit<HTMLAttributes<HTMLElement>, "children">;
 
 /**
  * 아지트/다이어리 등 표준 앱 화면의 단일 진실 공급원(Single Source of Truth) 레이아웃 컨테이너
  * - 기본 표준 여백: p-[12px_24px_24px] (좌우 24px, 상단 12px, 하단 24px)
  * - 기본 요소 간격: gap-[14px]
  */
-export function PageContainer({
-  children,
-  as: Component = "section",
-  className,
-  gap = "default",
-  "aria-label": ariaLabel,
-}: PageContainerProps) {
-  return (
-    <Component
-      aria-label={ariaLabel}
-      className={cn(
-        "flex min-h-0 flex-1 flex-col overflow-y-auto p-[12px_24px_24px]",
-        gap === "default" && "gap-[14px]",
-        gap === "tight" && "gap-[8px]",
-        className
-      )}
-    >
-      {children}
-    </Component>
-  );
-}
+export const PageContainer = forwardRef<HTMLElement, PageContainerProps>(
+  function PageContainer(
+    {
+      children,
+      as: Component = "section",
+      className,
+      gap = "default",
+      "aria-label": ariaLabel,
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <Component
+        ref={ref}
+        aria-label={ariaLabel}
+        className={cn(
+          "flex min-h-0 flex-1 flex-col overflow-y-auto p-[12px_24px_24px]",
+          gap === "default" && "gap-[14px]",
+          gap === "tight" && "gap-[8px]",
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);

--- a/components/molecules/TopicChip.tsx
+++ b/components/molecules/TopicChip.tsx
@@ -1,6 +1,7 @@
 type TopicChipProps = {
   children: string;
   selected?: boolean;
+  disabled?: boolean;
   /** destination toggle — selected chip uses solid brand purple */
   tone?: "default" | "brand";
   onClick?: () => void;
@@ -9,20 +10,29 @@ type TopicChipProps = {
 export function TopicChip({
   children,
   selected = false,
+  disabled = false,
   tone = "default",
   onClick,
 }: TopicChipProps) {
   const base =
     "inline-flex min-h-[29px] items-center rounded-[16px] border-0 p-[7px_12px] text-xs font-medium leading-[15px]";
 
-  const className = selected
-    ? tone === "brand"
-      ? `${base} bg-[var(--dl-color-bg-brand)] text-[var(--dl-color-text-inverse)]`
-      : `${base} bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)] m-dlTopicChipActive`
-    : `${base} bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-secondary)]`;
+  const className = disabled
+    ? `${base} cursor-not-allowed bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-tertiary)] opacity-50`
+    : selected
+      ? tone === "brand"
+        ? `${base} bg-[var(--dl-color-bg-brand)] text-[var(--dl-color-text-inverse)]`
+        : `${base} bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)] m-dlTopicChipActive`
+      : `${base} bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-secondary)]`;
 
   return (
-    <button type="button" className={className} aria-pressed={selected} onClick={onClick}>
+    <button
+      type="button"
+      className={className}
+      aria-pressed={selected}
+      disabled={disabled}
+      onClick={onClick}
+    >
       {children}
     </button>
   );

--- a/components/molecules/TopicVideoTile.tsx
+++ b/components/molecules/TopicVideoTile.tsx
@@ -48,7 +48,6 @@ export function TopicVideoTile({
       <CaptureClipOverlays
         capturedAt={parseUploadedAtToDate(video.uploadedAt)}
         caption={video.caption}
-        scale={1}
       />
       <div className="pointer-events-none absolute inset-0 z-10 flex flex-col justify-end p-6">
         <UserProfileBadge

--- a/components/organisms/AgitLandingDetail.tsx
+++ b/components/organisms/AgitLandingDetail.tsx
@@ -1,5 +1,5 @@
 import { DailyIcon, TextLink } from "@/components/atoms";
-import { RoomInfoRow } from "@/components/molecules";
+import { ui } from "@/components/atoms/styles";
 import { ROUTES } from "@/config/routes";
 import type { UiAgit } from "@/types/agit/ui";
 import Image from "next/image";
@@ -27,53 +27,58 @@ function isUsableImageSrc(src?: string): boolean {
 
 export function AgitLandingDetail({ agit, joinHref }: AgitLandingDetailProps) {
   const maxMembers = agit.maxMembers ?? agit.memberCount;
-  const remaining = Math.max(0, maxMembers - agit.memberCount);
   const participateHref = joinHref ?? ROUTES.agit.profile(agit.id);
   const thumbnailSrc = isUsableImageSrc(agit.thumbnailSrc) ? agit.thumbnailSrc : undefined;
 
   return (
     <section className="flex w-full flex-col gap-3.5">
-      <div
-        className="relative w-full h-[190px] overflow-hidden rounded-[18px] [&_img]:w-full [&_img]:h-full [&_img]:object-cover"
-        style={thumbnailSrc ? undefined : { background: agit.coverGradient }}
-      >
-        {thumbnailSrc ? (
-          <Image src={thumbnailSrc} alt="" fill className="object-cover" sizes="350px" />
-        ) : null}
-        <DailyIcon name="video" size={32} className="absolute top-[50%] left-[50%] w-[32px] h-[32px] [transform:translate(-50%,_-50%)]" />
-      </div>
-
-      {agit.category ? (
-        <div className="flex flex-wrap gap-[8px] items-center">
-          <span className="inline-flex items-center border border-[var(--dl-color-border-default)] rounded-[18px] bg-[var(--dl-color-bg-surface)] p-[8px_14px] text-[13px] font-medium leading-[19px] text-[var(--dl-color-text-secondary)] border-[var(--dl-color-border-brand)] bg-[var(--dl-color-bg-brand)] text-[#fff] m-dlPillBrand">
-            {agit.category}
-          </span>
+      <div className="w-full overflow-hidden rounded-[18px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] shadow-[0_8px_24px_rgba(23,_23,_28,_0.04)]">
+        <div
+          className="relative h-[190px] w-full overflow-hidden [&_img]:h-full [&_img]:w-full [&_img]:object-cover"
+          style={thumbnailSrc ? undefined : { background: agit.coverGradient }}
+        >
+          {thumbnailSrc ? (
+            <Image src={thumbnailSrc} alt="" fill className="object-cover" sizes="350px" />
+          ) : null}
         </div>
-      ) : null}
 
-      <h2 className="m-0 text-[28px] font-bold leading-[34px] text-[var(--dl-color-text-primary)]">{agit.name}</h2>
-      <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)]">{agit.description}</p>
+        <div className="flex flex-col gap-3.5 p-4">
+          {agit.category ? (
+            <span className="inline-flex w-fit items-center rounded-[18px] border-0 bg-[var(--dl-color-bg-brand)] p-[8px_14px] text-[13px] font-medium leading-[19px] text-[#fff]">
+              {agit.category}
+            </span>
+          ) : null}
 
-      <div className="w-full rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-elevated)] p-[16px_14px] flex flex-col gap-[10px] m-dlPanelStack">
-        <RoomInfoRow
-          icon="users"
-          title={`${agit.memberCount} / ${maxMembers}명`}
-          description={remaining > 0 ? `현재 ${remaining}자리 남음` : "정원이 가득 찼어요"}
-        />
-        <RoomInfoRow
-          icon="video"
-          title={`오늘 영상 ${agit.todayVideoCount ?? 0}개`}
-          description={`토픽: ${agit.topicSummary ?? "자유"}`}
-        />
+          <h2 className={`${ui.title} font-[family-name:var(--font-title)]`}>{agit.name}</h2>
+          {agit.description ? (
+            <p className={ui.subtitle}>{agit.description}</p>
+          ) : null}
+
+          <div className="flex flex-col gap-2.5">
+            <div className="flex items-center gap-2.5">
+              <DailyIcon name="users" size={20} />
+              <span className="text-sm font-medium leading-5 text-[var(--dl-color-text-primary)]">
+                {agit.memberCount}/{maxMembers}
+              </span>
+            </div>
+            <div className="flex items-center gap-2.5">
+              <DailyIcon name="crownBrand" size={20} />
+              <span className="min-w-0 truncate text-sm font-medium leading-5 text-[var(--dl-color-text-primary)]">
+                {agit.ownerName ?? "방장"}
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
 
-      <p className="m-0 text-sm font-normal leading-5 text-[var(--dl-color-text-secondary)] text-[12px] leading-[17px]">
-        방장은 {agit.ownerName ?? "방장"}입니다.
-      </p>
-
-      <div className="flex w-full flex-col gap-[14px] mt-auto">
-        <TextLink href={participateHref} className="inline-flex h-[44px] w-full items-center justify-center gap-[8px] rounded-[var(--dl-radius-md)] p-[12px_20px] text-sm font-medium leading-5 !no-underline border-0 bg-[var(--dl-color-bg-brand-subtle)] border-0 bg-[var(--dl-color-bg-brand)] !text-[var(--dl-color-text-inverse)] shadow-[none] [backdrop-filter:none] m-dlBtnPrimary no-underline">
-          이 아지트에 참여하기
+      <div className="mt-auto flex w-full flex-col gap-[14px] pt-2">
+        <TextLink
+          href={participateHref}
+          className="group relative inline-flex h-14 w-full items-center justify-center overflow-visible rounded-full bg-[linear-gradient(145deg,var(--dl-color-bg-brand),#3b82f6)] text-[17px] font-bold !text-white !no-underline ring-4 ring-white/20 shadow-[0_8px_24px_rgba(79,70,229,0.45)] transition-all duration-200 hover:scale-[1.03] hover:ring-white/40 hover:shadow-[0_12px_32px_rgba(79,70,229,0.6)] active:scale-95"
+        >
+          <span className="font-[family-name:var(--font-title)] drop-shadow-[0_2px_4px_rgba(0,0,0,0.3)]">
+            입장
+          </span>
         </TextLink>
       </div>
     </section>

--- a/components/organisms/AgitVideoViewer.tsx
+++ b/components/organisms/AgitVideoViewer.tsx
@@ -53,7 +53,6 @@ export function AgitVideoViewer({
             <CaptureClipOverlays
               capturedAt={parseUploadedAtToDate(item.uploadedAt)}
               caption={item.caption || currentDetail?.caption || ""}
-              scale={1}
             />
 
             {/* 우측 이모지 리액션 바 */}

--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -19,8 +19,6 @@ import { usePreviewFrameMetrics } from "@/hooks/usePreviewFrameMetrics";
 import { useVideoCaptureFlow } from "@/hooks/useVideoCaptureFlow";
 import { extractActionError } from "@/lib/video/actionPayload";
 import { VIDEO_DESTINATION_NOT_WIRED } from "@/lib/video/actionErrors";
-import { OVERLAY_DURATION_PX } from "@/lib/video/constants";
-import { formatRecordCountdown } from "@/lib/video/formatRecordTimer";
 import { playShutterSound } from "@/lib/video/playShutterSound";
 import { shouldMirrorVideo } from "@/lib/video/shouldMirrorVideo";
 import { toKstDateString } from "@/lib/topic/selectAgitTopic";
@@ -44,6 +42,18 @@ function pickId<T extends { id: string }>(items: T[], preferred: string): string
     return preferred;
   }
   return items[0]?.id ?? "";
+}
+
+function isTopicSelectable(topic: UiTopicListItem): boolean {
+  return topic.uploadedByMe !== true;
+}
+
+function pickTopicId(topics: UiTopicListItem[], preferred: string): string {
+  const selectable = topics.filter(isTopicSelectable);
+  if (preferred && selectable.some((topic) => topic.id === preferred)) {
+    return preferred;
+  }
+  return selectable[0]?.id ?? "";
 }
 
 export function CaptureFlowSection({
@@ -97,8 +107,6 @@ export function CaptureFlowSection({
   const containPreview = showConfirm && !originalView;
   const mirrorVideo = shouldMirrorVideo(facingMode, status, pixelsMirrored);
   const frameMetrics = usePreviewFrameMetrics(containPreview, sectionRef, slotRef);
-  const overlayScale = containPreview && frameMetrics.scale > 0 ? frameMetrics.scale : 1;
-
   const loadTopics = useCallback(async (agitUuid: string, preferredTopicId = "") => {
     if (!agitUuid) {
       setTopics([]);
@@ -114,7 +122,7 @@ export function CaptureFlowSection({
     }
 
     setTopics(result.data);
-    setSelectedTopicUuid(pickId(result.data, preferredTopicId));
+    setSelectedTopicUuid(pickTopicId(result.data, preferredTopicId));
   }, []);
 
   const loadDestinations = useCallback(async () => {
@@ -366,19 +374,7 @@ export function CaptureFlowSection({
           }}
         />
         {showConfirm ? (
-          <>
-            <CaptureClipOverlays capturedAt={capturedAt} caption={caption} scale={overlayScale} />
-            <span
-              className="absolute z-[1] font-semibold text-white"
-              style={{
-                right: 16 * overlayScale,
-                bottom: 16 * overlayScale,
-                fontSize: OVERLAY_DURATION_PX * overlayScale,
-              }}
-            >
-              {formatRecordCountdown(0, maxDurationMs)}
-            </span>
-          </>
+          <CaptureClipOverlays capturedAt={capturedAt} caption={caption} />
         ) : null}
       </div>
     </div>

--- a/components/organisms/CapturePreviewStage.tsx
+++ b/components/organisms/CapturePreviewStage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { DailyIcon, Input, Label, SubmitButton } from "@/components/atoms";
+import { Input, Label, SubmitButton } from "@/components/atoms";
 import { ui } from "@/components/atoms/styles";
-import { HeaderBackButton, ScreenHeader } from "@/components/molecules";
+import { HeaderBackButton, PageContainer, ScreenHeader } from "@/components/molecules";
 import { CAPTION_MAX_LENGTH } from "@/lib/video/constants";
 
 type CapturePreviewStageProps = {
@@ -28,27 +28,29 @@ export function CapturePreviewStage({
 }: CapturePreviewStageProps) {
   if (originalView) {
     return (
-      <button
-        type="button"
-        className="absolute top-3 left-[15px] z-40 grid h-11 w-11 place-items-center rounded-full border-0 bg-[var(--dl-color-bg-surface)]"
-        aria-label="원본 크기 닫기"
-        onClick={onCloseOriginal}
-      >
-        <DailyIcon name="x" size={20} />
-      </button>
+      <div className="absolute inset-x-0 top-0 z-40">
+        <ScreenHeader
+          tone="overlay"
+          leading={<HeaderBackButton onClick={onCloseOriginal} label="원본 크기 닫기" />}
+        />
+      </div>
     );
   }
 
   return (
     <>
-      <div className="order-1 shrink-0 px-[23px] pt-3">
+      <div className="order-1 shrink-0">
         <ScreenHeader
-          tone="plain"
           leading={<HeaderBackButton onClick={onBack} label="다시 촬영" />}
           title="영상 확인"
         />
       </div>
-      <div className="order-3 flex shrink-0 flex-col gap-3 px-[23px] pt-3 pb-8">
+      <PageContainer
+        as="div"
+        gap="tight"
+        aria-label="영상 확인"
+        className="order-3 flex-none overflow-visible"
+      >
         <div className={ui.field}>
           <Label htmlFor="capture-caption" className={ui.fieldLabel}>
             캡션
@@ -71,7 +73,7 @@ export function CapturePreviewStage({
             업로드 설정
           </SubmitButton>
         </div>
-      </div>
+      </PageContainer>
     </>
   );
 }

--- a/components/organisms/CaptureUploadSettingsStage.tsx
+++ b/components/organisms/CaptureUploadSettingsStage.tsx
@@ -4,7 +4,7 @@ import { SubmitButton } from "@/components/atoms";
 import { CaptureDestinationEmptyPanel } from "@/components/molecules/CaptureDestinationEmptyPanel";
 import { CaptureInlineCreateField } from "@/components/molecules/CaptureInlineCreateField";
 import { DestinationToggle, type DestinationId } from "@/components/molecules/DestinationToggle";
-import { HeaderBackButton, ScreenHeader } from "@/components/molecules";
+import { HeaderBackButton, PageContainer, ScreenHeader } from "@/components/molecules";
 import { TopicChip } from "@/components/molecules/TopicChip";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiDiaryTheme } from "@/types/diary/ui";
@@ -74,17 +74,17 @@ export function CaptureUploadSettingsStage({
   const isPublishRetry = Boolean(pendingPublishVideoUuid);
 
   return (
-    <section
-      className="flex h-full min-h-0 flex-col gap-[14px] overflow-y-auto bg-[var(--dl-color-bg-elevated)] px-[23px] pt-3 pb-8 text-[var(--dl-color-text-primary)]"
+    <div
+      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)]"
       aria-label="업로드 설정"
       aria-busy={destinationsLoading || uploading || creatingInline}
     >
       <ScreenHeader
-        tone="plain"
         leading={<HeaderBackButton onClick={onBack} />}
         title="업로드 설정"
       />
 
+      <PageContainer aria-label="업로드 설정" className="flex-1">
       {isPublishRetry ? (
         <div className="rounded-[16px] bg-[var(--dl-color-bg-brand-subtle)] px-4 py-3.5">
           <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-brand)]">
@@ -154,15 +154,23 @@ export function CaptureUploadSettingsStage({
             ) : (
               <div className="flex flex-col gap-3">
                 <div className="flex flex-wrap gap-2">
-                  {topics.map((topic) => (
+                  {topics.map((topic) => {
+                    const uploadedToday = topic.uploadedByMe === true;
+                    return (
                     <TopicChip
                       key={topic.id}
                       selected={selectedTopicUuid === topic.id}
-                      onClick={() => onTopicChange(topic.id)}
+                      disabled={uploadedToday}
+                      onClick={() => {
+                        if (!uploadedToday) {
+                          onTopicChange(topic.id);
+                        }
+                      }}
                     >
-                      {topic.title || "제목 없음"}
+                      {uploadedToday ? `${topic.title || "제목 없음"} · 오늘 완료` : topic.title || "제목 없음"}
                     </TopicChip>
-                  ))}
+                    );
+                  })}
                 </div>
                 <CaptureInlineCreateField
                   key={`topic-create-${topics.length}`}
@@ -238,6 +246,7 @@ export function CaptureUploadSettingsStage({
       <p className="m-0 text-center text-[11px] text-[var(--dl-color-text-tertiary)]">
         내 영상은 업로드 후 언제든 다운로드할 수 있어요.
       </p>
-    </section>
+      </PageContainer>
+    </div>
   );
 }

--- a/components/organisms/ChatMessageFullSection.tsx
+++ b/components/organisms/ChatMessageFullSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { UserAvatar } from "@/components/atoms";
 import { PageContainer, ScreenHeader } from "@/components/molecules";
-import { UserAvatar } from "@/components/atoms/UserAvatar";
 import { ROUTES } from "@/config/routes";
 import { readCachedChatMessage } from "@/lib/chat/messageCache";
 import { useRouter } from "next/navigation";
@@ -35,13 +35,14 @@ export function ChatMessageFullSection({ agitId, messageId }: ChatMessageFullSec
   }
 
   return (
-    <PageContainer aria-label="메시지 전체보기">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
         backHref={ROUTES.agit.chat(agitId)}
-        title="메시지"
+        title="전체보기"
       />
 
-      <article className="mt-6 flex flex-col gap-3">
+      <PageContainer aria-label="메시지 전체보기" className="flex-1">
+      <article className="flex flex-col gap-3">
         <div className="flex items-center gap-3">
           {!message.isMine && message.profileImageSrc ? (
             <UserAvatar src={message.profileImageSrc} size={40} className="border-0 bg-[var(--dl-color-bg-surface)]" />
@@ -64,6 +65,7 @@ export function ChatMessageFullSection({ agitId, messageId }: ChatMessageFullSec
           {message.content}
         </p>
       </article>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 }

--- a/components/organisms/DiaryVideoViewer.tsx
+++ b/components/organisms/DiaryVideoViewer.tsx
@@ -52,7 +52,6 @@ export function DiaryVideoViewer({
             <CaptureClipOverlays
               capturedAt={parseUploadedAtToDate(item.uploadedAt)}
               caption={item.caption || currentDetail?.caption || ""}
-              scale={1}
             />
 
             {/* 하단 우측: 날짜 */}

--- a/components/organisms/InviteJoinProfileForm.tsx
+++ b/components/organisms/InviteJoinProfileForm.tsx
@@ -53,7 +53,7 @@ export function InviteJoinProfileForm({
       return;
     }
 
-    router.push(ROUTES.agit.joined(result.data.agitUuid));
+    router.push(ROUTES.agit.detail(result.data.agitUuid));
     router.refresh();
   }
 

--- a/components/organisms/RoomChatSection.tsx
+++ b/components/organisms/RoomChatSection.tsx
@@ -4,9 +4,10 @@ import { getChatHistoryAction, markChatReadAction } from "@/actions/chatActions"
 import {
   ChatComposer,
   ChatRoomMessage,
+  NotificationIconToggle,
+  PageContainer,
   ScreenHeader,
 } from "@/components/molecules";
-import { NotificationIconToggle } from "@/components/molecules/NotificationIconToggle";
 import { ROUTES } from "@/config/routes";
 import { useAgitChatSocket } from "@/hooks/useAgitChatSocket";
 import { createLocalTalkMessage } from "@/lib/chat/createLocalMessage";
@@ -37,7 +38,7 @@ function mergeMessages(existing: UiChatMessage[], incoming: UiChatMessage[]): Ui
   return mergeChatMessages(existing, incoming);
 }
 
-function scrollToBottom(container: HTMLDivElement | null) {
+function scrollToBottom(container: HTMLElement | null) {
   if (!container) {
     return;
   }
@@ -57,7 +58,7 @@ export function RoomChatSection({
   const [nextCursor, setNextCursor] = useState(initialHistory.nextCursor);
   const [hasNext, setHasNext] = useState(initialHistory.hasNext);
   const [loadingOlder, setLoadingOlder] = useState(false);
-  const listRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLElement>(null);
   const shouldStickToBottomRef = useRef(true);
   const messagesRef = useRef(messages);
   const nextCursorRef = useRef(nextCursor);
@@ -276,26 +277,23 @@ export function RoomChatSection({
   }, [agit.id, currentUserUuid, draft, enableRemoteChat, sendRemoteMessage]);
 
   return (
-    <section
-      className="flex h-full min-h-0 flex-col overflow-hidden p-[12px_24px_16px]"
-      aria-label="아지트 채팅"
-    >
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
-        className="shrink-0"
         backHref={ROUTES.agit.detail(agit.id)}
         title={agit.name}
-        subtitle="채팅"
         trailing={
           <NotificationIconToggle checked={notify} label="채팅 알림" onChange={setNotify} />
         }
       />
 
-      <div
+      <PageContainer
         ref={listRef}
-        className="mt-[8px] min-h-0 flex-1 overflow-y-auto"
+        as="div"
+        gap="none"
+        aria-label="아지트 채팅"
+        className="flex-1 pb-[12px]"
         onScroll={handleScroll}
       >
-        <div className="flex flex-col">
         {loadingOlder ? (
           <p className="m-0 text-center text-xs text-[var(--dl-color-text-tertiary)]">
             이전 메시지 불러오는 중
@@ -325,12 +323,11 @@ export function RoomChatSection({
             </div>
           ))
         )}
-        </div>
-      </div>
+      </PageContainer>
 
-      <div className="shrink-0 pt-[8px]">
+      <PageContainer as="div" gap="none" className="flex-none overflow-hidden pb-[12px]">
         <ChatComposer value={draft} onChange={setDraft} onSubmit={handleSend} />
-      </div>
-    </section>
+      </PageContainer>
+    </div>
   );
 }

--- a/components/templates/RoomFlowTemplates.tsx
+++ b/components/templates/RoomFlowTemplates.tsx
@@ -143,7 +143,6 @@ export function InviteJoinLandingTemplate({
 
   return (
     <DailyLoopAuthTemplate>
-      <p className="m-0 text-xs font-semibold leading-[17px] text-[var(--dl-color-text-brand)]">INVITE · LANDING</p>
       <AuthTopBar title="아지트 정보" backHref={ROUTES.agit.root} />
       <AgitLandingDetail agit={agit} joinHref={ROUTES.agit.joinProfile(agit.inviteCode ?? agit.id)} />
     </DailyLoopAuthTemplate>

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -146,14 +146,14 @@ export function TopicCreateTemplate({ agit }: { agit: UiAgit | null }) {
   if (!agit) return <RoomMissing />;
 
   return (
-    <AgitFlowChrome>
-      <AuthTopBar
-        title="토픽 만들기"
-        backHref={ROUTES.agit.topics(agit.id)}
-      // step="토픽 이름과 진행 날짜를 정합니다"
-      />
-      <TopicCreateForm agitId={agit.id} />
-    </AgitFlowChrome>
+    <AppChromeTemplate activeTab="agit" variant="light">
+      <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+        <ScreenHeader backHref={ROUTES.agit.topics(agit.id)} title="토픽 만들기" />
+        <PageContainer aria-label="토픽 만들기">
+          <TopicCreateForm agitId={agit.id} />
+        </PageContainer>
+      </div>
+    </AppChromeTemplate>
   );
 }
 

--- a/lib/video/constants.ts
+++ b/lib/video/constants.ts
@@ -31,12 +31,6 @@ export const DEFAULT_CAPTURE_CAPTION = "";
 
 export const CAPTION_MAX_LENGTH = 80;
 
-/** Overlay sizes at capture/fullscreen scale. Preview shrinks these by frame/viewport. */
-export const OVERLAY_TIME_PX = 32;
-export const OVERLAY_CAPTION_PX = 20;
-export const OVERLAY_CAPTION_GAP_PX = 8;
-export const OVERLAY_DURATION_PX = 13;
-
 /** Drop sample.mp3 at public/plip/video/sample.mp3. Missing file falls back to a click. */
 export const SHUTTER_SOUND_SRC = "/plip/video/sample.mp3";
 

--- a/lib/video/formatOverlayClock.ts
+++ b/lib/video/formatOverlayClock.ts
@@ -1,24 +1,37 @@
+const KST = "Asia/Seoul";
+
+function formatKstClock(date: Date): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: KST,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+function formatKstDotDate(date: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: KST,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+    .format(date)
+    .replaceAll("-", ".");
+}
+
 export function formatOverlayClock(date: Date = new Date()): string {
-  const hours = date.getHours().toString().padStart(2, "0");
-  const minutes = date.getMinutes().toString().padStart(2, "0");
-  return `${hours}:${minutes}`;
+  return formatKstClock(date);
 }
 
 export function extractDate(uploadedAt?: string): string {
   if (!uploadedAt) {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = (now.getMonth() + 1).toString().padStart(2, "0");
-    const d = now.getDate().toString().padStart(2, "0");
-    return `${y}.${m}.${d}`;
+    return formatKstDotDate(new Date());
   }
 
-  const parsedDate = new Date(uploadedAt);
+  const parsedDate = parseUploadedAtToDate(uploadedAt);
   if (!Number.isNaN(parsedDate.getTime())) {
-    const y = parsedDate.getFullYear();
-    const m = (parsedDate.getMonth() + 1).toString().padStart(2, "0");
-    const d = parsedDate.getDate().toString().padStart(2, "0");
-    return `${y}.${m}.${d}`;
+    return formatKstDotDate(parsedDate);
   }
 
   const trimmed = uploadedAt.trim();
@@ -36,25 +49,15 @@ export function extractDate(uploadedAt?: string): string {
 }
 
 export function extractTime(uploadedAt?: string): string {
-  if (!uploadedAt) return "14:30";
-  const trimmed = uploadedAt.trim();
-
-  const spaceSplit = trimmed.split(/\s+/);
-  if (spaceSplit.length >= 2 && spaceSplit[1]) {
-    return spaceSplit[1].slice(0, 5);
-  }
-
-  if (trimmed.includes("T")) {
-    const timePart = trimmed.split("T")[1];
-    return timePart ? timePart.slice(0, 5) : "14:30";
-  }
-
-  return "14:30";
+  if (!uploadedAt) return formatKstClock(new Date());
+  return formatKstClock(parseUploadedAtToDate(uploadedAt));
 }
 
 export function parseUploadedAtToDate(uploadedAt?: string): Date {
   if (!uploadedAt) return new Date();
-  const parsed = new Date(uploadedAt);
+  const trimmed = uploadedAt.trim();
+  const naiveIso = /^\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(trimmed);
+  const parsed = new Date(naiveIso ? `${trimmed.replace(" ", "T")}Z` : trimmed);
   if (!Number.isNaN(parsed.getTime())) {
     return parsed;
   }

--- a/public/plip/daily-loop/icon-crown-brand.svg
+++ b/public/plip/daily-loop/icon-crown-brand.svg
@@ -1,0 +1,4 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 17L5 8L9.5 12L12 6L14.5 12L19 8L21 17H3Z" stroke="#6C4BF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M5 17H19V19H5V17Z" stroke="#6C4BF4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## 작업 내용

아지트 영상 시각을 KST로 맞추고, 촬영 확인 오버레이·당일 토픽 중복 업로드를 정리했다. 채팅/전체보기/토픽 만들기 헤더를 표준 레이아웃에 맞추고, 가입 완료 후 해당 방으로 바로 이동하며 아지트 정보 카드를 기존 카드 스타일로 맞춘다.

## 관련 이슈

Close #156

## 변경 사항

### 1. 영상 오버레이 시각 KST

- **파일:** `lib/video/formatOverlayClock.ts`
- **설명:** 타임존 없는 ISO는 UTC로 보고, 시계·날짜는 Asia/Seoul로 표시한다.

```typescript
const KST = "Asia/Seoul";

export function formatOverlayClock(date: Date = new Date()): string {
  return new Intl.DateTimeFormat("en-GB", {
    timeZone: KST,
    hour: "2-digit",
    minute: "2-digit",
    hour12: false,
  }).format(date);
}
```

### 2. 촬영 확인 오버레이·당일 토픽 제한

- **파일:** `components/molecules/CaptureClipOverlays.tsx`, `components/organisms/CaptureFlowSection.tsx`, `components/organisms/CapturePreviewStage.tsx`, `components/organisms/CaptureUploadSettingsStage.tsx`, `components/molecules/TopicChip.tsx`
- **설명:** 시각은 정중앙, 캡션은 그 아래(자리 미점유). 글자 크기는 cqmin. 확인 화면 00:05 제거. 오늘 이미 올린 토픽은 선택 불가.

```typescript
function isTopicSelectable(topic: UiTopicListItem): boolean {
  return topic.uploadedByMe !== true;
}
```

### 3. 채팅·전체보기 헤더

- **파일:** `components/organisms/RoomChatSection.tsx`, `components/organisms/ChatMessageFullSection.tsx`, `components/molecules/PageContainer.tsx`
- **설명:** ScreenHeader + PageContainer. PageContainer에 ref/onScroll을 열어 채팅 스크롤에 사용한다.

### 4. 토픽 만들기 헤더

- **파일:** `components/templates/RoomManageTemplates.tsx`
- **설명:** Auth 패딩 대신 토픽 목록과 같은 ScreenHeader 레이아웃을 쓴다.

### 5. 가입 이동·아지트 정보 카드

- **파일:** `components/organisms/InviteJoinProfileForm.tsx`, `components/organisms/AgitLandingDetail.tsx`, `components/templates/RoomFlowTemplates.tsx`, `public/plip/daily-loop/icon-crown-brand.svg`
- **설명:** 가입 후 `ROUTES.agit.detail`로 이동. 카드는 아지트/다이어리와 같은 shadow. 인원 `n/max`, 브랜드 왕관+방장. 입장 버튼은 독 카메라와 같은 그라데이션·링·글로우.

```typescript
router.push(ROUTES.agit.detail(result.data.agitUuid));
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
