### PR TITLE
Feature: 공개 검색과 메인 랜딩에 최신·추천 아지트를 연결한다

### DIFF
--- a/actions/agitActions.ts
+++ b/actions/agitActions.ts
@@ -6,6 +6,7 @@ import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-
 import { getApiErrorCode } from "@/lib/auth/auth-errors";
 import type { ApiJoinAgitResponse } from "@/types/agit/api";
 import { parseAgitNickname, parseCreateAgitInput, parseUpdateAgitInput } from "@/types/agit/schema";
+import type { ApiDiscoverSort } from "@/types/agit/api";
 import type { UiAgit, UiCreateAgitInput } from "@/types/agit/ui";
 
 function joinAgitErrorMessage(error: ApiError): string {
@@ -18,6 +19,9 @@ function joinAgitErrorMessage(error: ApiError): string {
   }
   if (code === "MEMBER_BANNED") {
     return "이 아지트에서 내보내진 상태입니다.";
+  }
+  if (code === "JOIN_REQUEST_PENDING") {
+    return "이미 입장 요청이 대기 중입니다.";
   }
   if (code === "INVALID_INVITE_CODE" || code === "AGIT_NOT_FOUND") {
     return "유효하지 않은 초대 코드입니다.";
@@ -74,6 +78,77 @@ export async function transferAgitHostAction(
 ): Promise<ActionResult<void>> {
   try {
     await agitService.transferAgitHost(agitId, ampId);
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function searchDiscoverAgitsAction(
+  query: string,
+  sort: ApiDiscoverSort,
+): Promise<ActionResult<UiAgit[]>> {
+  try {
+    const items = await agitService.searchDiscoverAgits({
+      q: query.trim() || undefined,
+      sort,
+    });
+    return actionSuccess(items);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function publishSearchMetricAction(
+  type: string,
+  agitUuid: string,
+): Promise<ActionResult<void>> {
+  try {
+    await agitService.publishSearchMetric(type, agitUuid);
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function requestJoinAgitAction(
+  agitId: string,
+  nickname: unknown,
+): Promise<ActionResult<ApiJoinAgitResponse>> {
+  const parsed = parseAgitNickname(nickname);
+  if (!parsed.ok) {
+    return actionFailure(parsed.error);
+  }
+
+  try {
+    const requested = await agitService.requestJoinAgit(agitId, { nickname: parsed.nickname });
+    return actionSuccess(requested);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return actionFailure(joinAgitErrorMessage(error));
+    }
+    return toActionError(error);
+  }
+}
+
+export async function approveJoinRequestAction(
+  agitId: string,
+  ampId: number,
+): Promise<ActionResult<void>> {
+  try {
+    await agitService.approveJoinRequest(agitId, ampId);
+    return actionSuccess(undefined);
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
+export async function rejectJoinRequestAction(
+  agitId: string,
+  ampId: number,
+): Promise<ActionResult<void>> {
+  try {
+    await agitService.rejectJoinRequest(agitId, ampId);
     return actionSuccess(undefined);
   } catch (error) {
     return toActionError(error);

--- a/app/(agit)/agit/[agitId]/manage/page.tsx
+++ b/app/(agit)/agit/[agitId]/manage/page.tsx
@@ -1,6 +1,7 @@
 import { AgitManageTemplate } from "@/components/templates";
 import { ROUTES } from "@/config/routes";
-import { getAgit } from "@/services/agitService";
+import { getAgit, listJoinRequests } from "@/services/agitService";
+import type { ApiJoinRequestItem } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
 import { redirect } from "next/navigation";
 
@@ -11,9 +12,11 @@ type PageProps = {
 export default async function AgitManagePage({ params }: PageProps) {
   const { agitId } = await params;
   let agit: UiAgit | null = null;
+  let joinRequests: ApiJoinRequestItem[] = [];
 
   try {
     agit = await getAgit(agitId);
+    joinRequests = await listJoinRequests(agitId);
   } catch {
     redirect(ROUTES.agit.detail(agitId));
   }
@@ -22,5 +25,5 @@ export default async function AgitManagePage({ params }: PageProps) {
     redirect(ROUTES.agit.detail(agitId));
   }
 
-  return <AgitManageTemplate agit={agit} />;
+  return <AgitManageTemplate agit={agit} joinRequests={joinRequests} />;
 }

--- a/app/(agit)/agit/[agitId]/preview/page.tsx
+++ b/app/(agit)/agit/[agitId]/preview/page.tsx
@@ -1,0 +1,21 @@
+import { AgitPreviewTemplate } from "@/components/templates";
+import { getAgitPreview } from "@/services/agitService";
+import type { ApiAgitPreview } from "@/types/agit/api";
+
+type PageProps = {
+  params: Promise<{ agitId: string }>;
+};
+
+export default async function AgitPreviewPage({ params }: PageProps) {
+  const { agitId } = await params;
+  let preview: ApiAgitPreview | null = null;
+  let error: string | undefined;
+
+  try {
+    preview = await getAgitPreview(agitId);
+  } catch (caught) {
+    error = caught instanceof Error ? caught.message : "아지트를 불러오지 못했습니다.";
+  }
+
+  return <AgitPreviewTemplate preview={preview} error={error} />;
+}

--- a/app/(agit)/agit/search/page.tsx
+++ b/app/(agit)/agit/search/page.tsx
@@ -1,0 +1,14 @@
+import { AgitSearchTemplate } from "@/components/templates";
+import { listMyAgits } from "@/services/agitService";
+
+export default async function AgitSearchPage() {
+  let myAgitIds: string[] = [];
+
+  try {
+    myAgitIds = (await listMyAgits()).map((agit) => agit.id);
+  } catch {
+    myAgitIds = [];
+  }
+
+  return <AgitSearchTemplate myAgitIds={myAgitIds} />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,25 @@
+import { auth } from "@/auth";
 import { IntroTemplate } from "@/components/templates/IntroTemplate";
+import { searchDiscoverAgits } from "@/services/agitService";
+import type { UiAgit } from "@/types/agit/ui";
 
-export default function IntroPage() {
-  return <IntroTemplate />;
+async function loadDiscover(sort: "new" | "popular"): Promise<UiAgit[]> {
+  try {
+    return await searchDiscoverAgits({ sort, size: 6 });
+  } catch {
+    return [];
+  }
+}
+
+export default async function IntroPage() {
+  const session = await auth();
+  const isLoggedIn = Boolean(session?.isLoggedIn);
+  const [latest, recommended] = await Promise.all([
+    loadDiscover("new"),
+    loadDiscover("popular"),
+  ]);
+
+  return (
+    <IntroTemplate latest={latest} recommended={recommended} isLoggedIn={isLoggedIn} />
+  );
 }

--- a/components/organisms/AgitPreviewSection.tsx
+++ b/components/organisms/AgitPreviewSection.tsx
@@ -91,7 +91,7 @@ export function AgitPreviewSection({
                     {formError}
                   </p>
                 ) : null}
-                <SubmitButton pending={pending}>입장 요청</SubmitButton>
+                <SubmitButton disabled={pending}>{pending ? "요청 중…" : "입장 요청"}</SubmitButton>
               </form>
             )}
           </>

--- a/components/organisms/AgitPreviewSection.tsx
+++ b/components/organisms/AgitPreviewSection.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { requestJoinAgitAction } from "@/actions/agitActions";
+import { SubmitButton, TextLink } from "@/components/atoms";
+import { AuthField, HeaderBackLink, PageContainer, ScreenHeader } from "@/components/molecules";
+import { ROUTES } from "@/config/routes";
+import { publishSearchMetricAction } from "@/actions/agitActions";
+import { AGIT_NICKNAME_MAX_LENGTH } from "@/types/agit/schema";
+import type { ApiAgitPreview } from "@/types/agit/api";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export function AgitPreviewSection({
+  preview,
+  error,
+}: {
+  preview: ApiAgitPreview | null;
+  error?: string;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (preview?.agitUuid) {
+      void publishSearchMetricAction("DETAIL_VIEW", preview.agitUuid);
+    }
+  }, [preview?.agitUuid]);
+
+  async function handleRequest(formData: FormData) {
+    if (!preview || pending) return;
+    setPending(true);
+    setFormError(null);
+    const result = await requestJoinAgitAction(preview.agitUuid, formData.get("nickname"));
+    setPending(false);
+    if (!result.ok) {
+      setFormError(result.error);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      <ScreenHeader
+        leading={<HeaderBackLink href={ROUTES.agit.search} />}
+        title="아지트"
+        titleAlign="center"
+      />
+      <PageContainer aria-label="아지트 미리보기" className="flex-1">
+        {error ? (
+          <p className="m-0 text-sm text-[var(--dl-color-text-secondary)]" role="alert">
+            {error}
+          </p>
+        ) : null}
+        {preview ? (
+          <>
+            <h1 className="m-0 text-xl font-semibold text-[var(--dl-color-text-primary)]">
+              {preview.agitName}
+            </h1>
+            <p className="m-[8px_0_0] text-sm text-[var(--dl-color-text-secondary)]">
+              {preview.description || "소개가 아직 없어요."}
+            </p>
+            <p className="m-[8px_0_0] text-xs text-[var(--dl-color-text-tertiary)]">
+              방장 {preview.hostNickname} · {preview.currentMemberCount}/{preview.maximumCapacity}명
+            </p>
+
+            {preview.myStatus === "ACTIVE" ? (
+              <TextLink
+                href={ROUTES.agit.detail(preview.agitUuid)}
+                className="mt-4 inline-flex text-sm font-semibold text-[var(--dl-color-text-brand)]"
+              >
+                아지트 입장
+              </TextLink>
+            ) : preview.myStatus === "PENDING" ? (
+              <p className="mt-4 text-sm text-[var(--dl-color-text-secondary)]">입장 요청이 대기 중입니다.</p>
+            ) : preview.myStatus === "BANNED" ? (
+              <p className="mt-4 text-sm text-[var(--dl-color-text-secondary)]">이 아지트에서 내보내진 상태입니다.</p>
+            ) : (
+              <form className="mt-4 flex flex-col gap-3" action={handleRequest}>
+                <AuthField
+                  id="join-request-nickname"
+                  name="nickname"
+                  label="닉네임"
+                  placeholder="아지트에서 쓸 이름"
+                  maxLength={AGIT_NICKNAME_MAX_LENGTH}
+                  required
+                />
+                {formError ? (
+                  <p className="m-0 text-sm text-[var(--dl-color-text-secondary)]" role="alert">
+                    {formError}
+                  </p>
+                ) : null}
+                <SubmitButton pending={pending}>입장 요청</SubmitButton>
+              </form>
+            )}
+          </>
+        ) : null}
+      </PageContainer>
+    </div>
+  );
+}

--- a/components/organisms/AgitSubSections.tsx
+++ b/components/organisms/AgitSubSections.tsx
@@ -1,7 +1,15 @@
+"use client";
+
 import { TextLink } from "@/components/atoms";
-import { HeaderBackLink, ScreenHeader } from "@/components/molecules";
+import {
+  HeaderBackLink,
+  PageContainer,
+  ScreenHeader,
+} from "@/components/molecules";
 import { AGIT_MEMBERS, AGIT_TOPICS, getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
+import type { UiAgit } from "@/types/agit/ui";
+import { useEffect, useMemo, useState } from "react";
 
 type AgitIdProps = { agitId: string };
 
@@ -73,23 +81,135 @@ export function AgitTopicsSection({ agitId }: AgitIdProps) {
   );
 }
 
-export function AgitSearchSection() {
+const DISCOVER_SORTS = [
+  { id: "new", label: "신규" },
+  { id: "popular", label: "인기" },
+  { id: "rising", label: "급상승" },
+] as const;
+
+export function AgitSearchSection({ myAgitIds }: { myAgitIds: string[] }) {
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<(typeof DISCOVER_SORTS)[number]["id"]>("new");
+  const [rooms, setRooms] = useState<UiAgit[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const myIds = useMemo(() => new Set(myAgitIds), [myAgitIds]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(async () => {
+      setLoading(true);
+      try {
+        const { publishSearchMetricAction, searchDiscoverAgitsAction } = await import(
+          "@/actions/agitActions"
+        );
+        const result = await searchDiscoverAgitsAction(query, sort);
+        if (cancelled) return;
+        if (!result.ok) {
+          setRooms([]);
+          setError(result.error);
+          return;
+        }
+        setRooms(result.data);
+        setError(null);
+        for (const item of result.data) {
+          void publishSearchMetricAction("SEARCH_IMPRESSION", item.id);
+        }
+      } catch (caught) {
+        if (cancelled) return;
+        setRooms([]);
+        setError(caught instanceof Error ? caught.message : "검색을 불러오지 못했습니다.");
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [query, sort]);
+
   return (
-    <section className="flex flex-1 flex-col bg-[transparent] text-[var(--dc-fg-primary)]" aria-label="아지트 검색">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
-        tone="glass"
         leading={<HeaderBackLink href={ROUTES.agit.root} />}
         title="검색"
         titleAlign="center"
       />
-      <div className="px-4 py-3">
-        <input
-          type="search"
-          placeholder="아지트 · 카테고리 검색"
-          className="border border-[var(--dc-glass-border)] rounded-[var(--dc-radius)] bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] shadow-[var(--dc-shadow)] backdrop-blur-[20px] w-full px-4 py-3 text-sm text-black outline-none"
-        />
-      </div>
-      <p className="px-4 text-xs text-black/45">초대 링크로 입장할 수 있어요.</p>
-    </section>
+
+      <PageContainer aria-label="아지트 검색" className="flex-1">
+        <label className="flex w-full items-center gap-[10px] min-h-12 rounded-[14px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] px-4">
+          <input
+            type="search"
+            value={query}
+            autoFocus
+            placeholder="아지트 이름 검색"
+            className="min-w-0 flex-1 border-0 bg-transparent text-sm leading-5 text-[var(--dl-color-text-primary)] outline-none placeholder:text-[var(--dl-color-text-tertiary)]"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </label>
+
+        <div className="flex gap-2" role="tablist" aria-label="검색 정렬">
+          {DISCOVER_SORTS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={sort === item.id}
+              className={`rounded-full px-3 py-1.5 text-sm font-semibold ${
+                sort === item.id
+                  ? "bg-[var(--dl-color-bg-brand-subtle)] text-[var(--dl-color-text-brand)]"
+                  : "text-[var(--dl-color-text-secondary)]"
+              }`}
+              onClick={() => setSort(item.id)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {error ? (
+          <p className="m-0 text-[14px] text-[var(--dl-color-text-secondary)]" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        {loading ? (
+          <p className="m-0 py-6 text-center text-sm text-[var(--dl-color-text-secondary)]">불러오는 중…</p>
+        ) : rooms.length > 0 ? (
+          <div className="grid grid-cols-2 gap-[12px]">
+            {rooms.map((room) => {
+              const joined = myIds.has(room.id);
+              const href = joined ? ROUTES.agit.detail(room.id) : ROUTES.agit.preview(room.id);
+              return (
+                <TextLink
+                  key={room.id}
+                  href={href}
+                  className="overflow-hidden rounded-[18px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] p-3 text-[inherit] no-underline"
+                  onClick={() => {
+                    void import("@/actions/agitActions").then(({ publishSearchMetricAction }) => {
+                      void publishSearchMetricAction("SEARCH_CLICK", room.id);
+                    });
+                  }}
+                >
+                  <p className="m-0 text-[13px] font-semibold text-[var(--dl-color-text-primary)]">
+                    {room.name}
+                  </p>
+                  <p className="m-[4px_0_0] line-clamp-2 text-[11px] text-[var(--dl-color-text-secondary)]">
+                    {room.description || (joined ? "참여 중" : "입장 요청")}
+                  </p>
+                </TextLink>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="m-0 py-6 text-center text-sm text-[var(--dl-color-text-secondary)]">
+            {query.trim() ? "일치하는 아지트가 없어요" : "아직 검색할 아지트가 없어요."}
+          </p>
+        )}
+      </PageContainer>
+    </div>
   );
 }

--- a/components/organisms/JoinRequestsSection.tsx
+++ b/components/organisms/JoinRequestsSection.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { approveJoinRequestAction, rejectJoinRequestAction } from "@/actions/agitActions";
+import type { ApiJoinRequestItem } from "@/types/agit/api";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function JoinRequestsSection({
+  agitId,
+  requests,
+}: {
+  agitId: string;
+  requests: ApiJoinRequestItem[];
+}) {
+  const router = useRouter();
+  const [pendingId, setPendingId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handle(ampId: number, action: "approve" | "reject") {
+    if (pendingId) return;
+    setPendingId(ampId);
+    setError(null);
+    const result =
+      action === "approve"
+        ? await approveJoinRequestAction(agitId, ampId)
+        : await rejectJoinRequestAction(agitId, ampId);
+    setPendingId(null);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <section className="flex flex-col gap-3" aria-label="입장 요청">
+      <h2 className="m-0 text-base font-semibold text-[var(--dl-color-text-primary)]">입장 요청</h2>
+      {error ? (
+        <p className="m-0 text-sm text-[var(--dl-color-text-secondary)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {requests.length === 0 ? (
+        <p className="m-0 text-sm text-[var(--dl-color-text-secondary)]">대기 중인 요청이 없어요.</p>
+      ) : (
+        requests.map((request) => (
+          <div
+            key={request.ampId}
+            className="flex items-center justify-between gap-3 rounded-2xl border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] p-3"
+          >
+            <span className="text-sm font-semibold text-[var(--dl-color-text-primary)]">
+              {request.nickname}
+            </span>
+            <span className="flex gap-2">
+              <button
+                type="button"
+                disabled={pendingId === request.ampId}
+                className="rounded-full px-3 py-1 text-xs font-semibold text-[var(--dl-color-text-brand)]"
+                onClick={() => void handle(request.ampId, "approve")}
+              >
+                수락
+              </button>
+              <button
+                type="button"
+                disabled={pendingId === request.ampId}
+                className="rounded-full px-3 py-1 text-xs font-semibold text-[var(--dl-color-text-secondary)]"
+                onClick={() => void handle(request.ampId, "reject")}
+              >
+                거절
+              </button>
+            </span>
+          </div>
+        ))
+      )}
+    </section>
+  );
+}

--- a/components/organisms/MainLandingSection.tsx
+++ b/components/organisms/MainLandingSection.tsx
@@ -1,0 +1,161 @@
+import { TextLink } from "@/components/atoms";
+import { ui } from "@/components/atoms/styles";
+import { cn } from "@/lib/utils";
+import { ROUTES } from "@/config/routes";
+import type { UiAgit } from "@/types/agit/ui";
+
+const GUIDE_STEPS = [
+  {
+    step: "1",
+    title: "아지트 찾기",
+    body: "최신·추천 목록에서 목적에 맞는 아지트를 고르거나, 검색으로 이름을 찾습니다.",
+  },
+  {
+    step: "2",
+    title: "입장 요청",
+    body: "닉네임을 넣고 입장 요청을 올리면 방장이 수락한 뒤 함께 기록할 수 있습니다. 초대 링크가 있으면 바로 입장할 수도 있습니다.",
+  },
+  {
+    step: "3",
+    title: "함께 기록",
+    body: "아지트에서 토픽·클립을 올리고, 홈 피드와 다이어리로 일상을 남깁니다.",
+  },
+] as const;
+
+function agitHref(agitId: string, isLoggedIn: boolean) {
+  const preview = ROUTES.agit.preview(agitId);
+  if (isLoggedIn) {
+    return preview;
+  }
+  return `${ROUTES.login}?callbackUrl=${encodeURIComponent(preview)}`;
+}
+
+function AgitRail({
+  title,
+  items,
+  empty,
+  isLoggedIn,
+}: {
+  title: string;
+  items?: UiAgit[];
+  empty: string;
+  isLoggedIn: boolean;
+}) {
+  const rooms = items ?? [];
+  return (
+    <section className="flex flex-col gap-3" aria-label={title}>
+      <div className="flex items-end justify-between gap-3">
+        <h2 className={ui.sectionTitle}>{title}</h2>
+        <TextLink href={isLoggedIn ? ROUTES.agit.search : ROUTES.login} className={cn(ui.link, "text-xs")}>
+          더보기
+        </TextLink>
+      </div>
+      {rooms.length === 0 ? (
+        <p className={ui.hint}>{empty}</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-3">
+          {rooms.map((agit) => (
+            <TextLink
+              key={agit.id}
+              href={agitHref(agit.id, isLoggedIn)}
+              className="overflow-hidden rounded-[18px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] p-3 text-[inherit] no-underline"
+            >
+              <div
+                className="mb-2 aspect-square w-full overflow-hidden rounded-[14px]"
+                style={{ background: agit.coverGradient }}
+                aria-hidden
+              />
+              <p className="m-0 line-clamp-1 text-[13px] font-semibold text-[var(--dl-color-text-primary)]">
+                {agit.name}
+              </p>
+              <p className="m-[4px_0_0] line-clamp-2 text-[11px] text-[var(--dl-color-text-secondary)]">
+                {agit.description || "함께 기록하는 아지트"}
+              </p>
+            </TextLink>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function MainLandingSection({
+  latest,
+  recommended,
+  isLoggedIn,
+}: {
+  latest: UiAgit[];
+  recommended: UiAgit[];
+  isLoggedIn: boolean;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-[390px] flex-col gap-8 px-5 pb-12 pt-6">
+      <header className="flex items-center justify-between gap-3">
+        <p className="m-0 text-lg font-bold text-[var(--dl-color-text-primary)]">PLIP</p>
+        {isLoggedIn ? (
+          <TextLink href={ROUTES.home} className={cn(ui.link, "text-sm")}>
+            피드로
+          </TextLink>
+        ) : (
+          <div className="flex items-center gap-3">
+            <TextLink href={ROUTES.login} className={cn(ui.link, "text-sm")}>
+              로그인
+            </TextLink>
+            <TextLink href={ROUTES.signup} className={cn(ui.btn, ui.btnPrimary, "h-9 w-auto px-3 text-xs")}>
+              시작하기
+            </TextLink>
+          </div>
+        )}
+      </header>
+
+      <section aria-label="소개">
+        <p className={ui.eyebrow}>함께 기록하는 루틴</p>
+        <h1 className={`${ui.title} mt-2`}>
+          목적에 맞는 아지트에서
+          <br />
+          일상을 남기세요
+        </h1>
+        <p className={`${ui.subtitle} mt-2`}>
+          최신·추천 아지트를 둘러보고, 입장 요청으로 합류할 수 있습니다.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-3" aria-label="이용 가이드">
+        <h2 className={ui.sectionTitle}>이렇게 시작해요</h2>
+        <ol className="m-0 flex list-none flex-col gap-2 p-0">
+          {GUIDE_STEPS.map((item) => (
+            <li
+              key={item.step}
+              className="flex gap-3 rounded-[16px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-3.5"
+            >
+              <span className="grid size-8 shrink-0 place-items-center rounded-full bg-[var(--dl-color-bg-brand-subtle)] text-sm font-bold text-[var(--dl-color-text-brand)]">
+                {item.step}
+              </span>
+              <span>
+                <span className="block text-sm font-semibold text-[var(--dl-color-text-primary)]">
+                  {item.title}
+                </span>
+                <span className="mt-1 block text-xs leading-5 text-[var(--dl-color-text-secondary)]">
+                  {item.body}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <AgitRail
+        title="최신 아지트"
+        items={latest}
+        empty="아직 새로 열린 아지트가 없어요."
+        isLoggedIn={isLoggedIn}
+      />
+      <AgitRail
+        title="추천 아지트"
+        items={recommended}
+        empty="추천할 아지트가 아직 없어요. 검색·조회가 쌓이면 여기에 올라갑니다."
+        isLoggedIn={isLoggedIn}
+      />
+    </div>
+  );
+}

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -15,6 +15,8 @@ export { AgitMenuDrawer } from "./AgitMenuDrawer";
 export { AgitDetailSection } from "./AgitDetailSection";
 export { AgitListSection } from "./AgitListSection";
 export { AgitManageForm } from "./AgitManageForm";
+export { AgitPreviewSection } from "./AgitPreviewSection";
+export { JoinRequestsSection } from "./JoinRequestsSection";
 export { AgitLandingDetail } from "./AgitLandingDetail";
 export { AgitProfileEditForm } from "./AgitProfileEditForm";
 export {
@@ -92,6 +94,7 @@ export { InvitesSafetySection } from "./InvitesSafetySection";
 export { HomeFeedSection } from "./HomeFeedSection";
 export { HeroSection } from "./HeroSection";
 export { WelcomeSection } from "./WelcomeSection";
+export { MainLandingSection } from "./MainLandingSection";
 export { ExploreSection } from "./ExploreSection";
 export {
   ShopChargeSection,

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -1,4 +1,5 @@
 import { TextLink } from "@/components/atoms";
+import { AgitPreviewSection } from "@/components/organisms/AgitPreviewSection";
 import {
   AgitSearchSection,
 } from "@/components/organisms/AgitSubSections";
@@ -8,7 +9,7 @@ import { AgitListSection } from "@/components/organisms/AgitListSection";
 import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
 import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
 import { ROUTES } from "@/config/routes";
-import type { ApiAgitDetailMember } from "@/types/agit/api";
+import type { ApiAgitDetailMember, ApiAgitPreview } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiChatHistory } from "@/types/chat/ui";
 import type { UiTopicGallery } from "@/types/topic/ui";
@@ -105,10 +106,28 @@ export function AgitChatTemplate({
   );
 }
 
-export function AgitSearchTemplate() {
+export function AgitPreviewTemplate({
+  preview,
+  error,
+}: {
+  preview: ApiAgitPreview | null;
+  error?: string;
+}) {
   return (
     <AppChromeTemplate activeTab="agit" variant="light" showNav={false}>
-      <AgitSearchSection />
+      <AgitPreviewSection preview={preview} error={error} />
+    </AppChromeTemplate>
+  );
+}
+
+export function AgitSearchTemplate({
+  myAgitIds,
+}: {
+  myAgitIds: string[];
+}) {
+  return (
+    <AppChromeTemplate activeTab="agit" variant="light" showNav={false}>
+      <AgitSearchSection myAgitIds={myAgitIds} />
     </AppChromeTemplate>
   );
 }

--- a/components/templates/HomeFeedTemplate.tsx
+++ b/components/templates/HomeFeedTemplate.tsx
@@ -1,5 +1,5 @@
 import { HomeFeedSection } from "@/components/organisms/HomeFeedSection";
-import { BottomNavigation } from "@/components/molecules";
+import { BottomNavigation, FeedTopBar } from "@/components/molecules";
 
 export function HomeFeedTemplate() {
   return (
@@ -9,6 +9,7 @@ export function HomeFeedTemplate() {
           <HomeFeedSection />
         </main>
       </div>
+      <FeedTopBar />
       <BottomNavigation active="feed" variant="feed" />
     </div>
   );

--- a/components/templates/IntroTemplate.tsx
+++ b/components/templates/IntroTemplate.tsx
@@ -1,10 +1,18 @@
-import { WelcomeSection } from "@/components/organisms/WelcomeSection";
-import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTemplate";
+import { MainLandingSection } from "@/components/organisms/MainLandingSection";
+import type { UiAgit } from "@/types/agit/ui";
 
-export function IntroTemplate() {
+export function IntroTemplate({
+  latest = [],
+  recommended = [],
+  isLoggedIn = false,
+}: {
+  latest?: UiAgit[];
+  recommended?: UiAgit[];
+  isLoggedIn?: boolean;
+}) {
   return (
-    <DailyLoopAuthTemplate>
-      <WelcomeSection />
-    </DailyLoopAuthTemplate>
+    <main className="min-h-0 h-full w-full overflow-y-auto bg-[var(--dl-color-bg-elevated)] text-[var(--dl-color-text-primary)]">
+      <MainLandingSection latest={latest} recommended={recommended} isLoggedIn={isLoggedIn} />
+    </main>
   );
 }

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -1,6 +1,7 @@
 import { TextLink } from "@/components/atoms";
 import { AuthTopBar, PageContainer, ScreenHeader } from "@/components/molecules";
 import { AgitManageForm } from "@/components/organisms/AgitManageForm";
+import { JoinRequestsSection } from "@/components/organisms/JoinRequestsSection";
 import { AgitProfileEditForm } from "@/components/organisms/AgitProfileEditForm";
 import { InvitesSafetySection } from "@/components/organisms/InvitesSafetySection";
 import { MembersPermissionsSection } from "@/components/organisms/MembersPermissionsSection";
@@ -14,7 +15,7 @@ import { DailyLoopAuthTemplate } from "@/components/templates/DailyLoopAuthTempl
 import { getAgitById } from "@/config/agit-mock";
 import { ROUTES } from "@/config/routes";
 import { shouldShowTopicCaptureSlot } from "@/lib/topic/selectAgitTopic";
-import type { ApiAgitDetailMember } from "@/types/agit/api";
+import type { ApiAgitDetailMember, ApiJoinRequestItem } from "@/types/agit/api";
 import type { UiAgit } from "@/types/agit/ui";
 import type { UiTopicDetail, UiTopicFeedWindow, UiTopicListSections, UiTopicVideo } from "@/types/topic/ui";
 
@@ -31,12 +32,19 @@ function RoomMissing() {
   );
 }
 
-export function RoomManageHubTemplate({ agit }: { agit: UiAgit | null }) {
+export function RoomManageHubTemplate({
+  agit,
+  joinRequests = [],
+}: {
+  agit: UiAgit | null;
+  joinRequests?: ApiJoinRequestItem[];
+}) {
   if (!agit) return <RoomMissing />;
 
   return (
     <AgitFlowChrome>
       <AuthTopBar title="아지트관리" backHref={ROUTES.agit.detail(agit.id)} />
+      <JoinRequestsSection agitId={agit.id} requests={joinRequests} />
       <AgitManageForm agit={agit} />
     </AgitFlowChrome>
   );

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -9,6 +9,7 @@ export {
   AgitListTemplate,
   AgitMembersTemplate,
   AgitSearchTemplate,
+  AgitPreviewTemplate,
   AgitTopicsTemplate,
   AgitManageTemplate,
   AgitProfileEditTemplate,

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -46,6 +46,17 @@ export const API_ENDPOINTS = {
       gatewayPath("agit", `/api/v1/agits/${encodeURIComponent(code)}/landing`),
     join: (code: string) =>
       gatewayPath("agit", `/api/v1/agits/${encodeURIComponent(code)}/join`),
+    preview: (agitUuid: string) => gatewayPath("agit", `/api/v1/agits/${agitUuid}/preview`),
+    joinRequests: (agitUuid: string) =>
+      gatewayPath("agit", `/api/v1/agits/${agitUuid}/join-requests`),
+    approveJoinRequest: (agitUuid: string, ampId: number) =>
+      gatewayPath("agit", `/api/v1/agits/${agitUuid}/join-requests/${ampId}/approve`),
+    rejectJoinRequest: (agitUuid: string, ampId: number) =>
+      gatewayPath("agit", `/api/v1/agits/${agitUuid}/join-requests/${ampId}/reject`),
+  },
+  analytics: {
+    search: gatewayPath("analytics", "/api/v1/agits/search"),
+    events: gatewayPath("analytics", "/api/v1/events"),
   },
   topic: {
     list: gatewayPath("topic", "/api/v1/topics"),

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -47,6 +47,7 @@ export const ROUTES = {
     poll: (agitId: string) => `/agit/${agitId}/chat/poll` as const,
     pollEdit: (agitId: string) => `/agit/${agitId}/chat/poll/edit` as const,
     search: "/agit/search",
+    preview: (agitId: string) => `/agit/${agitId}/preview` as const,
     join: (code: string) => `/agit/join/${encodeURIComponent(code)}` as const,
     joinProfile: (code: string) => `/agit/join/${encodeURIComponent(code)}/profile` as const,
   },

--- a/lib/api/agitApi.ts
+++ b/lib/api/agitApi.ts
@@ -12,8 +12,10 @@ import type {
   ApiUpdateAgitResponse,
   ApiReissueInviteCodeResponse,
   ApiAgitLanding,
+  ApiAgitPreview,
   ApiJoinAgitRequest,
   ApiJoinAgitResponse,
+  ApiJoinRequestItem,
   ApiUpdateMyMemberProfileRequest,
   ApiUpdateMyMemberProfileResponse,
 } from "@/types/agit/api";
@@ -109,6 +111,60 @@ export async function getAgitLanding(code: string): Promise<ApiAgitLanding> {
     baseUrl: getApiUrl(),
     headers: await getActorUserHeaders(),
   });
+}
+
+export async function getAgitPreview(agitUuid: string): Promise<ApiAgitPreview> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiAgitPreview>(API_ENDPOINTS.agit.preview(agitUuid), {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function requestJoinAgit(
+  agitUuid: string,
+  body: ApiJoinAgitRequest,
+): Promise<ApiJoinAgitResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiJoinAgitResponse>(API_ENDPOINTS.agit.joinRequests(agitUuid), {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      body,
+    }),
+  );
+}
+
+export async function listJoinRequests(agitUuid: string): Promise<ApiJoinRequestItem[]> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiJoinRequestItem[]>(API_ENDPOINTS.agit.joinRequests(agitUuid), {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function approveJoinRequest(agitUuid: string, ampId: number): Promise<ApiJoinAgitResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiJoinAgitResponse>(API_ENDPOINTS.agit.approveJoinRequest(agitUuid, ampId), {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function rejectJoinRequest(agitUuid: string, ampId: number): Promise<void> {
+  await withAuthRetry(async () =>
+    apiFetch<void>(API_ENDPOINTS.agit.rejectJoinRequest(agitUuid, ampId), {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
 }
 
 export async function joinAgit(code: string, body: ApiJoinAgitRequest): Promise<ApiJoinAgitResponse> {

--- a/lib/api/analyticsApi.ts
+++ b/lib/api/analyticsApi.ts
@@ -1,0 +1,36 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { getActorUserHeaders } from "@/lib/api/actorHeaders";
+import { apiFetch } from "@/lib/api/apiFetch";
+import { getApiUrl } from "@/lib/api/env";
+import { withAuthRetry } from "@/lib/api/withAuthRetry";
+import type { ApiDiscoverSearchPage, ApiDiscoverSort } from "@/types/agit/api";
+
+export async function searchDiscoverAgits(input: {
+  q?: string;
+  sort?: ApiDiscoverSort;
+  page?: number;
+  size?: number;
+}): Promise<ApiDiscoverSearchPage> {
+  return apiFetch<ApiDiscoverSearchPage>(API_ENDPOINTS.analytics.search, {
+    method: "GET",
+    baseUrl: getApiUrl(),
+    auth: false,
+    searchParams: {
+      q: input.q,
+      sort: input.sort,
+      page: input.page == null ? undefined : String(input.page),
+      size: input.size == null ? undefined : String(input.size),
+    },
+  });
+}
+
+export async function publishAnalyticsEvent(type: string, agitUuid: string): Promise<void> {
+  await withAuthRetry(async () =>
+    apiFetch<void>(API_ENDPOINTS.analytics.events, {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      body: { type, agitUuid },
+    }),
+  );
+}

--- a/services/agitService.ts
+++ b/services/agitService.ts
@@ -4,14 +4,19 @@ import * as chatService from "@/services/chatService";
 import type {
   ApiAgitDetail,
   ApiAgitLanding,
+  ApiAgitPreview,
   ApiCreateAgitRequest,
   ApiCreateAgitResponse,
+  ApiDiscoverSearchPage,
+  ApiDiscoverSort,
   ApiJoinAgitResponse,
+  ApiJoinRequestItem,
   ApiMyAgitItem,
   ApiUpdateAgitRequest,
   ApiUpdateMyMemberProfileRequest,
   ApiUpdateMyMemberProfileResponse,
 } from "@/types/agit/api";
+import * as analyticsApi from "@/lib/api/analyticsApi";
 import type { UiAgit, UiCreateAgitInput } from "@/types/agit/ui";
 
 export { sortAgitMembers } from "@/lib/agit/sortMembers";
@@ -180,6 +185,63 @@ export async function joinAgitByCode(
     nickname: input.nickname,
     ...(input.profileImagePath ? { profileImagePath: input.profileImagePath } : {}),
   });
+}
+
+export async function searchDiscoverAgits(input: {
+  q?: string;
+  sort?: ApiDiscoverSort;
+  size?: number;
+}): Promise<UiAgit[]> {
+  const page: ApiDiscoverSearchPage = await analyticsApi.searchDiscoverAgits({
+    q: input.q,
+    sort: input.sort,
+    page: 0,
+    size: input.size ?? 30,
+  });
+  return page.items.map((item) => ({
+    id: item.agitUuid,
+    name: item.agitName,
+    memberCount: 0,
+    description: item.description ?? "",
+    coverGradient: DEFAULT_COVER_GRADIENT,
+    topicCount: 0,
+    thumbnailSrc: toRenderableThumbnail(item.thumbnailPath),
+    joined: false,
+  }));
+}
+
+export async function publishSearchMetric(type: string, agitUuid: string): Promise<void> {
+  try {
+    await analyticsApi.publishAnalyticsEvent(type, agitUuid);
+  } catch {
+    // 검색은 지표 발행 실패와 무관하게 동작
+  }
+}
+
+export async function getAgitPreview(agitId: string): Promise<ApiAgitPreview> {
+  return agitApi.getAgitPreview(agitId);
+}
+
+export async function requestJoinAgit(
+  agitId: string,
+  input: { nickname: string; profileImagePath?: string },
+): Promise<ApiJoinAgitResponse> {
+  return agitApi.requestJoinAgit(agitId, {
+    nickname: input.nickname,
+    ...(input.profileImagePath ? { profileImagePath: input.profileImagePath } : {}),
+  });
+}
+
+export async function listJoinRequests(agitId: string): Promise<ApiJoinRequestItem[]> {
+  return agitApi.listJoinRequests(agitId);
+}
+
+export async function approveJoinRequest(agitId: string, ampId: number): Promise<void> {
+  await agitApi.approveJoinRequest(agitId, ampId);
+}
+
+export async function rejectJoinRequest(agitId: string, ampId: number): Promise<void> {
+  await agitApi.rejectJoinRequest(agitId, ampId);
 }
 
 export async function createAgit(input: UiCreateAgitInput): Promise<UiAgit> {

--- a/types/agit/api.ts
+++ b/types/agit/api.ts
@@ -107,3 +107,39 @@ export type ApiJoinAgitResponse = {
   profileImagePath: string | null;
   role: ApiAgitMemberRole;
 };
+
+export type ApiAgitPreview = {
+  agitUuid: string;
+  agitName: string;
+  description: string | null;
+  currentMemberCount: number;
+  maximumCapacity: number;
+  hostNickname: string;
+  thumbnailPath: string | null;
+  myStatus: "ACTIVE" | "PENDING" | "LEFT" | "BANNED" | null;
+};
+
+export type ApiJoinRequestItem = {
+  ampId: number;
+  userUuid: string;
+  nickname: string;
+  profileImagePath: string | null;
+};
+
+export type ApiDiscoverSort = "new" | "popular" | "rising";
+
+export type ApiDiscoverAgitItem = {
+  agitUuid: string;
+  agitName: string;
+  description: string | null;
+  thumbnailPath: string | null;
+  createdAt: string | null;
+  score: number | null;
+};
+
+export type ApiDiscoverSearchPage = {
+  items: ApiDiscoverAgitItem[];
+  page: number;
+  size: number;
+  total: number;
+};


### PR DESCRIPTION
## Summary
- 메인(/)을 공개 랜딩으로 바꿔 이용 가이드와 최신·추천 아지트를 보여준다
- /agit/search에서 신규/인기/급상승 검색과 입장 요청 흐름을 연결한다
- analytics 이벤트(노출/클릭)와 미리보기 페이지를 붙인다

## Test plan
- [ ] /에서 가이드·최신·추천 섹션이 보이는지 확인
- [ ] /agit/search 탭(신규/인기/급상승)과 검색이 동작하는지 확인
- [ ] 비회원 카드 → 로그인 후 미리보기, 회원은 입장 요청이 가는지 확인
- [ ] analytics 다운 시에도 앱 나머지 기능이 살아있는지 확인

Made with [Cursor](https://cursor.com)