### PR TITLE
[#157] Feature : 촬영·파일 영상을 720p 무음 mp4로 압축

### DIFF
--- a/components/organisms/CaptureCameraStage.tsx
+++ b/components/organisms/CaptureCameraStage.tsx
@@ -29,7 +29,8 @@ export function CaptureCameraStage({
 }: CaptureCameraStageProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isRecording = status === "recording";
-  const isBusy = status === "requesting" || isRecording;
+  const isPreparing = status === "preparing";
+  const isBusy = status === "requesting" || isRecording || isPreparing;
 
   useEffect(() => {
     unlockShutterAudio();
@@ -62,7 +63,16 @@ export function CaptureCameraStage({
         </p>
       ) : null}
 
-      {!isRecording ? (
+      {isPreparing ? (
+        <p
+          className="absolute inset-x-4 top-20 rounded bg-black/70 px-3 py-2 text-center text-xs text-white"
+          role="status"
+        >
+          영상 변환 중…
+        </p>
+      ) : null}
+
+      {!isRecording && !isPreparing ? (
         <p className="absolute inset-x-6 bottom-[168px] m-0 text-center text-xs text-white">
           화면 중앙에 오늘의 장면을 맞춰주세요
         </p>
@@ -106,8 +116,8 @@ export function CaptureCameraStage({
           <button
             type="button"
             className="relative grid h-[84px] w-[84px] place-items-center border-0 bg-transparent p-0"
-            aria-label={isRecording ? "촬영 중" : "촬영"}
-            disabled={status === "requesting"}
+            aria-label={isRecording ? "촬영 중" : isPreparing ? "영상 변환 중" : "촬영"}
+            disabled={status === "requesting" || isPreparing}
             onClick={() => {
               if (!isRecording) {
                 onStartRecording();

--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -60,7 +60,6 @@ export function CaptureFlowSection({
     elapsedMs,
     maxDurationMs,
     facingMode,
-    pixelsMirrored,
     capturedAt,
     uploading,
     startRecording,
@@ -95,7 +94,7 @@ export function CaptureFlowSection({
   const showSettings = isPreview && previewStep === "settings";
   const showConfirm = isPreview && previewStep === "confirm";
   const containPreview = showConfirm && !originalView;
-  const mirrorVideo = shouldMirrorVideo(facingMode, status, pixelsMirrored);
+  const mirrorVideo = shouldMirrorVideo(facingMode, status);
   const frameMetrics = usePreviewFrameMetrics(containPreview, sectionRef, slotRef);
   const overlayScale = containPreview && frameMetrics.scale > 0 ? frameMetrics.scale : 1;
 

--- a/components/organisms/VideoCaptureSection.tsx
+++ b/components/organisms/VideoCaptureSection.tsx
@@ -38,6 +38,7 @@ export function VideoCaptureSection() {
   const canUploadBlob = blob !== null && isWithinUploadLimit(blob.size);
   const blobOverLimit = blob !== null && blob.size > MAX_UPLOAD_BYTES;
   const mirrorFrontCamera = shouldMirrorVideo(facingMode, status);
+  const recorderBusy = uploading || status === "recording" || status === "preparing";
 
   return (
     <section className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6 font-mono text-sm">
@@ -87,7 +88,7 @@ export function VideoCaptureSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={uploading || status === "recording"}
+          disabled={recorderBusy}
           onClick={() => void prepareCamera()}
         >
           카메라 재시작
@@ -95,7 +96,7 @@ export function VideoCaptureSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={uploading || status === "recording"}
+          disabled={recorderBusy}
           onClick={() => void flipCamera()}
         >
           카메라 전환
@@ -106,6 +107,7 @@ export function VideoCaptureSection() {
           disabled={
             uploading ||
             status === "recording" ||
+            status === "preparing" ||
             status === "requesting" ||
             flowPhase === "complete"
           }
@@ -132,7 +134,7 @@ export function VideoCaptureSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={uploading}
+          disabled={recorderBusy}
           onClick={() => fileInputRef.current?.click()}
         >
           mp4/mov로 테스트
@@ -140,7 +142,7 @@ export function VideoCaptureSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={uploading}
+          disabled={recorderBusy}
           onClick={() => void uploadOversizeTest()}
         >
           8MB 초과 테스트
@@ -161,7 +163,7 @@ export function VideoCaptureSection() {
         <button
           type="button"
           className="rounded border px-3 py-2 disabled:opacity-50"
-          disabled={uploading}
+          disabled={recorderBusy}
           onClick={() => void retake()}
         >
           다시 촬영
@@ -193,12 +195,6 @@ export function VideoCaptureSection() {
           </p>
           <p>download poll attempts: {uploadResult.downloadPollAttempts}</p>
           <p>playback: {uploadResult.playback.kind}</p>
-          {mimeType && !mimeType.toLowerCase().includes("mp4") ? (
-            <p className="text-green-800">
-              녹화 MIME은 {mimeType}입니다. raw 버킷 파일이 webm인 것은 정상입니다. mp4
-              변환은 Day 2 FFmpeg에서 합니다.
-            </p>
-          ) : null}
           {uploadResult.playback.note ? (
             <p className="text-green-800">{uploadResult.playback.note}</p>
           ) : null}

--- a/components/organisms/VideoCaptureSection.tsx
+++ b/components/organisms/VideoCaptureSection.tsx
@@ -19,7 +19,6 @@ export function VideoCaptureSection() {
     blob,
     mimeType,
     facingMode,
-    pixelsMirrored,
     flowPhase,
     flowError,
     uploadResult,
@@ -38,7 +37,7 @@ export function VideoCaptureSection() {
   const progressPct = Math.min(100, Math.round((elapsedMs / maxDurationMs) * 100));
   const canUploadBlob = blob !== null && isWithinUploadLimit(blob.size);
   const blobOverLimit = blob !== null && blob.size > MAX_UPLOAD_BYTES;
-  const mirrorFrontCamera = shouldMirrorVideo(facingMode, status, pixelsMirrored);
+  const mirrorFrontCamera = shouldMirrorVideo(facingMode, status);
 
   return (
     <section className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-6 font-mono text-sm">

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -32,6 +32,8 @@ function mapRecorderStatusToFlowPhase(
       return "ready";
     case "recording":
       return "recording";
+    case "preparing":
+      return "initializing";
     case "preview":
       return "preview";
     case "error":

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  DEFAULT_UPLOAD_CONTENT_TYPE,
   MAX_RECORD_MS,
   RECORD_STOP_MS,
   RECORD_TIMESLICE_MS,
@@ -11,6 +12,7 @@ import {
   waitForVideoFrame,
   type CaptureCanvas,
 } from "@/lib/video/captureCanvas";
+import { needsPlaybackReencode, preparePlaybackMp4 } from "@/lib/video/preparePlaybackMp4";
 import { pickRecorderMimeType, requestCameraStream } from "@/lib/video/recorderMime";
 import { isIgnorablePlayError, safeVideoPlay } from "@/lib/video/safeVideoPlay";
 import { useCallback, useEffect, useRef, useState, type RefCallback } from "react";
@@ -20,6 +22,7 @@ export type RecorderStatus =
   | "requesting"
   | "ready"
   | "recording"
+  | "preparing"
   | "preview"
   | "error";
 
@@ -81,6 +84,8 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   const startedAtRef = useRef<number>(0);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const autoPrepareStartedRef = useRef(false);
+  const prepareGenerationRef = useRef(0);
+  const prepareAbortRef = useRef<AbortController | null>(null);
 
   const syncVideoElement = useCallback(
     (node: HTMLVideoElement | null) => {
@@ -134,6 +139,12 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     captureRef.current = null;
   }, []);
 
+  const abortPrepare = useCallback(() => {
+    prepareGenerationRef.current += 1;
+    prepareAbortRef.current?.abort();
+    prepareAbortRef.current = null;
+  }, []);
+
   const resetPreview = useCallback(() => {
     setPreviewUrl((current) => {
       if (current) {
@@ -145,6 +156,20 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     setElapsedMs(0);
     setCapturedAt(null);
   }, []);
+
+  const applyPreviewBlob = useCallback(
+    (nextBlob: Blob, nextMimeType: string) => {
+      const nextPreviewUrl = URL.createObjectURL(nextBlob);
+      setError(null);
+      setBlob(nextBlob);
+      setPreviewUrl(nextPreviewUrl);
+      setMimeType(nextMimeType);
+      setCapturedAt(new Date());
+      setStatus("preview");
+      onRecordingComplete?.();
+    },
+    [onRecordingComplete],
+  );
 
   const prepareCamera = useCallback(async () => {
     if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
@@ -174,6 +199,40 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       setStatus("error");
     }
   }, [facingMode, resetPreview, stopStream]);
+
+  const restoreLiveCamera = useCallback(async () => {
+    try {
+      stopStream();
+      const stream = await requestCameraStream(facingMode);
+      streamRef.current = stream;
+      setLiveStream(stream);
+    } catch {
+      /* keep conversion error */
+    }
+  }, [facingMode, stopStream]);
+
+  const convertThenPreview = useCallback(
+    async (source: Blob, generation: number, signal: AbortSignal) => {
+      try {
+        const prepared = await preparePlaybackMp4(source, signal);
+        if (generation !== prepareGenerationRef.current) {
+          return;
+        }
+        applyPreviewBlob(prepared, DEFAULT_UPLOAD_CONTENT_TYPE);
+      } catch (cause) {
+        if (generation !== prepareGenerationRef.current) {
+          return;
+        }
+        if (cause instanceof DOMException && cause.name === "AbortError") {
+          return;
+        }
+        setError(cause instanceof Error ? cause.message : "이 파일은 변환할 수 없습니다.");
+        setStatus("error");
+        await restoreLiveCamera();
+      }
+    },
+    [applyPreviewBlob, restoreLiveCamera],
+  );
 
   const stopRecording = useCallback(() => {
     clearTimers();
@@ -215,6 +274,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     resetPreview();
     chunksRef.current = [];
     stopCapture();
+    abortPrepare();
 
     await waitForVideoFrame(previewNode);
     const capture = startCaptureCanvas(previewNode);
@@ -256,15 +316,19 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
         return;
       }
 
-      const nextPreviewUrl = URL.createObjectURL(recordedBlob);
-
       stopStream();
-      setError(null);
-      setBlob(recordedBlob);
-      setPreviewUrl(nextPreviewUrl);
-      setCapturedAt(new Date());
-      setStatus("preview");
-      onRecordingComplete?.();
+
+      if (!needsPlaybackReencode(recordedBlob)) {
+        applyPreviewBlob(recordedBlob, selectedMimeType);
+        return;
+      }
+
+      abortPrepare();
+      const generation = prepareGenerationRef.current;
+      const controller = new AbortController();
+      prepareAbortRef.current = controller;
+      setStatus("preparing");
+      void convertThenPreview(recordedBlob, generation, controller.signal);
     };
 
     recorder.onerror = () => {
@@ -293,16 +357,19 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   }, [
     clearTimers,
     maxDurationMs,
-    onRecordingComplete,
     prepareCamera,
     recordStopMs,
     resetPreview,
     stopRecording,
     stopStream,
     stopCapture,
+    convertThenPreview,
+    applyPreviewBlob,
+    abortPrepare,
   ]);
 
   const discardRecording = useCallback(async () => {
+    abortPrepare();
     clearTimers();
     stopCapture();
     recorderRef.current = null;
@@ -311,29 +378,29 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     setError(null);
     setStatus("idle");
     await prepareCamera();
-  }, [clearTimers, prepareCamera, resetPreview, stopCapture, stopStream]);
+  }, [abortPrepare, clearTimers, prepareCamera, resetPreview, stopCapture, stopStream]);
 
   const loadFromFile = useCallback(
     (file: File) => {
+      abortPrepare();
       clearTimers();
       stopCapture();
       recorderRef.current = null;
       stopStream();
       resetPreview();
-
-      const nextPreviewUrl = URL.createObjectURL(file);
       setError(null);
-      setBlob(file);
-      setPreviewUrl(nextPreviewUrl);
-      setMimeType(file.type || "video/mp4");
-      setCapturedAt(new Date());
-      setStatus("preview");
+
+      const generation = prepareGenerationRef.current;
+      const controller = new AbortController();
+      prepareAbortRef.current = controller;
+      setStatus("preparing");
+      void convertThenPreview(file, generation, controller.signal);
     },
-    [clearTimers, resetPreview, stopCapture, stopStream],
+    [abortPrepare, clearTimers, convertThenPreview, resetPreview, stopCapture, stopStream],
   );
 
   const flipCamera = useCallback(async () => {
-    if (status === "recording") {
+    if (status === "recording" || status === "preparing") {
       return;
     }
 
@@ -378,6 +445,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     return () => {
       clearTimers();
       stopCapture();
+      abortPrepare();
       stopStream();
       setPreviewUrl((current) => {
         if (current) {
@@ -386,7 +454,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
         return null;
       });
     };
-  }, [clearTimers, stopCapture, stopStream]);
+  }, [abortPrepare, clearTimers, stopCapture, stopStream]);
 
   return {
     videoRef: bindVideoElement,

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -7,10 +7,10 @@ import {
   RECORD_VIDEO_BITS_PER_SECOND,
 } from "@/lib/video/constants";
 import {
-  startMirroredCapture,
+  startCaptureCanvas,
   waitForVideoFrame,
-  type MirroredCapture,
-} from "@/lib/video/mirroredCapture";
+  type CaptureCanvas,
+} from "@/lib/video/captureCanvas";
 import { pickRecorderMimeType, requestCameraStream } from "@/lib/video/recorderMime";
 import { isIgnorablePlayError, safeVideoPlay } from "@/lib/video/safeVideoPlay";
 import { useCallback, useEffect, useRef, useState, type RefCallback } from "react";
@@ -70,12 +70,11 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [mimeType, setMimeType] = useState<string | undefined>();
   const [liveStream, setLiveStream] = useState<MediaStream | null>(null);
-  const [pixelsMirrored, setPixelsMirrored] = useState(false);
   const [capturedAt, setCapturedAt] = useState<Date | null>(null);
 
   const streamRef = useRef<MediaStream | null>(null);
   const recorderRef = useRef<MediaRecorder | null>(null);
-  const mirrorRef = useRef<MirroredCapture | null>(null);
+  const captureRef = useRef<CaptureCanvas | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const stopTimerRef = useRef<number | null>(null);
   const tickTimerRef = useRef<number | null>(null);
@@ -130,9 +129,9 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     setLiveStream(null);
   }, []);
 
-  const stopMirror = useCallback(() => {
-    mirrorRef.current?.stop();
-    mirrorRef.current = null;
+  const stopCapture = useCallback(() => {
+    captureRef.current?.stop();
+    captureRef.current = null;
   }, []);
 
   const resetPreview = useCallback(() => {
@@ -144,7 +143,6 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     });
     setBlob(null);
     setElapsedMs(0);
-    setPixelsMirrored(false);
     setCapturedAt(null);
   }, []);
 
@@ -200,6 +198,13 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       return;
     }
 
+    const previewNode = videoRef.current;
+    if (!previewNode) {
+      setError("미리보기가 아직 준비되지 않았습니다.");
+      setStatus("error");
+      return;
+    }
+
     const selectedMimeType = pickRecorderMimeType();
     if (!selectedMimeType) {
       setError("MediaRecorder is not supported in this browser");
@@ -209,27 +214,25 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
 
     resetPreview();
     chunksRef.current = [];
-    stopMirror();
+    stopCapture();
 
-    let recordStream = stream;
-    let recordedMirrored = false;
-    if (facingMode === "user" && videoRef.current) {
-      await waitForVideoFrame(videoRef.current);
-      const mirrored = startMirroredCapture(videoRef.current);
-      if (mirrored) {
-        mirrorRef.current = mirrored;
-        recordStream = mirrored.stream;
-        recordedMirrored = true;
-      }
+    await waitForVideoFrame(previewNode);
+    const capture = startCaptureCanvas(previewNode);
+    if (!capture) {
+      setError("영상을 720p로 녹화할 수 없습니다.");
+      setStatus("error");
+      return;
     }
 
-    const recorder = new MediaRecorder(recordStream, {
+    captureRef.current = capture;
+
+    const recorder = new MediaRecorder(capture.stream, {
       mimeType: selectedMimeType,
       videoBitsPerSecond: RECORD_VIDEO_BITS_PER_SECOND,
+      bitsPerSecond: RECORD_VIDEO_BITS_PER_SECOND,
     });
     recorderRef.current = recorder;
     setMimeType(selectedMimeType);
-    setPixelsMirrored(recordedMirrored);
 
     recorder.ondataavailable = (event) => {
       if (event.data.size > 0) {
@@ -239,7 +242,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
 
     recorder.onstop = () => {
       clearTimers();
-      stopMirror();
+      stopCapture();
 
       const maxChunks = Math.ceil(maxDurationMs / RECORD_TIMESLICE_MS);
       const trimmedChunks = chunksRef.current.slice(0, maxChunks);
@@ -265,7 +268,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     };
 
     recorder.onerror = () => {
-      stopMirror();
+      stopCapture();
       setError("Recording failed");
       setStatus("error");
     };
@@ -296,25 +299,24 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     resetPreview,
     stopRecording,
     stopStream,
-    stopMirror,
-    facingMode,
+    stopCapture,
   ]);
 
   const discardRecording = useCallback(async () => {
     clearTimers();
-    stopMirror();
+    stopCapture();
     recorderRef.current = null;
     resetPreview();
     stopStream();
     setError(null);
     setStatus("idle");
     await prepareCamera();
-  }, [clearTimers, prepareCamera, resetPreview, stopMirror, stopStream]);
+  }, [clearTimers, prepareCamera, resetPreview, stopCapture, stopStream]);
 
   const loadFromFile = useCallback(
     (file: File) => {
       clearTimers();
-      stopMirror();
+      stopCapture();
       recorderRef.current = null;
       stopStream();
       resetPreview();
@@ -324,11 +326,10 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       setBlob(file);
       setPreviewUrl(nextPreviewUrl);
       setMimeType(file.type || "video/mp4");
-      setPixelsMirrored(false);
       setCapturedAt(new Date());
       setStatus("preview");
     },
-    [clearTimers, resetPreview, stopMirror, stopStream],
+    [clearTimers, resetPreview, stopCapture, stopStream],
   );
 
   const flipCamera = useCallback(async () => {
@@ -376,7 +377,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   useEffect(() => {
     return () => {
       clearTimers();
-      stopMirror();
+      stopCapture();
       stopStream();
       setPreviewUrl((current) => {
         if (current) {
@@ -385,7 +386,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
         return null;
       });
     };
-  }, [clearTimers, stopMirror, stopStream]);
+  }, [clearTimers, stopCapture, stopStream]);
 
   return {
     videoRef: bindVideoElement,
@@ -397,7 +398,6 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     previewUrl,
     mimeType,
     facingMode,
-    pixelsMirrored,
     capturedAt,
     prepareCamera,
     startRecording,

--- a/lib/video/captureCanvas.ts
+++ b/lib/video/captureCanvas.ts
@@ -1,14 +1,11 @@
 import { CAPTURE_FRAME_RATE, CAPTURE_HEIGHT, CAPTURE_WIDTH } from "@/lib/video/constants";
+import { drawCoverCrop } from "@/lib/video/coverCrop";
 
-export type MirroredCapture = {
+export type CaptureCanvas = {
   stream: MediaStream;
   stop: () => void;
 };
 
-/**
- * Front-camera pixels are opposite of the mirrored live view.
- * Draw a flipped canvas so the recorded blob matches what the user saw.
- */
 export async function waitForVideoFrame(sourceVideo: HTMLVideoElement, timeoutMs = 400): Promise<void> {
   if (sourceVideo.videoWidth > 0) {
     return;
@@ -21,17 +18,16 @@ export async function waitForVideoFrame(sourceVideo: HTMLVideoElement, timeoutMs
   });
 }
 
-export function startMirroredCapture(sourceVideo: HTMLVideoElement): MirroredCapture | null {
-  const width = sourceVideo.videoWidth || CAPTURE_WIDTH;
-  const height = sourceVideo.videoHeight || CAPTURE_HEIGHT;
-  if (width < 2 || height < 2) {
+/** Fixed 720×1280 cover-crop canvas. Front and rear cameras are treated the same (no flip). */
+export function startCaptureCanvas(sourceVideo: HTMLVideoElement): CaptureCanvas | null {
+  if (sourceVideo.videoWidth < 2 || sourceVideo.videoHeight < 2) {
     return null;
   }
 
   const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const context = canvas.getContext("2d");
+  canvas.width = CAPTURE_WIDTH;
+  canvas.height = CAPTURE_HEIGHT;
+  const context = canvas.getContext("2d", { alpha: false });
   if (!context || typeof canvas.captureStream !== "function") {
     return null;
   }
@@ -44,11 +40,14 @@ export function startMirroredCapture(sourceVideo: HTMLVideoElement): MirroredCap
       return;
     }
 
-    context.save();
-    context.translate(width, 0);
-    context.scale(-1, 1);
-    context.drawImage(sourceVideo, 0, 0, width, height);
-    context.restore();
+    drawCoverCrop(
+      context,
+      sourceVideo,
+      sourceVideo.videoWidth,
+      sourceVideo.videoHeight,
+      CAPTURE_WIDTH,
+      CAPTURE_HEIGHT,
+    );
     frameId = window.requestAnimationFrame(draw);
   };
 

--- a/lib/video/constants.ts
+++ b/lib/video/constants.ts
@@ -15,17 +15,22 @@ export const RECORDER_MIME_CANDIDATES = [
 /** Presigned PUT Content-Type must match upload-url query param */
 export const DEFAULT_UPLOAD_CONTENT_TYPE = "video/mp4";
 
-/** Server/client reject line. 5s 720p H.264 ~2.5 Mbps is ~1.6–2MB; iOS mp4/hevc can be larger. */
+/** Server/client reject line after 720p encode. */
 export const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
 
 export const MAX_UPLOAD_MB = MAX_UPLOAD_BYTES / (1024 * 1024);
+
+/** Camera mp4 at/under this size skips a second WebCodecs pass. */
+export const PLAYBACK_SKIP_REENCODE_BYTES = 2 * 1024 * 1024;
+
+export const MIN_PLAYBACK_DURATION_MS = 300;
 
 export const CAPTURE_WIDTH = 720;
 export const CAPTURE_HEIGHT = 1280;
 export const CAPTURE_FRAME_RATE = 30;
 
-/** MediaRecorder target. 2.5 Mbps × 5s ≈ 1.6MB so typical captures stay under 8MB. */
-export const RECORD_VIDEO_BITS_PER_SECOND = 2_500_000;
+/** MediaRecorder / WebCodecs target. 1.5 Mbps × 5s ≈ 0.9MB. */
+export const RECORD_VIDEO_BITS_PER_SECOND = 1_500_000;
 
 export const DEFAULT_CAPTURE_CAPTION = "";
 

--- a/lib/video/coverCrop.ts
+++ b/lib/video/coverCrop.ts
@@ -1,0 +1,19 @@
+export function drawCoverCrop(
+  context: CanvasRenderingContext2D,
+  source: CanvasImageSource,
+  sourceWidth: number,
+  sourceHeight: number,
+  destWidth: number,
+  destHeight: number,
+): void {
+  if (sourceWidth < 1 || sourceHeight < 1 || destWidth < 1 || destHeight < 1) {
+    return;
+  }
+
+  const scale = Math.max(destWidth / sourceWidth, destHeight / sourceHeight);
+  const drawWidth = sourceWidth * scale;
+  const drawHeight = sourceHeight * scale;
+  const dx = (destWidth - drawWidth) / 2;
+  const dy = (destHeight - drawHeight) / 2;
+  context.drawImage(source, dx, dy, drawWidth, drawHeight);
+}

--- a/lib/video/preparePlaybackMp4.ts
+++ b/lib/video/preparePlaybackMp4.ts
@@ -1,0 +1,318 @@
+import {
+  CAPTURE_FRAME_RATE,
+  CAPTURE_HEIGHT,
+  CAPTURE_WIDTH,
+  DEFAULT_UPLOAD_CONTENT_TYPE,
+  MAX_RECORD_MS,
+  MAX_UPLOAD_BYTES,
+  MIN_PLAYBACK_DURATION_MS,
+  PLAYBACK_SKIP_REENCODE_BYTES,
+  RECORD_VIDEO_BITS_PER_SECOND,
+} from "@/lib/video/constants";
+import { drawCoverCrop } from "@/lib/video/coverCrop";
+import { assertUploadSize } from "@/lib/video/uploadLimits";
+
+export const PLAYBACK_CONVERT_FAILED = "이 파일은 변환할 수 없습니다.";
+
+const AVC_CODEC_CANDIDATES = ["avc1.4d0028", "avc1.420028", "avc1.4d001f", "avc1.42001f"] as const;
+const CONVERT_TIMEOUT_MS = 20_000;
+const PLAYBACK_RATE = 4;
+
+export function needsPlaybackReencode(blob: Blob): boolean {
+  const type = blob.type.toLowerCase();
+  const isMp4 = type.startsWith("video/mp4");
+  return !(isMp4 && blob.size > 0 && blob.size <= PLAYBACK_SKIP_REENCODE_BYTES);
+}
+
+function conversionError(): Error {
+  return new Error(PLAYBACK_CONVERT_FAILED);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+}
+
+async function pickAvcCodec(): Promise<string | null> {
+  if (typeof VideoEncoder === "undefined" || typeof VideoEncoder.isConfigSupported !== "function") {
+    return null;
+  }
+
+  for (const codec of AVC_CODEC_CANDIDATES) {
+    try {
+      const support = await VideoEncoder.isConfigSupported({
+        codec,
+        width: CAPTURE_WIDTH,
+        height: CAPTURE_HEIGHT,
+        bitrate: RECORD_VIDEO_BITS_PER_SECOND,
+        framerate: CAPTURE_FRAME_RATE,
+        avc: { format: "avc" },
+      });
+      if (support.supported) {
+        return codec;
+      }
+    } catch {
+      /* try next */
+    }
+  }
+
+  return null;
+}
+
+function waitLoadedMetadata(video: HTMLVideoElement, signal?: AbortSignal): Promise<void> {
+  if (video.readyState >= HTMLMediaElement.HAVE_METADATA && Number.isFinite(video.duration)) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const finish = (error?: Error) => {
+      video.removeEventListener("loadedmetadata", onMeta);
+      video.removeEventListener("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    };
+    const onMeta = () => finish();
+    const onError = () => finish(conversionError());
+    const onAbort = () => finish(new DOMException("Aborted", "AbortError"));
+    video.addEventListener("loadedmetadata", onMeta, { once: true });
+    video.addEventListener("error", onError, { once: true });
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+/**
+ * Decode any playable blob, trim to 5s, cover-crop to 720×1280, drop audio, encode H.264 mp4.
+ */
+export async function preparePlaybackMp4(source: Blob, signal?: AbortSignal): Promise<Blob> {
+  throwIfAborted(signal);
+
+  if (typeof VideoEncoder === "undefined" || typeof VideoFrame === "undefined") {
+    throw conversionError();
+  }
+
+  const codec = await pickAvcCodec();
+  throwIfAborted(signal);
+  if (!codec) {
+    throw conversionError();
+  }
+
+  const objectUrl = URL.createObjectURL(source);
+  const video = document.createElement("video");
+  video.muted = true;
+  video.defaultMuted = true;
+  video.playsInline = true;
+  video.setAttribute("playsinline", "");
+  video.preload = "auto";
+  video.src = objectUrl;
+
+  let encoder: VideoEncoder | null = null;
+
+  try {
+    await waitLoadedMetadata(video, signal);
+    throwIfAborted(signal);
+
+    const duration = video.duration;
+    if (!Number.isFinite(duration) || duration * 1000 < MIN_PLAYBACK_DURATION_MS) {
+      throw new Error("영상이 너무 짧습니다.");
+    }
+
+    if (video.videoWidth < 2 || video.videoHeight < 2) {
+      throw conversionError();
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = CAPTURE_WIDTH;
+    canvas.height = CAPTURE_HEIGHT;
+    const context = canvas.getContext("2d", { alpha: false });
+    if (!context) {
+      throw conversionError();
+    }
+
+    const { Muxer, ArrayBufferTarget } = await import("mp4-muxer");
+    throwIfAborted(signal);
+
+    const target = new ArrayBufferTarget();
+    const muxer = new Muxer({
+      target,
+      video: {
+        codec: "avc",
+        width: CAPTURE_WIDTH,
+        height: CAPTURE_HEIGHT,
+        frameRate: CAPTURE_FRAME_RATE,
+      },
+      fastStart: "in-memory",
+      firstTimestampBehavior: "offset",
+    });
+
+    let encoderError: Error | null = null;
+    encoder = new VideoEncoder({
+      output: (chunk, meta) => {
+        muxer.addVideoChunk(chunk, meta);
+      },
+      error: (cause) => {
+        encoderError = cause instanceof Error ? cause : conversionError();
+      },
+    });
+    encoder.configure({
+      codec,
+      width: CAPTURE_WIDTH,
+      height: CAPTURE_HEIGHT,
+      bitrate: RECORD_VIDEO_BITS_PER_SECOND,
+      framerate: CAPTURE_FRAME_RATE,
+      avc: { format: "avc" },
+      hardwareAcceleration: "prefer-hardware",
+    });
+
+    const endTime = Math.min(duration, MAX_RECORD_MS / 1000);
+    video.playbackRate = PLAYBACK_RATE;
+    await video.play();
+    throwIfAborted(signal);
+
+    await collectFrames(video, context, encoder, endTime, signal, () => encoderError);
+
+    video.pause();
+    await encoder.flush();
+    encoder.close();
+    encoder = null;
+    muxer.finalize();
+
+    if (!target.buffer || target.buffer.byteLength === 0) {
+      throw conversionError();
+    }
+
+    return new Blob([target.buffer], { type: DEFAULT_UPLOAD_CONTENT_TYPE });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    if (error instanceof Error && error.message === "영상이 너무 짧습니다.") {
+      throw error;
+    }
+    throw conversionError();
+  } finally {
+    video.pause();
+    video.removeAttribute("src");
+    video.load();
+    URL.revokeObjectURL(objectUrl);
+    if (encoder && encoder.state !== "closed") {
+      encoder.close();
+    }
+  }
+}
+
+function collectFrames(
+  video: HTMLVideoElement,
+  context: CanvasRenderingContext2D,
+  encoder: VideoEncoder,
+  endTime: number,
+  signal: AbortSignal | undefined,
+  getEncoderError: () => Error | null,
+): Promise<void> {
+  if (typeof video.requestVideoFrameCallback !== "function") {
+    return Promise.reject(conversionError());
+  }
+
+  return new Promise((resolve, reject) => {
+    let frameIndex = 0;
+    let settled = false;
+    const timeoutId = window.setTimeout(() => {
+      finish(conversionError());
+    }, CONVERT_TIMEOUT_MS);
+
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      window.clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", onAbort);
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (frameIndex === 0) {
+        reject(conversionError());
+        return;
+      }
+      resolve();
+    };
+
+    const onAbort = () => finish(new DOMException("Aborted", "AbortError"));
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    const onFrame: VideoFrameRequestCallback = (_now, metadata) => {
+      if (settled) {
+        return;
+      }
+
+      const encoderError = getEncoderError();
+      if (encoderError) {
+        finish(encoderError);
+        return;
+      }
+
+      const mediaTime = metadata.mediaTime;
+      if (mediaTime >= endTime || video.ended) {
+        finish();
+        return;
+      }
+
+      try {
+        drawCoverCrop(
+          context,
+          video,
+          video.videoWidth,
+          video.videoHeight,
+          CAPTURE_WIDTH,
+          CAPTURE_HEIGHT,
+        );
+        const frame = new VideoFrame(canvasFromContext(context), {
+          timestamp: Math.round(mediaTime * 1_000_000),
+        });
+        encoder.encode(frame, { keyFrame: frameIndex % CAPTURE_FRAME_RATE === 0 });
+        frame.close();
+        frameIndex += 1;
+        video.requestVideoFrameCallback(onFrame);
+      } catch {
+        finish(conversionError());
+      }
+    };
+
+    video.requestVideoFrameCallback(onFrame);
+  });
+}
+
+function canvasFromContext(context: CanvasRenderingContext2D): HTMLCanvasElement {
+  return context.canvas as HTMLCanvasElement;
+}
+
+export async function preparePlaybackMp4IfNeeded(blob: Blob, signal?: AbortSignal): Promise<Blob> {
+  if (blob.size === 0) {
+    throw new Error("녹화 데이터가 비어 있습니다.");
+  }
+
+  if (!needsPlaybackReencode(blob)) {
+    return blob;
+  }
+
+  try {
+    return await preparePlaybackMp4(blob, signal);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    if (blob.size > MAX_UPLOAD_BYTES) {
+      assertUploadSize(blob);
+    }
+    throw error;
+  }
+}

--- a/lib/video/shouldMirrorVideo.ts
+++ b/lib/video/shouldMirrorVideo.ts
@@ -1,14 +1,13 @@
 import type { RecorderStatus } from "@/hooks/useVideoRecorder";
 
+/** CSS-mirror the live selfie preview only. Recorded/preview/upload pixels are not flipped. */
 export function shouldMirrorVideo(
   facingMode: "user" | "environment",
   status: RecorderStatus,
-  pixelsMirrored: boolean,
 ): boolean {
   if (facingMode !== "user") {
     return false;
   }
 
-  const isLive = status === "requesting" || status === "ready" || status === "recording";
-  return isLive || !pixelsMirrored;
+  return status === "requesting" || status === "ready" || status === "recording";
 }

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -6,6 +6,7 @@ import {
 import { extractActionError } from "@/lib/video/actionPayload";
 import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";
 import { resolvePlaybackSource, type PlaybackSource } from "@/lib/video/playback";
+import { preparePlaybackMp4IfNeeded } from "@/lib/video/preparePlaybackMp4";
 import { putPresignedUpload } from "@/lib/video/putPresigned";
 import { resolveUploadContentType } from "@/lib/video/recorderMime";
 import { assertUploadSize } from "@/lib/video/uploadLimits";
@@ -32,18 +33,19 @@ export async function uploadRecordedVideo(
   blob: Blob,
   options?: { caption?: string; recorderMimeType?: string },
 ): Promise<VideoUploadPipelineResult> {
-  assertUploadSize(blob);
+  const prepared = await preparePlaybackMp4IfNeeded(blob);
+  assertUploadSize(prepared);
 
-  const contentType = resolveUploadContentType(options?.recorderMimeType ?? blob.type);
+  const contentType = resolveUploadContentType(prepared.type || options?.recorderMimeType);
 
-  const uploadUrlResult = await issueUploadUrlAction(contentType, blob.size);
+  const uploadUrlResult = await issueUploadUrlAction(contentType, prepared.size);
   const uploadUrlError = extractActionError(uploadUrlResult);
   if (uploadUrlError || !uploadUrlResult.ok) {
     throw new Error(uploadUrlError ?? "upload-url failed");
   }
 
   const { videoUuid, uploadUrl } = uploadUrlResult.data;
-  const putResult = await putPresignedUpload(uploadUrl, blob, contentType);
+  const putResult = await putPresignedUpload(uploadUrl, prepared, contentType);
 
   const completeResult = await completeVideoAction(videoUuid, options?.caption);
   const completeError = extractActionError(completeResult);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^4.4.0",
         "framer-motion": "^13.1.1",
         "lucide-react": "^1.31.0",
+        "mp4-muxer": "^5.2.2",
         "next": "16.3.0",
         "next-auth": "^5.0.0-beta.32",
         "react": "19.2.8",
@@ -2418,6 +2419,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.19.tgz",
+      "integrity": "sha512-+yFUIDUaASFz0vQpWBErPxun/Lb+F0TdrlTsj50gm7K797YzEx2TmV6fEiwciHyFNghlZYPgQXH5qRcwMHcJFQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2480,6 +2487,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7263,6 +7276,17 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-13.0.0.tgz",
       "integrity": "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==",
       "license": "MIT"
+    },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "date-fns": "^4.4.0",
     "framer-motion": "^13.1.1",
     "lucide-react": "^1.31.0",
+    "mp4-muxer": "^5.2.2",
     "next": "16.3.0",
     "next-auth": "^5.0.0-beta.32",
     "react": "19.2.8",


### PR DESCRIPTION
## 작업 내용

피드 재생은 raw S3 객체를 쓰는데, 카메라 원본 해상도 그대로 올려 5초 클립이 ~4.7MB까지 커졌습니다. 업로드 전에 클라이언트가 720×1280 무음 H.264 mp4로 맞춰 S3에 작은 raw를 넣습니다. 전·후면 픽셀 미러는 하지 않고, 파일 피커는 선택 직후 5초 트림·재인코딩한 blob만 미리보기·PUT합니다.

## 관련 이슈

Close #157

## 변경 사항

### 1. 720p 캡처 캔버스로 전후면 동일 녹화

- **파일:** `lib/video/captureCanvas.ts`, `lib/video/coverCrop.ts`, `lib/video/constants.ts`, `lib/video/shouldMirrorVideo.ts`, `hooks/useVideoRecorder.ts`, `components/organisms/CaptureFlowSection.tsx`, `components/organisms/VideoCaptureSection.tsx`
- **설명:** 녹화는 항상 720×1280 cover-crop 캔버스 스트림을 MediaRecorder에 넣습니다. 전면 `scale(-1,1)`은 없고, CSS 미러는 라이브 미리보기에만 적용합니다. 비트레이트 목표는 1.5Mbps입니다.

```typescript
export function startCaptureCanvas(sourceVideo: HTMLVideoElement): CaptureCanvas | null {
  const canvas = document.createElement("canvas");
  canvas.width = CAPTURE_WIDTH;
  canvas.height = CAPTURE_HEIGHT;
  drawCoverCrop(
    context,
    sourceVideo,
    sourceVideo.videoWidth,
    sourceVideo.videoHeight,
    CAPTURE_WIDTH,
    CAPTURE_HEIGHT,
  );
  const stream = canvas.captureStream(CAPTURE_FRAME_RATE);
}
```

### 2. 선택 직후 720p 무음 mp4 재인코딩

- **파일:** `lib/video/preparePlaybackMp4.ts`, `hooks/useVideoRecorder.ts`, `components/organisms/CaptureCameraStage.tsx`, `package.json`
- **설명:** 파일은 고르는 즉시 WebCodecs + `mp4-muxer`로 앞 5초·무음·H.264 mp4를 만듭니다. 촬영본은 mp4이면서 2MB 이하면 스킵하고, webm이거나 그보다 크면 미리보기 전에 변환합니다. 변환 중에는 `preparing`과 「영상 변환 중…」을 띄웁니다.

```typescript
export function needsPlaybackReencode(blob: Blob): boolean {
  const type = blob.type.toLowerCase();
  const isMp4 = type.startsWith("video/mp4");
  return !(isMp4 && blob.size > 0 && blob.size <= PLAYBACK_SKIP_REENCODE_BYTES);
}
```

### 3. PUT은 최종 mp4 크기로 발급

- **파일:** `lib/video/uploadPipeline.ts`
- **설명:** lab `uploadFile`이 원본을 넣어도 PUT 전에 한 번 더 맞춥니다. presigned URL은 변환된 `blob.size`로만 발급합니다.

```typescript
const prepared = await preparePlaybackMp4IfNeeded(blob);
assertUploadSize(prepared);
const contentType = resolveUploadContentType(prepared.type || options?.recorderMimeType);
const uploadUrlResult = await issueUploadUrlAction(contentType, prepared.size);
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`) — 전·후면 촬영 blob ~1MB mp4, 긴/가로/오디오 파일 선택 직후 5초 세로 미리보기

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [x] 커밋 메시지 형식: `Type: 변경 요약`
- [x] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인