### PR TITLE
[#160] Feature : 영상 변환 토스트 및 다이어리 기본 기록 목적지

### DIFF
--- a/app/(capture)/video/page.tsx
+++ b/app/(capture)/video/page.tsx
@@ -5,8 +5,16 @@ type PageProps = {
     agitUuid?: string;
     topicUuid?: string;
     themeId?: string;
+    destination?: string;
   }>;
 };
+
+function parseDestinationKind(value?: string): "diary" | "agit" | undefined {
+  if (value === "diary" || value === "agit") {
+    return value;
+  }
+  return undefined;
+}
 
 export default async function CaptureVideoPage({ searchParams }: PageProps) {
   const query = await searchParams;
@@ -15,6 +23,7 @@ export default async function CaptureVideoPage({ searchParams }: PageProps) {
       initialAgitUuid={query.agitUuid}
       initialTopicUuid={query.topicUuid}
       initialThemeId={query.themeId}
+      initialDestinationKind={parseDestinationKind(query.destination)}
     />
   );
 }

--- a/components/molecules/BottomNavigation.tsx
+++ b/components/molecules/BottomNavigation.tsx
@@ -60,6 +60,10 @@ export function BottomNavigation({
   active = "diary",
 }: BottomNavigationProps) {
   const [hoveredId, setHoveredId] = useState<BottomNavTab | null>(null);
+  const captureHref =
+    active === "diary"
+      ? ROUTES.capture.videoWith({ destination: "diary" })
+      : ROUTES.capture.video;
 
   return (
     <LayoutGroup id="app-bottom-nav">
@@ -108,7 +112,7 @@ export function BottomNavigation({
                   )}
 
                   <TextLink
-                    href={item.href}
+                    href={captureHref}
                     aria-label={item.label}
                     className="relative z-10 flex items-center justify-center !no-underline overflow-visible group"
                   >

--- a/components/molecules/CaptureCreateForm.tsx
+++ b/components/molecules/CaptureCreateForm.tsx
@@ -6,7 +6,7 @@ import { NoticeCard } from "@/components/molecules/NoticeCard";
 
 export const CAPTURE_TOPIC_CREATE_NOTICE = {
   title: "등록 규칙",
-  body: "한 사용자는 이 토픽에 영상 1개만 등록할 수 있어요. 진행 날짜는 오늘 하루입니다.",
+  body: "한 사용자는 이 토픽에 영상 1개만 등록할 수 있어요. 진행 날짜는 하루입니다.",
 } as const;
 
 type CaptureCreateFormProps = {
@@ -71,7 +71,7 @@ export function CaptureCreateForm({
       ) : null}
       <div className="mt-auto flex w-full flex-col gap-[14px]">
         <SubmitButton variant="brand" disabled={busy}>
-          {busy ? "만드는 중…" : submitLabel}
+          {busy ? "만드는 중..." : submitLabel}
         </SubmitButton>
       </div>
     </form>

--- a/components/molecules/CaptureCreateForm.tsx
+++ b/components/molecules/CaptureCreateForm.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { SubmitButton } from "@/components/atoms";
+import { AuthField } from "@/components/molecules/AuthField";
+import { NoticeCard } from "@/components/molecules/NoticeCard";
+
+export const CAPTURE_TOPIC_CREATE_NOTICE = {
+  title: "등록 규칙",
+  body: "한 사용자는 이 토픽에 영상 1개만 등록할 수 있어요. 진행 날짜는 오늘 하루입니다.",
+} as const;
+
+type CaptureCreateFormProps = {
+  idPrefix: string;
+  nameLabel: string;
+  placeholder: string;
+  hint: string;
+  maxLength: number;
+  submitLabel: string;
+  busy?: boolean;
+  error?: string | null;
+  noticeTitle?: string;
+  noticeBody?: string;
+  onSubmit: (value: string) => void | Promise<void>;
+};
+
+export function CaptureCreateForm({
+  idPrefix,
+  nameLabel,
+  placeholder,
+  hint,
+  maxLength,
+  submitLabel,
+  busy = false,
+  error = null,
+  noticeTitle,
+  noticeBody,
+  onSubmit,
+}: CaptureCreateFormProps) {
+  async function handleSubmit(formData: FormData) {
+    if (busy) {
+      return;
+    }
+
+    const value = String(formData.get("name") ?? "").trim();
+    if (!value) {
+      return;
+    }
+
+    await onSubmit(value);
+  }
+
+  return (
+    <form className="flex w-full flex-col gap-3.5" action={handleSubmit}>
+      <AuthField
+        id={`${idPrefix}-name`}
+        name="name"
+        label={nameLabel}
+        hint={hint}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        required
+        disabled={busy}
+      />
+      {noticeTitle && noticeBody ? (
+        <NoticeCard tone="brand" title={noticeTitle} body={noticeBody} />
+      ) : null}
+      {error ? (
+        <p className="m-0 text-[12px] font-semibold text-[var(--dl-color-text-danger)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div className="mt-auto flex w-full flex-col gap-[14px]">
+        <SubmitButton variant="brand" disabled={busy}>
+          {busy ? "만드는 중…" : submitLabel}
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}

--- a/components/molecules/CaptureDestinationEmptyPanel.tsx
+++ b/components/molecules/CaptureDestinationEmptyPanel.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Input, SubmitButton } from "@/components/atoms";
 import { TextLink } from "@/components/atoms/TextLink";
+import { ui } from "@/components/atoms/styles";
+import { CaptureCreateForm, CAPTURE_TOPIC_CREATE_NOTICE } from "@/components/molecules/CaptureCreateForm";
 import { ROUTES } from "@/config/routes";
+import { DIARY_THEME_NAME_MAX_LENGTH } from "@/types/diary/schema";
 import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
-import { useState } from "react";
 
 const NEW_TAB_HINT = "새 탭에서 열립니다. 촬영 화면 탭으로 돌아와 업로드를 이어주세요.";
 
@@ -30,7 +31,7 @@ type CaptureDestinationEmptyPanelProps =
 export function CaptureDestinationEmptyPanel(props: CaptureDestinationEmptyPanelProps) {
   if (props.kind === "agit") {
     return (
-      <div className="flex flex-col gap-3 rounded-[16px] border border-dashed border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-4">
+      <div className="flex flex-col gap-3 rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] px-3.5 py-4">
         <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
           참여 중인 아지트가 없어요. 아지트를 만들거나 가입한 뒤 이 탭으로 돌아와 주세요.
         </p>
@@ -56,7 +57,7 @@ export function CaptureDestinationEmptyPanel(props: CaptureDestinationEmptyPanel
         {props.onReload ? (
           <button
             type="button"
-            className="self-start border-0 bg-transparent p-0 text-[13px] font-medium text-[var(--dl-color-text-brand)]"
+            className={`${ui.link} cursor-pointer self-start border-0 bg-transparent p-0`}
             onClick={props.onReload}
           >
             참여 아지트 목록 새로고침
@@ -67,83 +68,44 @@ export function CaptureDestinationEmptyPanel(props: CaptureDestinationEmptyPanel
   }
 
   if (props.kind === "topic") {
-    return <TopicEmptyForm {...props} />;
+    return (
+      <div className="flex flex-col gap-3.5 rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] px-3.5 py-4">
+        <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
+          이 아지트에 등록할 토픽이 없어요. 아래에서 바로 만들 수 있어요.
+        </p>
+        <CaptureCreateForm
+          idPrefix="empty-topic"
+          nameLabel="토픽 이름"
+          placeholder="점심 메뉴"
+          hint={`최대 ${TOPIC_TITLE_MAX_LENGTH}자`}
+          maxLength={TOPIC_TITLE_MAX_LENGTH}
+          submitLabel="토픽 만들기"
+          busy={props.busy}
+          error={props.error}
+          noticeTitle={CAPTURE_TOPIC_CREATE_NOTICE.title}
+          noticeBody={CAPTURE_TOPIC_CREATE_NOTICE.body}
+          onSubmit={props.onCreateTopic}
+        />
+      </div>
+    );
   }
 
-  return <ThemeEmptyForm {...props} />;
-}
-
-function TopicEmptyForm({
-  busy = false,
-  error = null,
-  onCreateTopic,
-}: Omit<Extract<CaptureDestinationEmptyPanelProps, { kind: "topic" }>, "kind" | "agitUuid">) {
-  const [title, setTitle] = useState("");
-
   return (
-    <div className="flex flex-col gap-3 rounded-[16px] border border-dashed border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-4">
-      <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
-        이 아지트에 등록할 토픽이 없어요. 아래에서 바로 만들 수 있어요.
-      </p>
-      <Input
-        value={title}
-        maxLength={TOPIC_TITLE_MAX_LENGTH}
-        placeholder="토픽 이름"
-        variant="daily"
-        disabled={busy}
-        onChange={(event) => setTitle(event.target.value)}
-      />
-      <SubmitButton
-        type="button"
-        variant="brand"
-        className="!w-auto shrink-0 self-start px-4"
-        disabled={busy || !title.trim()}
-        onClick={() => void onCreateTopic(title.trim())}
-      >
-        {busy ? "만드는 중…" : "토픽 만들기"}
-      </SubmitButton>
-      {error ? (
-        <p className="m-0 text-[12px] text-[#d84545]" role="alert">
-          {error}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-function ThemeEmptyForm({
-  busy = false,
-  error = null,
-  onCreateTheme,
-}: Extract<CaptureDestinationEmptyPanelProps, { kind: "theme" }>) {
-  const [name, setName] = useState("");
-
-  return (
-    <div className="flex flex-col gap-3 rounded-[16px] border border-dashed border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-4">
+    <div className="flex flex-col gap-3.5 rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] px-3.5 py-4">
       <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
         다이어리 테마가 없어요. 아래에서 바로 만들 수 있어요.
       </p>
-      <Input
-        value={name}
-        placeholder="테마 이름"
-        variant="daily"
-        disabled={busy}
-        onChange={(event) => setName(event.target.value)}
+      <CaptureCreateForm
+        idPrefix="empty-theme"
+        nameLabel="테마 이름"
+        placeholder="예: 맛집 탐방, 운동 기록"
+        hint={`최대 ${DIARY_THEME_NAME_MAX_LENGTH}자`}
+        maxLength={DIARY_THEME_NAME_MAX_LENGTH}
+        submitLabel="테마 만들기"
+        busy={props.busy}
+        error={props.error}
+        onSubmit={props.onCreateTheme}
       />
-      <SubmitButton
-        type="button"
-        variant="brand"
-        className="!w-auto shrink-0 self-start px-4"
-        disabled={busy || !name.trim()}
-        onClick={() => void onCreateTheme(name.trim())}
-      >
-        {busy ? "만드는 중…" : "테마 만들기"}
-      </SubmitButton>
-      {error ? (
-        <p className="m-0 text-[12px] text-[#d84545]" role="alert">
-          {error}
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/components/molecules/CaptureDestinationEmptyPanel.tsx
+++ b/components/molecules/CaptureDestinationEmptyPanel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { TextLink } from "@/components/atoms/TextLink";
+import { IconButton, TextLink } from "@/components/atoms";
 import { ui } from "@/components/atoms/styles";
 import { CaptureCreateForm, CAPTURE_TOPIC_CREATE_NOTICE } from "@/components/molecules/CaptureCreateForm";
 import { ROUTES } from "@/config/routes";
 import { DIARY_THEME_NAME_MAX_LENGTH } from "@/types/diary/schema";
 import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
+import { RefreshCw } from "lucide-react";
+import type { ReactNode } from "react";
 
 const NEW_TAB_HINT = "새 탭에서 열립니다. 촬영 화면 탭으로 돌아와 업로드를 이어주세요.";
 
@@ -28,51 +30,43 @@ type CaptureDestinationEmptyPanelProps =
       onCreateTheme: (name: string) => void | Promise<void>;
     };
 
+function EmptyDashNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1.5 rounded-xl border border-dashed border-[#e3e0ed] bg-[#fbfaff] p-3.5 text-center">
+      <p className="m-0 text-xs font-medium text-[#756e8a]">{children}</p>
+    </div>
+  );
+}
+
 export function CaptureDestinationEmptyPanel(props: CaptureDestinationEmptyPanelProps) {
   if (props.kind === "agit") {
     return (
-      <div className="flex flex-col gap-3 rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] px-3.5 py-4">
-        <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
-          참여 중인 아지트가 없어요. 아지트를 만들거나 가입한 뒤 이 탭으로 돌아와 주세요.
-        </p>
+      <div className="flex flex-col gap-3">
+        <EmptyDashNote>참여 중인 아지트가 없어요.</EmptyDashNote>
         <p className="m-0 text-[11px] text-[var(--dl-color-text-tertiary)]">{NEW_TAB_HINT}</p>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex items-center gap-2">
           <TextLink
             href={ROUTES.agit.create}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex min-h-10 items-center rounded-[var(--dl-radius-md)] bg-[var(--dl-color-bg-brand)] px-4 text-sm font-medium text-[var(--dl-color-text-inverse)] no-underline"
+            className={`${ui.btn} ${ui.btnPrimary} w-auto no-underline`}
           >
             아지트 만들기
           </TextLink>
-          <TextLink
-            href={ROUTES.agit.root}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex min-h-10 items-center rounded-[var(--dl-radius-md)] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] px-4 text-sm font-medium text-[var(--dl-color-text-primary)] no-underline"
-          >
-            아지트 둘러보기
-          </TextLink>
+          {props.onReload ? (
+            <IconButton variant="surface" label="목록 새로고침" onClick={props.onReload}>
+              <RefreshCw className="size-5" />
+            </IconButton>
+          ) : null}
         </div>
-        {props.onReload ? (
-          <button
-            type="button"
-            className={`${ui.link} cursor-pointer self-start border-0 bg-transparent p-0`}
-            onClick={props.onReload}
-          >
-            참여 아지트 목록 새로고침
-          </button>
-        ) : null}
       </div>
     );
   }
 
   if (props.kind === "topic") {
     return (
-      <div className="flex flex-col gap-3.5 rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] px-3.5 py-4">
-        <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
-          이 아지트에 등록할 토픽이 없어요. 아래에서 바로 만들 수 있어요.
-        </p>
+      <div className="flex flex-col gap-3.5">
+        <EmptyDashNote>아직 토픽이 없어요</EmptyDashNote>
         <CaptureCreateForm
           idPrefix="empty-topic"
           nameLabel="토픽 이름"
@@ -91,10 +85,8 @@ export function CaptureDestinationEmptyPanel(props: CaptureDestinationEmptyPanel
   }
 
   return (
-    <div className="flex flex-col gap-3.5 rounded-[var(--dl-radius-lg)] bg-[var(--dl-color-bg-surface)] px-3.5 py-4">
-      <p className="m-0 text-[13px] leading-5 text-[var(--dl-color-text-secondary)]">
-        다이어리 테마가 없어요. 아래에서 바로 만들 수 있어요.
-      </p>
+    <div className="flex flex-col gap-3.5">
+      <EmptyDashNote>등록된 테마가 없습니다.</EmptyDashNote>
       <CaptureCreateForm
         idPrefix="empty-theme"
         nameLabel="테마 이름"

--- a/components/molecules/CaptureInlineCreateField.tsx
+++ b/components/molecules/CaptureInlineCreateField.tsx
@@ -1,79 +1,93 @@
 "use client";
 
-import { Input, SubmitButton } from "@/components/atoms";
+import { DailyIcon, IconButton } from "@/components/atoms";
+import { ui } from "@/components/atoms/styles";
+import { AnimatedBottomSheet } from "@/components/molecules/AnimatedOverlays";
+import { CaptureCreateForm } from "@/components/molecules/CaptureCreateForm";
 import { useState } from "react";
 
 type CaptureInlineCreateFieldProps = {
   label: string;
+  title: string;
+  idPrefix: string;
+  nameLabel: string;
   placeholder: string;
+  hint: string;
   actionLabel: string;
-  maxLength?: number;
+  maxLength: number;
   busy?: boolean;
   error?: string | null;
+  noticeTitle?: string;
+  noticeBody?: string;
   onSubmit: (value: string) => void | Promise<void>;
 };
 
 export function CaptureInlineCreateField({
   label,
+  title,
+  idPrefix,
+  nameLabel,
   placeholder,
+  hint,
   actionLabel,
   maxLength,
   busy = false,
   error = null,
+  noticeTitle,
+  noticeBody,
   onSubmit,
 }: CaptureInlineCreateFieldProps) {
   const [open, setOpen] = useState(false);
-  const [value, setValue] = useState("");
+  const titleId = `${idPrefix}-sheet-title`;
 
-  if (!open) {
-    return (
+  function handleClose() {
+    if (busy) {
+      return;
+    }
+    setOpen(false);
+  }
+
+  return (
+    <>
       <button
         type="button"
-        className="self-start border-0 bg-transparent p-0 text-[13px] font-medium text-[var(--dl-color-text-brand)]"
+        className={`${ui.link} cursor-pointer border-0 bg-transparent p-0 text-left`}
         onClick={() => setOpen(true)}
       >
         + {label}
       </button>
-    );
-  }
 
-  return (
-    <div className="flex flex-col gap-2 rounded-[12px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-3">
-      <Input
-        value={value}
-        maxLength={maxLength}
-        placeholder={placeholder}
-        variant="daily"
-        disabled={busy}
-        onChange={(event) => setValue(event.target.value)}
-      />
-      <div className="flex flex-wrap gap-2">
-        <SubmitButton
-          type="button"
-          variant="brand"
-          className="!w-auto shrink-0 px-4"
-          disabled={busy || !value.trim()}
-          onClick={() => void onSubmit(value.trim())}
-        >
-          {busy ? "만드는 중…" : actionLabel}
-        </SubmitButton>
-        <button
-          type="button"
-          className="min-h-11 rounded-[var(--dl-radius-md)] px-3 text-[13px] font-medium text-[var(--dl-color-text-secondary)]"
-          disabled={busy}
-          onClick={() => {
-            setOpen(false);
-            setValue("");
-          }}
-        >
-          취소
-        </button>
-      </div>
-      {error ? (
-        <p className="m-0 text-[12px] text-[#d84545]" role="alert">
-          {error}
-        </p>
-      ) : null}
-    </div>
+      <AnimatedBottomSheet
+        open={open}
+        onClose={handleClose}
+        labelledBy={titleId}
+        aria-label={title}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2
+            id={titleId}
+            className="m-0 text-lg font-bold font-[family-name:var(--font-title)] text-[var(--dl-color-text-primary)]"
+          >
+            {title}
+          </h2>
+          <IconButton variant="surface" label="닫기" disabled={busy} onClick={handleClose}>
+            <DailyIcon name="x" size={18} />
+          </IconButton>
+        </div>
+        <CaptureCreateForm
+          idPrefix={idPrefix}
+          nameLabel={nameLabel}
+          placeholder={placeholder}
+          hint={hint}
+          maxLength={maxLength}
+          submitLabel={actionLabel}
+          busy={busy}
+          error={error}
+          noticeTitle={noticeTitle}
+          noticeBody={noticeBody}
+          onSubmit={onSubmit}
+        />
+      </AnimatedBottomSheet>
+    </>
   );
 }

--- a/components/molecules/DiaryDateScrollSection.tsx
+++ b/components/molecules/DiaryDateScrollSection.tsx
@@ -18,7 +18,9 @@ export function DiaryDateScrollSection({ entry, className }: DiaryDateScrollSect
   const dateLabel = formatDiaryDate(entry.date);
   const weekday = formatDiaryWeekday(entry.date);
   const isEmpty = entry.isEmpty || !entry.hasClips;
-  const href = isEmpty ? ROUTES.capture.video : ROUTES.diary.date(entry.date);
+  const href = isEmpty
+    ? ROUTES.capture.videoWith({ destination: "diary" })
+    : ROUTES.diary.date(entry.date);
 
   return (
     <article

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -91,6 +91,7 @@ export { VideoBottomInfo } from "./VideoBottomInfo";
 export { VideoReactionBar } from "./VideoReactionBar";
 export { VideoThumbnailGrid } from "./VideoThumbnailGrid";
 export { CaptureClipOverlays } from "./CaptureClipOverlays";
+export { CaptureCreateForm } from "./CaptureCreateForm";
 export { ThumbnailUpload } from "./ThumbnailUpload";
 
 // --- 7. Chat, Social & Member Molecules ---

--- a/components/organisms/CaptureCameraStage.tsx
+++ b/components/organisms/CaptureCameraStage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DailyIcon } from "@/components/atoms";
+import { toast } from "@/components/ui/toast";
 import type { RecorderStatus } from "@/hooks/useVideoRecorder";
 import { formatRecordCountdown } from "@/lib/video/formatRecordTimer";
 import { unlockShutterAudio } from "@/lib/video/playShutterSound";
@@ -43,6 +44,22 @@ export function CaptureCameraStage({
     };
   }, []);
 
+  useEffect(() => {
+    if (!isPreparing) {
+      return;
+    }
+
+    const toastId = toast.add({
+      type: "loading",
+      title: "영상 변환 중…",
+      timeout: 0,
+    });
+
+    return () => {
+      toast.close(toastId);
+    };
+  }, [isPreparing]);
+
   return (
     <div className="absolute inset-0 z-10">
       <button
@@ -60,15 +77,6 @@ export function CaptureCameraStage({
           role="alert"
         >
           {error}
-        </p>
-      ) : null}
-
-      {isPreparing ? (
-        <p
-          className="absolute inset-x-4 top-20 rounded bg-black/70 px-3 py-2 text-center text-xs text-white"
-          role="status"
-        >
-          영상 변환 중…
         </p>
       ) : null}
 

--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -33,6 +33,7 @@ type CaptureFlowSectionProps = {
   initialAgitUuid?: string;
   initialTopicUuid?: string;
   initialThemeId?: string;
+  initialDestinationKind?: DestinationId;
 };
 
 type PreviewStep = "confirm" | "settings";
@@ -56,10 +57,25 @@ function pickTopicId(topics: UiTopicListItem[], preferred: string): string {
   return selectable[0]?.id ?? "";
 }
 
+function resolveInitialDestinationKind(
+  initialDestinationKind: DestinationId | undefined,
+  initialAgitUuid: string,
+  initialThemeId: string,
+): DestinationId {
+  if (initialAgitUuid) {
+    return "agit";
+  }
+  if (initialDestinationKind === "diary" || initialThemeId) {
+    return "diary";
+  }
+  return "agit";
+}
+
 export function CaptureFlowSection({
   initialAgitUuid = "",
   initialTopicUuid = "",
   initialThemeId = "",
+  initialDestinationKind,
 }: CaptureFlowSectionProps) {
   const router = useRouter();
   const {
@@ -81,7 +97,7 @@ export function CaptureFlowSection({
   const [previewStep, setPreviewStep] = useState<PreviewStep>("confirm");
   const [caption, setCaption] = useState("");
   const [destinationKind, setDestinationKind] = useState<DestinationId>(
-    initialThemeId && !initialAgitUuid ? "diary" : "agit",
+    resolveInitialDestinationKind(initialDestinationKind, initialAgitUuid, initialThemeId),
   );
   const [agits, setAgits] = useState<UiAgit[]>([]);
   const [topics, setTopics] = useState<UiTopicListItem[]>([]);

--- a/components/organisms/CaptureUploadSettingsStage.tsx
+++ b/components/organisms/CaptureUploadSettingsStage.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { SubmitButton } from "@/components/atoms";
+import { CAPTURE_TOPIC_CREATE_NOTICE } from "@/components/molecules/CaptureCreateForm";
 import { CaptureDestinationEmptyPanel } from "@/components/molecules/CaptureDestinationEmptyPanel";
 import { CaptureInlineCreateField } from "@/components/molecules/CaptureInlineCreateField";
 import { DestinationToggle, type DestinationId } from "@/components/molecules/DestinationToggle";
 import { HeaderBackButton, PageContainer, ScreenHeader } from "@/components/molecules";
 import { TopicChip } from "@/components/molecules/TopicChip";
 import type { UiAgit } from "@/types/agit/ui";
+import { DIARY_THEME_NAME_MAX_LENGTH } from "@/types/diary/schema";
 import type { UiDiaryTheme } from "@/types/diary/ui";
 import type { UiTopicListItem } from "@/types/topic/ui";
 import { TOPIC_TITLE_MAX_LENGTH } from "@/types/topic/schema";
@@ -175,11 +177,17 @@ export function CaptureUploadSettingsStage({
                 <CaptureInlineCreateField
                   key={`topic-create-${topics.length}`}
                   label="새 토픽 만들기"
-                  placeholder="토픽 이름"
+                  title="토픽 만들기"
+                  idPrefix="capture-topic-create"
+                  nameLabel="토픽 이름"
+                  placeholder="점심 메뉴"
+                  hint={`최대 ${TOPIC_TITLE_MAX_LENGTH}자`}
                   actionLabel="토픽 만들기"
                   maxLength={TOPIC_TITLE_MAX_LENGTH}
                   busy={creatingInline}
                   error={inlineCreateError}
+                  noticeTitle={CAPTURE_TOPIC_CREATE_NOTICE.title}
+                  noticeBody={CAPTURE_TOPIC_CREATE_NOTICE.body}
                   onSubmit={onCreateTopic}
                 />
               </div>
@@ -209,8 +217,13 @@ export function CaptureUploadSettingsStage({
           <CaptureInlineCreateField
             key={`theme-create-${themes.length}`}
             label="새 테마 만들기"
-            placeholder="테마 이름"
+            title="테마 생성"
+            idPrefix="capture-theme-create"
+            nameLabel="테마 이름"
+            placeholder="예: 맛집 탐방, 운동 기록"
+            hint={`최대 ${DIARY_THEME_NAME_MAX_LENGTH}자`}
             actionLabel="테마 만들기"
+            maxLength={DIARY_THEME_NAME_MAX_LENGTH}
             busy={creatingInline}
             error={inlineCreateError}
             onSubmit={onCreateTheme}
@@ -219,12 +232,12 @@ export function CaptureUploadSettingsStage({
       )}
 
       {destinationError ? (
-        <p className="m-0 text-[12px] text-[#d84545]" role="alert">
+          <p className="m-0 text-[12px] font-semibold text-[var(--dl-color-text-danger)]" role="alert">
           {destinationError}
         </p>
       ) : null}
       {saveError ? (
-        <p className="m-0 text-[12px] text-[#d84545]" role="alert">
+        <p className="m-0 text-[12px] font-semibold text-[var(--dl-color-text-danger)]" role="alert">
           {saveError}
         </p>
       ) : null}

--- a/components/templates/CaptureVideoTemplate.tsx
+++ b/components/templates/CaptureVideoTemplate.tsx
@@ -1,21 +1,25 @@
+import type { DestinationId } from "@/components/molecules/DestinationToggle";
 import { CaptureFlowSection } from "@/components/organisms/CaptureFlowSection";
 
 type CaptureVideoTemplateProps = {
   initialAgitUuid?: string;
   initialTopicUuid?: string;
   initialThemeId?: string;
+  initialDestinationKind?: DestinationId;
 };
 
 export function CaptureVideoTemplate({
   initialAgitUuid,
   initialTopicUuid,
   initialThemeId,
+  initialDestinationKind,
 }: CaptureVideoTemplateProps) {
   return (
     <CaptureFlowSection
       initialAgitUuid={initialAgitUuid}
       initialTopicUuid={initialTopicUuid}
       initialThemeId={initialThemeId}
+      initialDestinationKind={initialDestinationKind}
     />
   );
 }

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -81,11 +81,13 @@ export const ROUTES = {
       agitUuid?: string;
       topicUuid?: string;
       themeId?: string;
+      destination?: "diary" | "agit";
     }) => {
       const params = new URLSearchParams();
       if (query?.agitUuid) params.set("agitUuid", query.agitUuid);
       if (query?.topicUuid) params.set("topicUuid", query.topicUuid);
       if (query?.themeId) params.set("themeId", query.themeId);
+      if (query?.destination) params.set("destination", query.destination);
       const search = params.toString();
       return search ? (`/video?${search}` as const) : ("/video" as const);
     },


### PR DESCRIPTION
## 작업 내용

영상 파일을 고르면 변환 중 안내가 카메라 화면 배너로 떠서, 앱에서 쓰는 토스트로 바꿨습니다. 다이어리에서 하단 카메라로 촬영·업로드 설정에 들어가면 기록 목적지가 아지트로 열려 있어, 다이어리 진입은 다이어리가 선택된 상태가 되게 했습니다. 아지트 UUID가 있는 경로와 그 외 탭은 아지트를 유지합니다.

## 관련 이슈

Close #160

## 변경 사항

### 1. 영상 변환 중 안내를 토스트로 표시

- **파일:** `components/organisms/CaptureCameraStage.tsx`
- **설명:** `preparing`일 때 화면 상단 배너를 제거하고, 기존 `toast`의 loading 타입으로 변환 중을 표시한 뒤 상태가 끝나면 닫습니다.

```tsx
useEffect(() => {
  if (!isPreparing) {
    return;
  }

  const toastId = toast.add({
    type: "loading",
    title: "영상 변환 중…",
    timeout: 0,
  });

  return () => {
    toast.close(toastId);
  };
}, [isPreparing]);
```

### 2. 다이어리 촬영 진입 시 기록 목적지 기본값을 다이어리로 설정

- **파일:** `config/routes.ts`, `app/(capture)/video/page.tsx`, `components/templates/CaptureVideoTemplate.tsx`, `components/organisms/CaptureFlowSection.tsx`, `components/molecules/BottomNavigation.tsx`, `components/molecules/DiaryDateScrollSection.tsx`
- **설명:** `/video?destination=diary` 쿼리를 추가하고, 다이어리 탭 카메라와 빈 날짜 기록 진입에 붙입니다. 아지트 UUID가 있으면 아지트, 아니면 `destination=diary` 또는 `themeId`가 있을 때 다이어리입니다.

```tsx
function resolveInitialDestinationKind(
  initialDestinationKind: DestinationId | undefined,
  initialAgitUuid: string,
  initialThemeId: string,
): DestinationId {
  if (initialAgitUuid) {
    return "agit";
  }
  if (initialDestinationKind === "diary" || initialThemeId) {
    return "diary";
  }
  return "agit";
}
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
