### PR TITLE
Feature: 로그인 후 홈으로 보내고 알림·썸네일 업로드를 연결한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ AGENTS.md
 CLAUDE.md
 .cursor/
 .cursorrules
+
+# generated profile photo uploads (seed files stay tracked)
+/public/images/profile/*_*
+
+# local notification inbox fallback
+/.data/

--- a/actions/agitActions.ts
+++ b/actions/agitActions.ts
@@ -2,6 +2,7 @@
 
 import { ApiError } from "@/lib/api/apiFetch";
 import * as agitService from "@/services/agitService";
+import { notifyJoinOutcome } from "@/services/notificationService";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import { getApiErrorCode } from "@/lib/auth/auth-errors";
 import type { ApiJoinAgitResponse } from "@/types/agit/api";
@@ -84,6 +85,13 @@ export async function transferAgitHostAction(
   }
 }
 
+const DISCOVER_SEARCH_UNAVAILABLE =
+  "랭킹·검색을 잠시 불러올 수 없어요. 잠시 후 다시 시도해 주세요.";
+
+function toDiscoverSearchError(): ActionResult<never> {
+  return actionFailure(DISCOVER_SEARCH_UNAVAILABLE);
+}
+
 export async function searchDiscoverAgitsAction(
   query: string,
   sort: ApiDiscoverSort,
@@ -94,8 +102,8 @@ export async function searchDiscoverAgitsAction(
       sort,
     });
     return actionSuccess(items);
-  } catch (error) {
-    return toActionError(error);
+  } catch {
+    return toDiscoverSearchError();
   }
 }
 
@@ -131,12 +139,38 @@ export async function requestJoinAgitAction(
   }
 }
 
+type JoinDecisionNotify = {
+  requesterUserUuid?: string;
+  agitName?: string;
+};
+
+async function notifyJoinDecision(
+  agitId: string,
+  approved: boolean,
+  notify?: JoinDecisionNotify,
+): Promise<void> {
+  const requesterUserUuid = notify?.requesterUserUuid?.trim();
+  if (!requesterUserUuid) return;
+  try {
+    await notifyJoinOutcome({
+      requesterUserUuid,
+      agitId,
+      agitName: notify?.agitName?.trim() || "아지트",
+      approved,
+    });
+  } catch {
+    // 승인/거절 자체는 성공. 알림 기록 실패는 무시.
+  }
+}
+
 export async function approveJoinRequestAction(
   agitId: string,
   ampId: number,
+  notify?: JoinDecisionNotify,
 ): Promise<ActionResult<void>> {
   try {
     await agitService.approveJoinRequest(agitId, ampId);
+    await notifyJoinDecision(agitId, true, notify);
     return actionSuccess(undefined);
   } catch (error) {
     return toActionError(error);
@@ -146,9 +180,11 @@ export async function approveJoinRequestAction(
 export async function rejectJoinRequestAction(
   agitId: string,
   ampId: number,
+  notify?: JoinDecisionNotify,
 ): Promise<ActionResult<void>> {
   try {
     await agitService.rejectJoinRequest(agitId, ampId);
+    await notifyJoinDecision(agitId, false, notify);
     return actionSuccess(undefined);
   } catch (error) {
     return toActionError(error);

--- a/actions/notificationActions.ts
+++ b/actions/notificationActions.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { toUserActionError } from "@/lib/action/userActionError";
+import * as notificationService from "@/services/notificationService";
+import * as userService from "@/services/userService";
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import type { UiNotificationInbox, UiNotificationItem } from "@/types/notification/ui";
+
+export async function getNotificationInboxAction(): Promise<ActionResult<UiNotificationInbox>> {
+  try {
+    return actionSuccess(await notificationService.ensureSeededInbox());
+  } catch (error) {
+    return toUserActionError(error);
+  }
+}
+
+export async function getUnreadNotificationCountAction(): Promise<ActionResult<number>> {
+  try {
+    return actionSuccess(await notificationService.getUnreadNotificationCount());
+  } catch (error) {
+    return toUserActionError(error);
+  }
+}
+
+export async function markNotificationReadAction(
+  id: string,
+): Promise<ActionResult<UiNotificationItem | void>> {
+  try {
+    return actionSuccess(await notificationService.markNotificationRead(id));
+  } catch (error) {
+    return toUserActionError(error);
+  }
+}
+
+export async function markAllNotificationsReadAction(): Promise<ActionResult<number>> {
+  try {
+    return actionSuccess(await notificationService.markAllNotificationsRead());
+  } catch (error) {
+    return toUserActionError(error);
+  }
+}
+
+export async function markInboxNotificationReadAction(
+  id: string,
+): Promise<ActionResult<void>> {
+  try {
+    const profile = await userService.getMyProfile();
+    await notificationService.markInboxRead(id, profile.userUuid);
+    return actionSuccess(undefined);
+  } catch (error) {
+    if (error instanceof Error) {
+      return actionFailure(error.message);
+    }
+    return actionFailure("알림을 읽음 처리하지 못했어요.");
+  }
+}

--- a/actions/userActions.ts
+++ b/actions/userActions.ts
@@ -4,6 +4,8 @@ import { signOut } from "@/auth";
 import * as authService from "@/services/authService";
 import * as userService from "@/services/userService";
 import { toUserActionError } from "@/lib/action/userActionError";
+import { ApiError } from "@/lib/api/apiFetch";
+import { saveProfileImageFile } from "@/lib/user/saveProfileImage";
 import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import type { UiAuthTokens } from "@/types/auth/ui";
 import type { UiNotificationSettings, UiTermsAgreementItem, UiUserProfile } from "@/types/user/ui";
@@ -11,7 +13,6 @@ import {
   USER_NICKNAME_MAX_LENGTH,
   USER_NICKNAME_MIN_LENGTH,
 } from "@/types/user/ui";
-import { ApiError } from "@/lib/api/apiFetch";
 
 function parseNickname(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") {
@@ -34,20 +35,35 @@ export async function getMyProfileAction(): Promise<ActionResult<UiUserProfile>>
 }
 
 export async function updateMyProfileAction(
-  nickname: FormDataEntryValue | null,
+  formData: FormData,
 ): Promise<ActionResult<UiUserProfile>> {
-  const parsed = parseNickname(nickname);
-  if (!parsed) {
+  const nicknameValue = formData.get("nickname");
+  const imageValue = formData.get("profileImage");
+  const imageFile = imageValue instanceof File && imageValue.size > 0 ? imageValue : null;
+
+  const parsed = parseNickname(nicknameValue);
+  if (nicknameValue != null && String(nicknameValue).trim() !== "" && !parsed) {
+    return actionFailure(`닉네임은 ${USER_NICKNAME_MIN_LENGTH}~${USER_NICKNAME_MAX_LENGTH}자여야 합니다.`);
+  }
+  if (!parsed && !imageFile) {
     return actionFailure(`닉네임은 ${USER_NICKNAME_MIN_LENGTH}~${USER_NICKNAME_MAX_LENGTH}자여야 합니다.`);
   }
 
   try {
     const current = await userService.getMyProfile();
-    if (current.nickname === parsed) {
-      return actionFailure("현재 사용 중인 닉네임과 동일합니다.");
+    const nicknameChanged = Boolean(parsed && parsed !== current.nickname);
+    const profileImagePath = imageFile
+      ? await saveProfileImageFile(current.userUuid, imageFile)
+      : undefined;
+
+    if (!nicknameChanged && !profileImagePath) {
+      return actionFailure("변경 사항이 없습니다.");
     }
 
-    const profile = await userService.updateMyProfile({ nickname: parsed });
+    const profile = await userService.updateMyProfile({
+      ...(nicknameChanged && parsed ? { nickname: parsed } : {}),
+      ...(profileImagePath ? { profileImagePath } : {}),
+    });
     return actionSuccess(profile);
   } catch (error) {
     return toUserActionError(error);

--- a/actions/videoActions.ts
+++ b/actions/videoActions.ts
@@ -6,6 +6,7 @@ import type {
   VideoDestinationActionData,
   VideoDetailActionData,
   VideoDownloadUrlActionData,
+  VideoThumbnailUploadUrlActionData,
   VideoUploadUrlActionData,
 } from "@/types/video/action";
 import type { VideoDestinationRequest } from "@/types/video/api";
@@ -22,6 +23,7 @@ import {
   toCompleteActionData,
   toDetailActionData,
   toDownloadUrlActionData,
+  toThumbnailUploadUrlActionData,
   toUploadUrlActionData,
 } from "@/lib/video/actionPayload";
 import * as videoService from "@/services/videoService";
@@ -30,6 +32,8 @@ const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const ALLOWED_CONTENT_TYPES = new Set(["video/mp4", "video/quicktime"]);
+const ALLOWED_THUMBNAIL_CONTENT_TYPES = new Set(["image/jpeg"]);
+const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
 
 async function requireSessionUserUuid(): Promise<
   { ok: true; userUuid: string } | { ok: false; error: string }
@@ -58,6 +62,15 @@ function resolveContentType(contentType?: string): string | undefined {
 
   const normalized = contentType.trim().toLowerCase();
   return ALLOWED_CONTENT_TYPES.has(normalized) ? normalized : undefined;
+}
+
+function resolveThumbnailContentType(contentType?: string): string | undefined {
+  if (!contentType?.trim()) {
+    return "image/jpeg";
+  }
+
+  const normalized = contentType.trim().toLowerCase();
+  return ALLOWED_THUMBNAIL_CONTENT_TYPES.has(normalized) ? normalized : undefined;
 }
 
 function toActionError(error: unknown): ActionResult<never> {
@@ -108,9 +121,50 @@ export async function issueUploadUrlAction(
   }
 }
 
+export async function issueThumbnailUploadUrlAction(
+  videoUuid: string,
+  contentType: string | undefined,
+  contentLengthBytes: number,
+): Promise<ActionResult<VideoThumbnailUploadUrlActionData>> {
+  const resolvedVideoUuid = resolveVideoUuid(videoUuid);
+  if (!resolvedVideoUuid) {
+    return actionFailure("Invalid videoUuid");
+  }
+
+  const session = await requireSessionUserUuid();
+  if (!session.ok) {
+    return actionFailure(session.error);
+  }
+
+  const resolvedContentType = resolveThumbnailContentType(contentType);
+  if (!resolvedContentType) {
+    return actionFailure("contentType must be image/jpeg");
+  }
+
+  if (!Number.isFinite(contentLengthBytes) || contentLengthBytes <= 0) {
+    return actionFailure("contentLengthBytes must be a positive number");
+  }
+
+  if (contentLengthBytes > MAX_THUMBNAIL_BYTES) {
+    return actionFailure("thumbnail must be 2MB or smaller");
+  }
+
+  try {
+    const data = await videoService.issueThumbnailUploadUrl(
+      resolvedVideoUuid,
+      resolvedContentType,
+      contentLengthBytes,
+    );
+    return actionSuccess(toThumbnailUploadUrlActionData(data));
+  } catch (error) {
+    return toActionError(error);
+  }
+}
+
 export async function completeVideoAction(
   videoUuid: string,
   caption?: string,
+  thumbnailS3Key?: string,
 ): Promise<ActionResult<VideoCompleteActionData>> {
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);
   if (!resolvedVideoUuid) {
@@ -123,11 +177,13 @@ export async function completeVideoAction(
   }
 
   const normalizedCaption = caption?.trim() || undefined;
+  const normalizedThumbnailS3Key = thumbnailS3Key?.trim() || undefined;
 
   try {
     const data = await videoService.completeVideo(
       resolvedVideoUuid,
       normalizedCaption,
+      normalizedThumbnailS3Key,
     );
     return actionSuccess(toCompleteActionData(data));
   } catch (error) {

--- a/app/(agit)/agit/page.tsx
+++ b/app/(agit)/agit/page.tsx
@@ -1,5 +1,6 @@
 import { AgitListTemplate } from "@/components/templates";
 import { listMyAgits } from "@/services/agitService";
+import { getInboxUnreadCount } from "@/services/notificationService";
 import { getServerUserUuid } from "@/lib/auth/server-token";
 import { isEnableRemoteChatEnabled } from "@/lib/api/env";
 import type { UiAgit } from "@/types/agit/ui";
@@ -7,6 +8,7 @@ import type { UiAgit } from "@/types/agit/ui";
 export default async function AgitListPage() {
   let items: UiAgit[] = [];
   let error: string | undefined;
+  let inboxUnreadCount = 0;
   const currentUserUuid = await getServerUserUuid();
   const enableRemoteChat = isEnableRemoteChatEnabled();
 
@@ -18,12 +20,21 @@ export default async function AgitListPage() {
       caught instanceof Error ? caught.message : "아지트 목록을 불러오지 못했습니다.";
   }
 
+  if (currentUserUuid) {
+    try {
+      inboxUnreadCount = await getInboxUnreadCount(currentUserUuid);
+    } catch {
+      inboxUnreadCount = 0;
+    }
+  }
+
   return (
     <AgitListTemplate
       items={items}
       error={error}
       currentUserUuid={currentUserUuid}
       enableRemoteChat={enableRemoteChat}
+      inboxUnreadCount={inboxUnreadCount}
     />
   );
 }

--- a/app/(home)/notifications/page.tsx
+++ b/app/(home)/notifications/page.tsx
@@ -1,0 +1,15 @@
+import { NotificationInboxTemplate } from "@/components/templates";
+import * as notificationService from "@/services/notificationService";
+import type { UiNotificationInbox } from "@/types/notification/ui";
+
+const EMPTY_INBOX: UiNotificationInbox = { items: [], unreadCount: 0 };
+
+export default async function NotificationsPage() {
+  let inbox = EMPTY_INBOX;
+  try {
+    inbox = await notificationService.ensureSeededInbox();
+  } catch {
+    inbox = EMPTY_INBOX;
+  }
+  return <NotificationInboxTemplate inbox={inbox} />;
+}

--- a/app/(mypage)/mypage/inbox/page.tsx
+++ b/app/(mypage)/mypage/inbox/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+import { ROUTES } from "@/config/routes";
+
+export default function NotificationInboxRedirectPage() {
+  redirect(ROUTES.notifications);
+}

--- a/app/(mypage)/mypage/page.tsx
+++ b/app/(mypage)/mypage/page.tsx
@@ -1,14 +1,18 @@
 import { MyPageTemplate } from "@/components/templates";
+import { getInboxUnreadCount } from "@/services/notificationService";
 import * as userService from "@/services/userService";
 
 export default async function MyPage() {
   let profile = null;
+  let inboxUnreadCount = 0;
 
   try {
     profile = await userService.getMyProfile();
+    inboxUnreadCount = await getInboxUnreadCount(profile.userUuid);
   } catch {
     profile = null;
+    inboxUnreadCount = 0;
   }
 
-  return <MyPageTemplate profile={profile} />;
+  return <MyPageTemplate profile={profile} inboxUnreadCount={inboxUnreadCount} />;
 }

--- a/auth.ts
+++ b/auth.ts
@@ -7,6 +7,7 @@ import Google from "next-auth/providers/google";
 import Kakao from "next-auth/providers/kakao";
 import type { NextRequest } from "next/server";
 import authConfig from "@/auth.config";
+import { ROUTES } from "@/config/routes";
 import { ApiError } from "@/lib/api/apiFetch";
 import { AUTH_ERROR_CODES, getApiErrorCode } from "@/lib/auth/auth-errors";
 import { saveSocialSignupPendingToken } from "@/lib/auth/social-signup-pending";
@@ -68,6 +69,7 @@ const NaverProvider: Provider = {
 const GUEST_ONLY_PREFIXES = ["/login", "/signup", "/forgot-password", "/reset-password"];
 const PROTECTED_PREFIXES = [
   "/home",
+  "/notifications",
   "/diary",
   "/agit",
   "/mypage",
@@ -207,7 +209,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const isLoggedIn = session?.isLoggedIn === true;
 
       if (matchesPrefix(pathname, GUEST_ONLY_PREFIXES) && isLoggedIn) {
-        return Response.redirect(new URL("/diary", request.nextUrl));
+        return Response.redirect(new URL(ROUTES.home, request.nextUrl));
       }
 
       // 방 가입 랜딩 페이지(/agit/join/[code])는 비로그인 상태에서도 접근 허용

--- a/components/molecules/CaptureThumbnailField.tsx
+++ b/components/molecules/CaptureThumbnailField.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { SubmitButton } from "@/components/atoms";
+import { ui } from "@/components/atoms/styles";
+import { useRef } from "react";
+
+type CaptureThumbnailFieldProps = {
+  previewUrl: string | null;
+  source: "file" | "frame" | null;
+  error: string | null;
+  disabled?: boolean;
+  required?: boolean;
+  onPickFile: (file: File) => void;
+  onCaptureFrame: () => void;
+};
+
+export function CaptureThumbnailField({
+  previewUrl,
+  source,
+  error,
+  disabled = false,
+  required = true,
+  onPickFile,
+  onCaptureFrame,
+}: CaptureThumbnailFieldProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const sourceLabel = source === "file" ? "이미지 파일" : source === "frame" ? "영상 장면" : null;
+
+  return (
+    <div className={ui.field}>
+      <p className={ui.fieldLabel}>
+        썸네일{required ? <span className="text-[var(--dl-color-text-danger)]"> *</span> : null}
+      </p>
+      <div className="flex items-start gap-3">
+        <div
+          className="relative h-[128px] w-[72px] shrink-0 overflow-hidden rounded-[12px] bg-[var(--dl-color-bg-brand-subtle)]"
+          aria-hidden={!previewUrl}
+        >
+          {previewUrl ? (
+            <img src={previewUrl} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center px-1 text-center text-[10px] leading-4 text-[var(--dl-color-text-tertiary)]">
+              미등록
+            </div>
+          )}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <p className="m-0 text-[12px] leading-4 text-[var(--dl-color-text-secondary)]">
+            {sourceLabel
+              ? `${sourceLabel}으로 등록됐어요.`
+              : "이미지를 고르거나, 재생 중인 장면을 담아 주세요."}
+          </p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <SubmitButton
+              type="button"
+              variant="brandOutline"
+              className="min-h-10 flex-1"
+              disabled={disabled}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              이미지 선택
+            </SubmitButton>
+            <SubmitButton
+              type="button"
+              variant="brandOutline"
+              className="min-h-10 flex-1"
+              disabled={disabled}
+              onClick={onCaptureFrame}
+            >
+              현재 장면 담기
+            </SubmitButton>
+          </div>
+        </div>
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
+        className="sr-only"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          event.target.value = "";
+          if (file) {
+            onPickFile(file);
+          }
+        }}
+      />
+      {error ? (
+        <p className="m-0 text-[12px] font-semibold text-[var(--dl-color-text-danger)]" role="alert">
+          {error}
+        </p>
+      ) : required && !previewUrl ? (
+        <p className="m-0 text-[12px] text-[var(--dl-color-text-tertiary)]">업로드하려면 썸네일이 필요해요.</p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/molecules/FeedTopBar.tsx
+++ b/components/molecules/FeedTopBar.tsx
@@ -1,5 +1,6 @@
 import leftoverStyles from "@/components/styles/leftover.module.css";
 import { PlipLogo, TextLink } from "@/components/atoms";
+import { NotificationBell } from "@/components/molecules/NotificationBell";
 import { ROUTES } from "@/config/routes";
 import type { UiFeedTab } from "@/types/feed/ui";
 
@@ -10,7 +11,13 @@ type FeedTopBarProps = {
 export function FeedTopBar({ activeTab = "myAgits" }: FeedTopBarProps) {
   return (
     <header className={`${leftoverStyles.plipTtFeedTop} pointer-events-none absolute inset-x-0 top-0 z-[4] grid grid-cols-[auto_1fr_auto] items-center gap-2 px-[0.85rem] pt-[0.7rem]`}>
-      <PlipLogo width={86} height={50} className="w-[5.4rem] h-auto [filter:drop-shadow(0_2px_8px_rgba(0,_0,_0,_0.45))]" />
+      <TextLink
+        href={ROUTES.home}
+        aria-label="홈"
+        className="pointer-events-auto relative z-[3] w-[5.4rem] !no-underline"
+      >
+        <PlipLogo width={86} height={50} className="h-auto w-[5.4rem] [filter:drop-shadow(0_2px_8px_rgba(0,_0,_0,_0.45))]" />
+      </TextLink>
       <div className="flex justify-center gap-[1.25rem] [justify-self:center]" role="tablist" aria-label="피드 탭">
         <span
           role="tab"
@@ -27,9 +34,12 @@ export function FeedTopBar({ activeTab = "myAgits" }: FeedTopBarProps) {
           그룹영상
         </span>
       </div>
-      <TextLink href={ROUTES.agit.search} className="absolute right-[0.85rem] top-[0.95rem] z-[3] !text-[#fff] !no-underline text-[0.78rem] font-semibold p-[0.28rem_0.7rem] rounded-[var(--dc-btn-radius)] border border-[var(--dc-glass-dark-border)] bg-[linear-gradient(180deg,_var(--dc-glass-dark-from),_var(--dc-glass-dark-to))] backdrop-blur-[16px]">
-        검색
-      </TextLink>
+      <div className="pointer-events-auto flex items-center justify-end gap-1.5">
+        <NotificationBell variant="feed" />
+        <TextLink href={ROUTES.agit.search} className="!text-[#fff] !no-underline text-[0.78rem] font-semibold p-[0.28rem_0.7rem] rounded-[var(--dc-btn-radius)] border border-[var(--dc-glass-dark-border)] bg-[linear-gradient(180deg,_var(--dc-glass-dark-from),_var(--dc-glass-dark-to))] backdrop-blur-[16px]">
+          검색
+        </TextLink>
+      </div>
     </header>
   );
 }

--- a/components/molecules/NotificationBell.tsx
+++ b/components/molecules/NotificationBell.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import {
+  getNotificationInboxAction,
+  markAllNotificationsReadAction,
+  markNotificationReadAction,
+} from "@/actions/notificationActions";
+import { DailyIcon } from "@/components/atoms";
+import { AnimatedDropdown } from "@/components/molecules/AnimatedOverlays";
+import { NotificationInboxList } from "@/components/organisms/NotificationInboxList";
+import { ROUTES } from "@/config/routes";
+import { cn } from "@/lib/utils";
+import type { UiNotificationInbox } from "@/types/notification/ui";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+type NotificationBellProps = {
+  variant?: "feed" | "light";
+  unreadCount?: number;
+};
+
+function unreadLabel(count: number): string {
+  if (count <= 0) {
+    return "";
+  }
+  return count > 99 ? "99+" : String(count);
+}
+
+export function NotificationBell({ variant = "light", unreadCount = 0 }: NotificationBellProps) {
+  const [open, setOpen] = useState(false);
+  const [inbox, setInbox] = useState<UiNotificationInbox>({
+    items: [],
+    unreadCount,
+  });
+
+  const refresh = useCallback(async () => {
+    const result = await getNotificationInboxAction();
+    if (result.ok) {
+      setInbox(result.data);
+    }
+  }, []);
+
+  useEffect(() => {
+    const immediate = window.setTimeout(() => {
+      void refresh();
+    }, 0);
+    const timer = window.setInterval(() => {
+      void refresh();
+    }, 30_000);
+    return () => {
+      window.clearTimeout(immediate);
+      window.clearInterval(timer);
+    };
+  }, [refresh]);
+
+  async function handleMarkRead(id: string) {
+    const result = await markNotificationReadAction(id);
+    if (result.ok) {
+      setInbox((current) => ({
+        items: current.items.map((item) => (item.id === id ? { ...item, read: true } : item)),
+        unreadCount: Math.max(
+          0,
+          current.unreadCount - (current.items.find((item) => item.id === id && !item.read) ? 1 : 0),
+        ),
+      }));
+    }
+  }
+
+  async function handleMarkAllRead() {
+    const result = await markAllNotificationsReadAction();
+    if (result.ok) {
+      setInbox((current) => ({
+        items: current.items.map((item) => ({ ...item, read: true })),
+        unreadCount: 0,
+      }));
+    }
+  }
+
+  const countLabel = unreadLabel(inbox.unreadCount);
+  const isFeed = variant === "feed";
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        className={cn(
+          "relative inline-flex items-center justify-center no-underline",
+          isFeed
+            ? "size-9 rounded-[var(--dc-btn-radius)] border border-[var(--dc-glass-dark-border)] bg-[linear-gradient(180deg,var(--dc-glass-dark-from),var(--dc-glass-dark-to))] text-white backdrop-blur-[16px]"
+            : "size-11 rounded-[var(--dl-radius-md)] border-0 bg-[var(--dl-color-bg-surface)] text-[var(--dl-color-text-primary)]",
+        )}
+        aria-label={countLabel ? `알림 ${countLabel}개` : "알림"}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => {
+          setOpen((current) => !current);
+          void refresh();
+        }}
+      >
+        <DailyIcon name="bell" size={isFeed ? 18 : 20} className={isFeed ? "brightness-0 invert" : ""} />
+        {countLabel ? (
+          <span className="absolute -right-0.5 -top-0.5 inline-flex min-w-[16px] items-center justify-center rounded-full bg-[#ff3b5c] px-1 text-[10px] font-bold leading-4 text-white">
+            {countLabel}
+          </span>
+        ) : null}
+      </button>
+
+      {open ? (
+        <button
+          type="button"
+          className="fixed inset-0 z-[20] cursor-default border-0 bg-transparent"
+          aria-label="알림 닫기"
+          onClick={() => setOpen(false)}
+        />
+      ) : null}
+
+      <AnimatedDropdown
+        open={open}
+        role="dialog"
+        aria-label="알림"
+        className={cn(
+          "absolute right-0 top-[calc(100%+0.4rem)] z-[21] w-[min(20.5rem,calc(100vw-1.7rem))] overflow-hidden rounded-[16px] border shadow-[0_16px_40px_rgba(0,0,0,0.18)]",
+          isFeed
+            ? "border-[var(--dc-glass-dark-border)] bg-[rgba(18,18,22,0.92)] text-white backdrop-blur-[20px]"
+            : "border-black/8 bg-white text-[var(--dl-color-text-primary)]",
+        )}
+      >
+        <div className="flex items-center justify-between gap-2 px-3.5 py-2.5">
+          <strong className="text-[0.9rem] font-semibold">알림</strong>
+          <button
+            type="button"
+            className={cn(
+              "border-0 bg-transparent text-[0.75rem] font-semibold",
+              isFeed ? "text-white/72" : "text-[var(--dl-color-text-secondary)]",
+            )}
+            onClick={() => void handleMarkAllRead()}
+          >
+            모두 읽음
+          </button>
+        </div>
+        <NotificationInboxList
+          items={inbox.items.slice(0, 6)}
+          variant={variant}
+          compact
+          onItemClick={(item) => {
+            void handleMarkRead(item.id);
+            setOpen(false);
+          }}
+        />
+        <Link
+          href={ROUTES.notifications}
+          className={cn(
+            "block border-t px-3.5 py-2.5 text-center text-[0.78rem] font-semibold no-underline",
+            isFeed ? "border-white/10 text-white" : "border-black/6 text-[var(--dl-color-text-brand)]",
+          )}
+          onClick={() => setOpen(false)}
+        >
+          전체 알림 보기
+        </Link>
+      </AnimatedDropdown>
+    </div>
+  );
+}

--- a/components/molecules/ScreenHeader.tsx
+++ b/components/molecules/ScreenHeader.tsx
@@ -1,5 +1,6 @@
-import { DailyIcon, IconButton, IconLink, ScreenSubtitle, ScreenTitle } from "@/components/atoms";
+import { DailyIcon, IconButton, IconLink, NavHomeIcon, ScreenSubtitle, ScreenTitle } from "@/components/atoms";
 import { ui } from "@/components/atoms/styles";
+import { ROUTES } from "@/config/routes";
 import { cn } from "@/lib/utils";
 import type { ReactNode } from "react";
 
@@ -120,6 +121,20 @@ export function HeaderSearchButton({ onClick, label = "검색" }: { onClick: () 
   );
 }
 
+export function HeaderHomeLink({
+  href = ROUTES.home,
+  label = "홈",
+}: {
+  href?: string;
+  label?: string;
+}) {
+  return (
+    <IconLink href={href} label={label}>
+      <NavHomeIcon className="size-5" />
+    </IconLink>
+  );
+}
+
 export function HeaderStep({ children }: { children: ReactNode }) {
   return <span className={ui.topbarStep}>{children}</span>;
 }
@@ -168,7 +183,9 @@ export function ScreenHeader({
       <HeaderBackButton onClick={onBack} label={backLabel} />
     ) : backHref ? (
       <HeaderBackLink href={backHref} label={backLabel} />
-    ) : null);
+    ) : (
+      <HeaderHomeLink />
+    ));
 
   const menuButton = onMenuOpen ? (
     <HeaderMenuButton label={menuLabel} onClick={onMenuOpen} />

--- a/components/molecules/SocialAuthButtons.tsx
+++ b/components/molecules/SocialAuthButtons.tsx
@@ -48,7 +48,7 @@ export function SocialAuthButtons({
   disabled,
   className,
 }: SocialAuthButtonsProps) {
-  const targetUrl = getSafeCallbackUrl(callbackUrl ?? ROUTES.diary.root);
+  const targetUrl = getSafeCallbackUrl(callbackUrl ?? ROUTES.home);
 
   function handleSignIn(provider: SocialProvider) {
     void signIn(provider, { callbackUrl: targetUrl });

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -18,6 +18,7 @@ export {
   AuthTopBar,
   HeaderBackButton,
   HeaderBackLink,
+  HeaderHomeLink,
   HeaderMenuButton,
   HeaderSearchButton,
   HeaderSearchLink,
@@ -56,6 +57,7 @@ export { ExploreNav } from "./ExploreNav";
 export { RoomNav } from "./RoomNav";
 export { FeedActionRail } from "./FeedActionRail";
 export { FeedTopBar } from "./FeedTopBar";
+export { NotificationBell } from "./NotificationBell";
 export { MyPageMenuItem } from "./MyPageMenuItem";
 export { SettingsRow } from "./SettingsRow";
 
@@ -92,6 +94,7 @@ export { VideoReactionBar } from "./VideoReactionBar";
 export { VideoThumbnailGrid } from "./VideoThumbnailGrid";
 export { CaptureClipOverlays } from "./CaptureClipOverlays";
 export { CaptureCreateForm } from "./CaptureCreateForm";
+export { CaptureThumbnailField } from "./CaptureThumbnailField";
 export { ThumbnailUpload } from "./ThumbnailUpload";
 
 // --- 7. Chat, Social & Member Molecules ---

--- a/components/organisms/AgitListSection.tsx
+++ b/components/organisms/AgitListSection.tsx
@@ -2,7 +2,7 @@
 import leftoverStyles from "@/components/styles/leftover.module.css";
 
 import { IconButton, TextLink } from "@/components/atoms";
-import { AgitListRow, HeaderSearchLink, PageContainer, ScreenHeader } from "@/components/molecules";
+import { AgitListRow, HeaderSearchLink, NotificationBell, PageContainer, ScreenHeader } from "@/components/molecules";
 import { ROUTES } from "@/config/routes";
 import { useAgitListChatSync } from "@/hooks/useAgitListChatSync";
 import { Plus } from "lucide-react";
@@ -13,6 +13,7 @@ type AgitListSectionProps = {
   error?: string;
   currentUserUuid?: string;
   enableRemoteChat?: boolean;
+  inboxUnreadCount?: number;
 };
 
 export function AgitListSection({
@@ -20,6 +21,7 @@ export function AgitListSection({
   error,
   currentUserUuid,
   enableRemoteChat = false,
+  inboxUnreadCount = 0,
 }: AgitListSectionProps) {
   const rooms = items;
   const totalVideos = rooms.reduce((sum, room) => sum + (room.todayVideoCount ?? 0), 0);
@@ -30,7 +32,12 @@ export function AgitListSection({
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
         title="아지트"
-        trailing={<HeaderSearchLink href={ROUTES.agit.search} />}
+        trailing={
+          <>
+            <NotificationBell unreadCount={inboxUnreadCount} />
+            <HeaderSearchLink href={ROUTES.agit.search} />
+          </>
+        }
       />
 
       <PageContainer aria-label="내 아지트" className="flex-1">

--- a/components/organisms/AgitSubSections.tsx
+++ b/components/organisms/AgitSubSections.tsx
@@ -170,14 +170,12 @@ export function AgitSearchSection({ myAgitIds }: { myAgitIds: string[] }) {
           ))}
         </div>
 
-        {error ? (
-          <p className="m-0 text-[14px] text-[var(--dl-color-text-secondary)]" role="alert">
-            {error}
-          </p>
-        ) : null}
-
         {loading ? (
           <p className="m-0 py-6 text-center text-sm text-[var(--dl-color-text-secondary)]">불러오는 중…</p>
+        ) : error ? (
+          <p className="m-0 py-6 text-center text-sm text-[var(--dl-color-text-secondary)]" role="alert">
+            {error}
+          </p>
         ) : rooms.length > 0 ? (
           <div className="grid grid-cols-2 gap-[12px]">
             {rooms.map((room) => {

--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -20,6 +20,7 @@ import { useVideoCaptureFlow } from "@/hooks/useVideoCaptureFlow";
 import { extractActionError } from "@/lib/video/actionPayload";
 import { VIDEO_DESTINATION_NOT_WIRED } from "@/lib/video/actionErrors";
 import { playShutterSound } from "@/lib/video/playShutterSound";
+import { captureVideoFrame, prepareThumbnailImage } from "@/lib/video/prepareThumbnail";
 import { shouldMirrorVideo } from "@/lib/video/shouldMirrorVideo";
 import { toKstDateString } from "@/lib/topic/selectAgitTopic";
 import type { UiAgit } from "@/types/agit/ui";
@@ -37,6 +38,7 @@ type CaptureFlowSectionProps = {
 };
 
 type PreviewStep = "confirm" | "settings";
+type ThumbnailSource = "file" | "frame";
 
 function pickId<T extends { id: string }>(items: T[], preferred: string): string {
   if (preferred && items.some((item) => item.id === preferred)) {
@@ -113,8 +115,13 @@ export function CaptureFlowSection({
   const [publishing, setPublishing] = useState(false);
   const [pendingPublishVideoUuid, setPendingPublishVideoUuid] = useState<string | null>(null);
   const [originalView, setOriginalView] = useState(false);
+  const [thumbnailFile, setThumbnailFile] = useState<File | null>(null);
+  const [thumbnailPreviewUrl, setThumbnailPreviewUrl] = useState<string | null>(null);
+  const [thumbnailSource, setThumbnailSource] = useState<ThumbnailSource | null>(null);
+  const [thumbnailError, setThumbnailError] = useState<string | null>(null);
   const sectionRef = useRef<HTMLElement>(null);
   const slotRef = useRef<HTMLDivElement>(null);
+  const previewVideoElRef = useRef<HTMLVideoElement | null>(null);
 
   const isPreview = status === "preview" || flowPhase === "uploading" || flowPhase === "complete";
   const showSettings = isPreview && previewStep === "settings";
@@ -179,6 +186,44 @@ export function CaptureFlowSection({
     });
   }, [loadDestinations]);
 
+  const replaceThumbnail = useCallback((file: File, source: ThumbnailSource) => {
+    setThumbnailPreviewUrl((current) => {
+      if (current) {
+        URL.revokeObjectURL(current);
+      }
+      return URL.createObjectURL(file);
+    });
+    setThumbnailFile(file);
+    setThumbnailSource(source);
+    setThumbnailError(null);
+  }, []);
+
+  const clearThumbnail = useCallback(() => {
+    setThumbnailPreviewUrl((current) => {
+      if (current) {
+        URL.revokeObjectURL(current);
+      }
+      return null;
+    });
+    setThumbnailFile(null);
+    setThumbnailSource(null);
+    setThumbnailError(null);
+  }, []);
+
+  const thumbnailPreviewUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    thumbnailPreviewUrlRef.current = thumbnailPreviewUrl;
+  }, [thumbnailPreviewUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (thumbnailPreviewUrlRef.current) {
+        URL.revokeObjectURL(thumbnailPreviewUrlRef.current);
+      }
+    };
+  }, []);
+
   const handleStartRecording = useCallback(() => {
     playShutterSound();
     void startRecording();
@@ -191,8 +236,9 @@ export function CaptureFlowSection({
     setPendingPublishVideoUuid(null);
     setOriginalView(false);
     setPreviewStep("confirm");
+    clearThumbnail();
     void retake();
-  }, [retake]);
+  }, [clearThumbnail, retake]);
 
   const navigateAfterPublish = useCallback(
     (destination: VideoDestination) => {
@@ -271,15 +317,58 @@ export function CaptureFlowSection({
       return;
     }
 
+    if (!thumbnailFile) {
+      setSaveError("썸네일을 등록해 주세요. 이전 화면에서 이미지를 고르거나 장면을 담을 수 있어요.");
+      return;
+    }
+
     setSaveError(null);
-    const uploaded = await uploadCapture(caption.trim() || undefined);
+    const uploaded = await uploadCapture(caption.trim() || undefined, thumbnailFile);
     if (!uploaded) {
       setSaveError("업로드에 실패했습니다.");
       return;
     }
 
     await publishDestination(uploaded.videoUuid, destination);
-  }, [caption, publishDestination, resolveDestination, uploadCapture]);
+  }, [caption, publishDestination, resolveDestination, thumbnailFile, uploadCapture]);
+
+  const handlePickThumbnailFile = useCallback(
+    async (file: File) => {
+      try {
+        const prepared = await prepareThumbnailImage(file);
+        replaceThumbnail(prepared, "file");
+      } catch (error) {
+        setThumbnailError(error instanceof Error ? error.message : "썸네일 이미지를 준비하지 못했습니다.");
+      }
+    },
+    [replaceThumbnail],
+  );
+
+  const handleCaptureThumbnailFrame = useCallback(async () => {
+    const video = previewVideoElRef.current;
+    if (!video) {
+      setThumbnailError("영상을 찾을 수 없습니다.");
+      return;
+    }
+
+    try {
+      const captured = await captureVideoFrame(video);
+      replaceThumbnail(captured, "frame");
+    } catch (error) {
+      setThumbnailError(error instanceof Error ? error.message : "영상 장면을 담지 못했습니다.");
+    }
+  }, [replaceThumbnail]);
+
+  const handleContinueToSettings = useCallback(() => {
+    if (!thumbnailFile) {
+      setThumbnailError("썸네일을 등록해 주세요. 이미지를 고르거나 현재 장면을 담아 주세요.");
+      return;
+    }
+
+    setThumbnailError(null);
+    setOriginalView(false);
+    setPreviewStep("settings");
+  }, [thumbnailFile]);
 
   const handleRetryPublish = useCallback(async () => {
     if (!pendingPublishVideoUuid) {
@@ -369,7 +458,10 @@ export function CaptureFlowSection({
         }
       >
         <video
-          ref={videoRef}
+          ref={(node) => {
+            videoRef(node);
+            previewVideoElRef.current = node;
+          }}
           className={`h-full w-full object-cover ${mirrorVideo ? "-scale-x-100" : ""}`}
           autoPlay
           playsInline
@@ -414,14 +506,16 @@ export function CaptureFlowSection({
           caption={caption}
           uploading={uploading}
           originalView={originalView}
+          thumbnailPreviewUrl={thumbnailPreviewUrl}
+          thumbnailSource={thumbnailSource}
+          thumbnailError={thumbnailError}
           onCaptionChange={setCaption}
+          onPickThumbnailFile={(file) => void handlePickThumbnailFile(file)}
+          onCaptureThumbnailFrame={() => void handleCaptureThumbnailFrame()}
           onBack={handleRetake}
           onViewOriginal={() => setOriginalView(true)}
           onCloseOriginal={() => setOriginalView(false)}
-          onContinue={() => {
-            setOriginalView(false);
-            setPreviewStep("settings");
-          }}
+          onContinue={handleContinueToSettings}
         />
       ) : null}
 
@@ -440,6 +534,7 @@ export function CaptureFlowSection({
           creatingInline={creatingInline}
           uploading={uploading || publishing}
           saveError={saveError ?? (flowError && !pendingPublishVideoUuid ? flowError : null)}
+          thumbnailPreviewUrl={thumbnailPreviewUrl}
           pendingPublishVideoUuid={pendingPublishVideoUuid}
           onDestinationKindChange={(kind) => {
             setInlineCreateError(null);

--- a/components/organisms/CapturePreviewStage.tsx
+++ b/components/organisms/CapturePreviewStage.tsx
@@ -2,14 +2,19 @@
 
 import { Input, Label, SubmitButton } from "@/components/atoms";
 import { ui } from "@/components/atoms/styles";
-import { HeaderBackButton, PageContainer, ScreenHeader } from "@/components/molecules";
+import { CaptureThumbnailField, HeaderBackButton, PageContainer, ScreenHeader } from "@/components/molecules";
 import { CAPTION_MAX_LENGTH } from "@/lib/video/constants";
 
 type CapturePreviewStageProps = {
   caption: string;
   uploading: boolean;
   originalView: boolean;
+  thumbnailPreviewUrl: string | null;
+  thumbnailSource: "file" | "frame" | null;
+  thumbnailError: string | null;
   onCaptionChange: (value: string) => void;
+  onPickThumbnailFile: (file: File) => void;
+  onCaptureThumbnailFrame: () => void;
   onBack: () => void;
   onViewOriginal: () => void;
   onCloseOriginal: () => void;
@@ -20,7 +25,12 @@ export function CapturePreviewStage({
   caption,
   uploading,
   originalView,
+  thumbnailPreviewUrl,
+  thumbnailSource,
+  thumbnailError,
   onCaptionChange,
+  onPickThumbnailFile,
+  onCaptureThumbnailFrame,
   onBack,
   onViewOriginal,
   onCloseOriginal,
@@ -65,11 +75,25 @@ export function CapturePreviewStage({
             onChange={(event) => onCaptionChange(event.target.value)}
           />
         </div>
+        <CaptureThumbnailField
+          previewUrl={thumbnailPreviewUrl}
+          source={thumbnailSource}
+          error={thumbnailError}
+          disabled={uploading}
+          onPickFile={onPickThumbnailFile}
+          onCaptureFrame={onCaptureThumbnailFrame}
+        />
         <div className="flex gap-2">
           <SubmitButton type="button" variant="brandOutline" className="flex-1" onClick={onViewOriginal}>
             원본 크기 보기
           </SubmitButton>
-          <SubmitButton type="button" variant="brand" className="flex-1" disabled={uploading} onClick={onContinue}>
+          <SubmitButton
+            type="button"
+            variant="brand"
+            className="flex-1"
+            disabled={uploading || !thumbnailPreviewUrl}
+            onClick={onContinue}
+          >
             업로드 설정
           </SubmitButton>
         </div>

--- a/components/organisms/CaptureUploadSettingsStage.tsx
+++ b/components/organisms/CaptureUploadSettingsStage.tsx
@@ -27,6 +27,7 @@ type CaptureUploadSettingsStageProps = {
   creatingInline: boolean;
   uploading: boolean;
   saveError: string | null;
+  thumbnailPreviewUrl: string | null;
   pendingPublishVideoUuid: string | null;
   onDestinationKindChange: (value: DestinationId) => void;
   onAgitChange: (agitUuid: string) => void;
@@ -54,6 +55,7 @@ export function CaptureUploadSettingsStage({
   creatingInline,
   uploading,
   saveError,
+  thumbnailPreviewUrl,
   pendingPublishVideoUuid,
   onDestinationKindChange,
   onAgitChange,
@@ -69,11 +71,12 @@ export function CaptureUploadSettingsStage({
   const selectedAgit = agits.find((agit) => agit.id === selectedAgitUuid);
   const selectedTopic = topics.find((topic) => topic.id === selectedTopicUuid);
   const selectedTheme = themes.find((theme) => theme.id === selectedThemeId);
-  const canSave =
+  const canSaveDestination =
     destinationKind === "diary"
       ? Boolean(selectedThemeId && selectedTheme?.themeUuid)
       : Boolean(selectedAgitUuid && selectedTopicUuid);
   const isPublishRetry = Boolean(pendingPublishVideoUuid);
+  const canSave = canSaveDestination && (isPublishRetry || Boolean(thumbnailPreviewUrl));
 
   return (
     <div
@@ -94,6 +97,21 @@ export function CaptureUploadSettingsStage({
           </p>
         </div>
       ) : null}
+
+      {thumbnailPreviewUrl ? (
+        <div className="flex items-center gap-3">
+          <img
+            src={thumbnailPreviewUrl}
+            alt="등록한 썸네일"
+            className="h-[72px] w-[40px] rounded-[8px] object-cover"
+          />
+          <p className="m-0 text-[13px] text-[var(--dl-color-text-secondary)]">썸네일이 함께 업로드됩니다.</p>
+        </div>
+      ) : isPublishRetry ? null : (
+        <p className="m-0 text-[12px] font-semibold text-[var(--dl-color-text-danger)]" role="alert">
+          썸네일을 등록해 주세요. 이전 화면에서 이미지를 고르거나 장면을 담을 수 있어요.
+        </p>
+      )}
 
       <p className="m-0 text-[15px] font-semibold">기록 목적지</p>
       <DestinationToggle value={destinationKind} onChange={onDestinationKindChange} />

--- a/components/organisms/JoinRequestsSection.tsx
+++ b/components/organisms/JoinRequestsSection.tsx
@@ -7,9 +7,11 @@ import { useState } from "react";
 
 export function JoinRequestsSection({
   agitId,
+  agitName,
   requests,
 }: {
   agitId: string;
+  agitName?: string;
   requests: ApiJoinRequestItem[];
 }) {
   const router = useRouter();
@@ -20,10 +22,15 @@ export function JoinRequestsSection({
     if (pendingId) return;
     setPendingId(ampId);
     setError(null);
+    const request = requests.find((item) => item.ampId === ampId);
+    const notify = {
+      requesterUserUuid: request?.userUuid,
+      agitName,
+    };
     const result =
       action === "approve"
-        ? await approveJoinRequestAction(agitId, ampId)
-        : await rejectJoinRequestAction(agitId, ampId);
+        ? await approveJoinRequestAction(agitId, ampId, notify)
+        : await rejectJoinRequestAction(agitId, ampId, notify);
     setPendingId(null);
     if (!result.ok) {
       setError(result.error);

--- a/components/organisms/MainLandingSection.tsx
+++ b/components/organisms/MainLandingSection.tsx
@@ -91,7 +91,17 @@ export function MainLandingSection({
   return (
     <div className="mx-auto flex w-full max-w-[390px] flex-col gap-8 px-5 pb-12 pt-6">
       <header className="flex items-center justify-between gap-3">
-        <p className="m-0 text-lg font-bold text-[var(--dl-color-text-primary)]">PLIP</p>
+        {isLoggedIn ? (
+          <TextLink
+            href={ROUTES.home}
+            aria-label="홈"
+            className="m-0 text-lg font-bold text-[var(--dl-color-text-primary)] !no-underline"
+          >
+            PLIP
+          </TextLink>
+        ) : (
+          <p className="m-0 text-lg font-bold text-[var(--dl-color-text-primary)]">PLIP</p>
+        )}
         {isLoggedIn ? (
           <TextLink href={ROUTES.home} className={cn(ui.link, "text-sm")}>
             피드로

--- a/components/organisms/MyPageSections.tsx
+++ b/components/organisms/MyPageSections.tsx
@@ -68,7 +68,7 @@ export function MyPageProfileSection() {
       <div className="flex flex-col gap-[0.35rem] p-[0.75rem_1rem_1.25rem] [&_a]:rounded-[var(--dc-radius)] [&_a]:border [&_a]:border-[var(--dc-glass-border)] [&_a]:bg-[linear-gradient(180deg,_var(--dc-glass-from),_var(--dc-glass-to))] [&_a]:shadow-[var(--dc-shadow)] [&_a]:backdrop-blur-[20px] [&_a]:p-[0.75rem_0.9rem] [&_a]:text-[0.875rem] [&_a]:font-medium [&_a]:!text-[var(--dc-fg-primary)] [&_a]:!no-underline">
         <TextLink href={ROUTES.shop.root}>상점 · 포인트</TextLink>
         <TextLink href={ROUTES.shop.myItems}>내 아이템</TextLink>
-        <TextLink href={ROUTES.mypage.notifications}>알림</TextLink>
+        <TextLink href={ROUTES.notifications}>알림</TextLink>
         <TextLink href={ROUTES.mypage.settings}>설정 및 개인정보</TextLink>
       </div>
     </section>
@@ -121,7 +121,7 @@ export function MyPageSettingsSection() {
     <section className={`${leftoverStyles.plipTtSettings} flex flex-col gap-0.5 bg-transparent p-4 text-[var(--dc-fg-primary)]`} aria-label="설정">
       <h1>설정 및 개인정보</h1>
       {[
-        { href: ROUTES.mypage.notifications, label: "알림" },
+        { href: ROUTES.notifications, label: "알림" },
         { href: ROUTES.mypage.password, label: "비밀번호" },
         { href: ROUTES.mypage.profile, label: "계정" },
         { href: ROUTES.shop.root, label: "상점 · 포인트" },

--- a/components/organisms/NotificationInboxList.tsx
+++ b/components/organisms/NotificationInboxList.tsx
@@ -1,0 +1,94 @@
+import { TextLink } from "@/components/atoms";
+import { NOTIFICATION_TYPE_LABEL } from "@/types/notification/ui";
+import type { UiNotificationItem } from "@/types/notification/ui";
+import { cn } from "@/lib/utils";
+
+type NotificationInboxListProps = {
+  items: UiNotificationItem[];
+  variant?: "feed" | "light";
+  compact?: boolean;
+  onItemClick?: (item: UiNotificationItem) => void;
+};
+
+function formatTime(value: string | null): string {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function NotificationInboxList({
+  items,
+  variant = "light",
+  compact = false,
+  onItemClick,
+}: NotificationInboxListProps) {
+  const isFeed = variant === "feed";
+
+  if (items.length === 0) {
+    return (
+      <p className={cn("px-4 py-6 text-center text-sm", isFeed ? "text-white/62" : "text-black/45")}>
+        새 알림이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <ul className={cn("m-0 list-none p-0", compact ? "max-h-[22rem] overflow-y-auto" : "flex flex-col gap-2")}>
+      {items.map((item) => (
+        <li key={item.id}>
+          <TextLink
+            href={item.href}
+            onClick={() => onItemClick?.(item)}
+            className={cn(
+              "block no-underline",
+              compact ? "px-3.5 py-2.5" : "rounded-[16px] border px-4 py-3",
+              item.read ? "opacity-70" : "",
+              isFeed
+                ? compact
+                  ? "text-white hover:bg-white/8"
+                  : "border-white/10 bg-white/6 text-white"
+                : compact
+                  ? "text-[var(--dl-color-text-primary)] hover:bg-black/4"
+                  : "border-black/6 bg-white text-[var(--dl-color-text-primary)]",
+            )}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span
+                className={cn(
+                  "text-[0.68rem] font-semibold uppercase tracking-wide",
+                  isFeed ? "text-white/55" : "text-[var(--dl-color-text-secondary)]",
+                )}
+              >
+                {NOTIFICATION_TYPE_LABEL[item.type]}
+              </span>
+              <span className={cn("text-[0.68rem]", isFeed ? "text-white/45" : "text-black/35")}>
+                {formatTime(item.createdAt)}
+              </span>
+            </div>
+            <p className={cn("m-0 mt-1 text-[0.88rem] font-semibold", item.read ? "" : "font-bold")}>
+              {item.title}
+            </p>
+            {item.body ? (
+              <p className={cn("m-0 mt-0.5 line-clamp-2 text-[0.78rem]", isFeed ? "text-white/68" : "text-black/55")}>
+                {item.body}
+              </p>
+            ) : null}
+            {!item.read ? (
+              <span className="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-[#ff3b5c]" aria-hidden />
+            ) : null}
+          </TextLink>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/organisms/NotificationInboxSection.tsx
+++ b/components/organisms/NotificationInboxSection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { markInboxNotificationReadAction } from "@/actions/notificationActions";
+import { TextLink } from "@/components/atoms";
+import type { UiInboxNotification } from "@/types/notification/ui";
+import { useRouter } from "next/navigation";
+
+export function NotificationInboxSection({
+  items,
+}: {
+  items: UiInboxNotification[];
+}) {
+  const router = useRouter();
+
+  async function handleOpen(item: UiInboxNotification) {
+    if (item.id.startsWith("stored:") && item.unread) {
+      await markInboxNotificationReadAction(item.id);
+    }
+    router.push(item.href);
+    router.refresh();
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="m-0 text-sm text-[var(--dl-color-text-secondary)]">
+        아직 받은 알림이 없어요.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="m-0 flex list-none flex-col gap-3 p-0">
+      {items.map((item) => (
+        <li key={item.id}>
+          <TextLink
+            href={item.href}
+            onClick={(event) => {
+              event.preventDefault();
+              void handleOpen(item);
+            }}
+            className="flex flex-col gap-1 rounded-2xl border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-elevated)] p-3 !no-underline"
+          >
+            <span className="flex items-center justify-between gap-2">
+              <span className="text-sm font-semibold text-[var(--dl-color-text-primary)]">
+                {item.title}
+              </span>
+              {item.unread ? (
+                <span className="size-2 shrink-0 rounded-full bg-[var(--dl-color-bg-brand)]" aria-label="읽지 않음" />
+              ) : null}
+            </span>
+            {item.body ? (
+              <span className="text-xs text-[var(--dl-color-text-secondary)]">{item.body}</span>
+            ) : null}
+          </TextLink>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/organisms/ProfileEditForm.tsx
+++ b/components/organisms/ProfileEditForm.tsx
@@ -6,14 +6,18 @@ import { ui } from "@/components/atoms/styles";
 import { toast } from "@/components/ui/toast";
 import { handleClientActionResult } from "@/lib/action/handleClientActionResult";
 import { ROUTES } from "@/config/routes";
+import { prepareProfileImageFile } from "@/lib/user/prepareProfileImage";
+import {
+  PROFILE_IMAGE_ACCEPT,
+  PROFILE_IMAGE_MAX_MB,
+} from "@/lib/user/profileImage";
 import {
   USER_NICKNAME_MAX_LENGTH,
   USER_NICKNAME_MIN_LENGTH,
   type UiUserProfile,
 } from "@/types/user/ui";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from "react";
 
 type ProfileEditFormProps = {
   profile: UiUserProfile;
@@ -21,8 +25,48 @@ type ProfileEditFormProps = {
 
 export function ProfileEditForm({ profile }: ProfileEditFormProps) {
   const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const previewUrlRef = useRef<string | null>(null);
   const [nickname, setNickname] = useState(profile.nickname);
+  const [previewSrc, setPreviewSrc] = useState(profile.profileImageUrl);
+  const [imageFile, setImageFile] = useState<File | null>(null);
   const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, []);
+
+  function openFilePicker() {
+    if (pending) return;
+    fileInputRef.current?.click();
+  }
+
+  async function handleImageChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+
+    try {
+      const prepared = await prepareProfileImageFile(file);
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+      const nextUrl = URL.createObjectURL(prepared);
+      previewUrlRef.current = nextUrl;
+      setPreviewSrc(nextUrl);
+      setImageFile(prepared);
+    } catch (error) {
+      toast.add({
+        type: "error",
+        title: "프로필 사진 선택 실패",
+        description: error instanceof Error ? error.message : "이미지를 불러오지 못했습니다.",
+      });
+    }
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -30,7 +74,13 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
     setPending(true);
 
-    const result = await updateMyProfileAction(nickname);
+    const formData = new FormData();
+    formData.set("nickname", nickname);
+    if (imageFile) {
+      formData.set("profileImage", imageFile);
+    }
+
+    const result = await updateMyProfileAction(formData);
     setPending(false);
 
     if (!(await handleClientActionResult(result, router, { errorTitle: "프로필 저장 실패" }))) {
@@ -46,8 +96,8 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
     <form className="flex w-full flex-col gap-3.5" onSubmit={handleSubmit}>
       <div className="flex min-h-[84px] w-full items-center gap-[12px] rounded-[14px] border border-[var(--dl-color-border-default)] bg-[var(--dl-color-bg-surface)] p-[14px]">
         <div className="h-[56px] w-[56px] shrink-0 overflow-hidden rounded-[999px]">
-          <Image
-            src={profile.profileImageUrl}
+          <img
+            src={previewSrc}
             alt=""
             width={56}
             height={56}
@@ -59,12 +109,21 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
             프로필 사진
           </p>
           <p className="m-0 text-[13px] leading-[16px] text-[var(--dl-color-text-secondary)]">
-            이미지 업로드는 준비 중입니다
+            JPG, PNG, WEBP · 최대 {PROFILE_IMAGE_MAX_MB}MB
           </p>
         </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={PROFILE_IMAGE_ACCEPT}
+          className="sr-only"
+          onChange={handleImageChange}
+        />
         <button
           type="button"
-          className="inline-flex h-[44px] cursor-pointer items-center gap-[8px] border-0 bg-[transparent] p-[12px_0] text-sm font-medium leading-5 text-[var(--dl-color-text-brand)]"
+          disabled={pending}
+          onClick={openFilePicker}
+          className="inline-flex h-[44px] cursor-pointer items-center gap-[8px] border-0 bg-[transparent] p-[12px_0] text-sm font-medium leading-5 text-[var(--dl-color-text-brand)] disabled:cursor-not-allowed disabled:opacity-50"
         >
           <DailyIcon name="camera" size={20} />
           사진 변경

--- a/components/organisms/ProfileHubSection.tsx
+++ b/components/organisms/ProfileHubSection.tsx
@@ -2,7 +2,7 @@
 
 import { logoutAction } from "@/actions/authActions";
 import { SubmitButton, TextLink, UserAvatar } from "@/components/atoms";
-import { PageContainer, ScreenHeader, SettingsRow } from "@/components/molecules";
+import { NotificationBell, PageContainer, ScreenHeader, SettingsRow } from "@/components/molecules";
 import { WithdrawAccountDialog } from "@/components/organisms/WithdrawAccountDialog";
 import { toast } from "@/components/ui/toast";
 import { ROUTES } from "@/config/routes";
@@ -12,9 +12,10 @@ import { useState } from "react";
 
 type ProfileHubSectionProps = {
   profile: UiUserProfile | null;
+  inboxUnreadCount?: number;
 };
 
-export function ProfileHubSection({ profile }: ProfileHubSectionProps) {
+export function ProfileHubSection({ profile, inboxUnreadCount = 0 }: ProfileHubSectionProps) {
   const router = useRouter();
   const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
@@ -53,7 +54,9 @@ export function ProfileHubSection({ profile }: ProfileHubSectionProps) {
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <ScreenHeader
         tone="default"
-        title="설정" />
+        title="설정"
+        trailing={<NotificationBell unreadCount={inboxUnreadCount} />}
+      />
 
       <PageContainer aria-label="마이페이지" className="flex-1">
         <div className="flex w-full items-center gap-[12px] rounded-[18px] bg-[var(--dl-color-bg-brand-subtle)] p-[14px]">
@@ -102,6 +105,12 @@ export function ProfileHubSection({ profile }: ProfileHubSectionProps) {
               description="계정 비밀번호 수정"
             />
           ) : null}
+          <SettingsRow
+            href={ROUTES.notifications}
+            title="알림함"
+            description="채팅·입장 요청·토픽·새 글"
+            icon="bell"
+          />
           <SettingsRow
             href={ROUTES.mypage.notifications}
             title="알림 설정"

--- a/components/organisms/ProfileSetupForm.tsx
+++ b/components/organisms/ProfileSetupForm.tsx
@@ -60,7 +60,7 @@ export function ProfileSetupForm() {
       return;
     }
 
-    router.push(ROUTES.diary.root);
+    router.push(ROUTES.home);
     router.refresh();
   }
 

--- a/components/organisms/SignUpForm.tsx
+++ b/components/organisms/SignUpForm.tsx
@@ -215,7 +215,7 @@ export function SignUpForm() {
         return;
       }
 
-      router.push(ROUTES.diary.root);
+      router.push(ROUTES.home);
       router.refresh();
       return;
     }
@@ -286,7 +286,7 @@ export function SignUpForm() {
           onOpenChange={setRestoreOpen}
           payload={restorePayload}
           onCompleted={() => {
-            router.push(ROUTES.diary.root);
+            router.push(ROUTES.home);
             router.refresh();
           }}
         />

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -66,6 +66,8 @@ export { TermsAgreementsForm } from "./TermsAgreementsForm";
 export { AccountSecuritySection } from "./AccountSecuritySection";
 export { WithdrawAccountDialog } from "./WithdrawAccountDialog";
 export { NotificationSettingsForm } from "./NotificationSettingsForm";
+export { NotificationInboxSection } from "./NotificationInboxSection";
+export { NotificationInboxList } from "./NotificationInboxList";
 
 // --- 7. Profile & MyPage Organisms ---
 export { ProfileEditForm } from "./ProfileEditForm";

--- a/components/templates/AgitTemplates.tsx
+++ b/components/templates/AgitTemplates.tsx
@@ -19,11 +19,13 @@ export function AgitListTemplate({
   error,
   currentUserUuid,
   enableRemoteChat = false,
+  inboxUnreadCount = 0,
 }: {
   items: UiAgit[];
   error?: string;
   currentUserUuid?: string;
   enableRemoteChat?: boolean;
+  inboxUnreadCount?: number;
 }) {
   return (
     <AppChromeTemplate activeTab="agit" variant="light">
@@ -32,6 +34,7 @@ export function AgitListTemplate({
         error={error}
         currentUserUuid={currentUserUuid}
         enableRemoteChat={enableRemoteChat}
+        inboxUnreadCount={inboxUnreadCount}
       />
     </AppChromeTemplate>
   );

--- a/components/templates/MyPageTemplate.tsx
+++ b/components/templates/MyPageTemplate.tsx
@@ -6,12 +6,14 @@ import type { ReactNode } from "react";
 type MyPageTemplateProps = {
   showBottomNav?: boolean;
   profile: UiUserProfile | null;
+  inboxUnreadCount?: number;
   children?: ReactNode;
 };
 
 export function MyPageTemplate({
   showBottomNav = true,
   profile,
+  inboxUnreadCount = 0,
   children,
 }: MyPageTemplateProps) {
   return (
@@ -21,7 +23,7 @@ export function MyPageTemplate({
       showNav={showBottomNav}
       mainOverflow="hidden"
     >
-      {children ?? <ProfileHubSection profile={profile} />}
+      {children ?? <ProfileHubSection profile={profile} inboxUnreadCount={inboxUnreadCount} />}
     </AppChromeTemplate>
   );
 }

--- a/components/templates/NotificationInboxTemplate.tsx
+++ b/components/templates/NotificationInboxTemplate.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { markAllNotificationsReadAction, markNotificationReadAction } from "@/actions/notificationActions";
+import { ScreenHeader } from "@/components/molecules";
+import { NotificationInboxList } from "@/components/organisms/NotificationInboxList";
+import { AppChromeTemplate } from "@/components/templates/AppChromeTemplate";
+import { ROUTES } from "@/config/routes";
+import type { UiInboxNotification, UiNotificationInbox } from "@/types/notification/ui";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type NotificationInboxTemplateProps = {
+  inbox?: UiNotificationInbox;
+  items?: UiInboxNotification[];
+};
+
+function fromLegacy(items: UiInboxNotification[]): UiNotificationInbox {
+  const mapped = items.map((item) => ({
+    id: item.id,
+    type: item.type === "JOIN_REQUESTED" || item.type === "JOIN_REJECTED" ? "JOIN_REQUEST" as const : "CREATION" as const,
+    title: item.title,
+    body: item.body,
+    href: item.href,
+    read: !item.unread,
+    createdAt: item.createdAt,
+  }));
+  return {
+    items: mapped,
+    unreadCount: mapped.filter((item) => !item.read).length,
+  };
+}
+
+export function NotificationInboxTemplate({ inbox, items }: NotificationInboxTemplateProps) {
+  const router = useRouter();
+  const [state, setState] = useState<UiNotificationInbox>(
+    inbox ?? fromLegacy(items ?? []),
+  );
+
+  async function handleMarkAllRead() {
+    const result = await markAllNotificationsReadAction();
+    if (result.ok) {
+      setState({
+        items: state.items.map((item) => ({ ...item, read: true })),
+        unreadCount: 0,
+      });
+    }
+  }
+
+  return (
+    <AppChromeTemplate
+      activeTab="mypage"
+      variant="light"
+      padded="none"
+      header={
+        <ScreenHeader
+          tone="sticky"
+          backHref={ROUTES.home}
+          title="알림"
+          trailing={
+            <button
+              type="button"
+              className="border-0 bg-transparent text-[0.8rem] font-semibold text-[var(--dl-color-text-brand)]"
+              onClick={() => void handleMarkAllRead()}
+            >
+              모두 읽음
+            </button>
+          }
+        />
+      }
+    >
+      <div className="px-6 pb-8 pt-2">
+        <p className="mb-3 text-xs text-[var(--dl-color-text-secondary)]">
+          읽지 않은 알림 {state.unreadCount}개
+        </p>
+        <NotificationInboxList
+          items={state.items}
+          variant="light"
+          onItemClick={(item) => {
+            void markNotificationReadAction(item.id);
+            router.push(item.href);
+          }}
+        />
+      </div>
+    </AppChromeTemplate>
+  );
+}

--- a/components/templates/RoomManageTemplates.tsx
+++ b/components/templates/RoomManageTemplates.tsx
@@ -44,7 +44,7 @@ export function RoomManageHubTemplate({
   return (
     <AgitFlowChrome>
       <AuthTopBar title="아지트관리" backHref={ROUTES.agit.detail(agit.id)} />
-      <JoinRequestsSection agitId={agit.id} requests={joinRequests} />
+      <JoinRequestsSection agitId={agit.id} agitName={agit.name} requests={joinRequests} />
       <AgitManageForm agit={agit} />
     </AgitFlowChrome>
   );

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -33,6 +33,7 @@ export { IntroTemplate } from "./IntroTemplate";
 export { LoginTemplate } from "./LoginTemplate";
 export { MyPageTemplate } from "./MyPageTemplate";
 export { NotificationSettingsTemplate } from "./NotificationSettingsTemplate";
+export { NotificationInboxTemplate } from "./NotificationInboxTemplate";
 export { TermsAgreementsTemplate } from "./TermsAgreementsTemplate";
 export { PollCreateTemplate, PollEditTemplate } from "./PollTemplates";
 export { RecordCalendarTemplate } from "./RecordCalendarTemplate";

--- a/config/api-endpoints.ts
+++ b/config/api-endpoints.ts
@@ -28,6 +28,12 @@ export const API_ENDPOINTS = {
     profile: gatewayPath("user", "/api/v1/users/me/profile"),
     password: gatewayPath("user", "/api/v1/users/me/password"),
     notificationSettings: gatewayPath("user", "/api/v1/users/me/notification-settings"),
+    notifications: gatewayPath("user", "/api/v1/users/me/notifications"),
+    notificationUnreadCount: gatewayPath("user", "/api/v1/users/me/notifications/unread-count"),
+    notificationRead: (id: number) =>
+      gatewayPath("user", `/api/v1/users/me/notifications/${id}/read`),
+    notificationReadAll: gatewayPath("user", "/api/v1/users/me/notifications/read-all"),
+    notificationSeed: gatewayPath("user", "/api/v1/users/me/notifications/seed"),
     termsAgreements: gatewayPath("user", "/api/v1/users/me/terms-agreements"),
   },
   agit: {
@@ -88,6 +94,8 @@ export const API_ENDPOINTS = {
   },
   video: {
     uploadUrl: gatewayPath("video", "/api/v1/videos/upload-url"),
+    thumbnailUploadUrl: (videoUuid: string) =>
+      gatewayPath("video", `/api/v1/videos/${videoUuid}/thumbnail-upload-url`),
     complete: (videoUuid: string) =>
       gatewayPath("video", `/api/v1/videos/${videoUuid}/complete`),
     detail: (videoUuid: string) => gatewayPath("video", `/api/v1/videos/${videoUuid}`),

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -66,11 +66,13 @@ export const ROUTES = {
     refund: "/shop/refund",
     refundHistory: "/shop/refund/history",
   },
+  notifications: "/notifications",
   mypage: {
     root: "/mypage",
     profile: "/mypage/profile",
     password: "/mypage/profile/password",
     notifications: "/mypage/notifications",
+    inbox: "/notifications",
     termsAgreements: "/mypage/terms-agreements",
     settings: "/mypage/settings",
   },

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -76,7 +76,12 @@ export function useVideoCaptureFlow() {
   const uploadBlob = useCallback(
     async (
       blob: Blob,
-      options?: { caption?: string; recorderMimeType?: string; localPreviewUrl?: string | null },
+      options?: {
+        caption?: string;
+        recorderMimeType?: string;
+        localPreviewUrl?: string | null;
+        thumbnail?: Blob;
+      },
     ) => {
       setUploading(true);
       setFlowError(null);
@@ -87,6 +92,7 @@ export function useVideoCaptureFlow() {
           caption: options?.caption ?? DEFAULT_CAPTURE_CAPTION,
           recorderMimeType: options?.recorderMimeType ?? blob.type,
           localPreviewUrl: options?.localPreviewUrl,
+          thumbnail: options?.thumbnail,
         });
 
         setUploadResult(result);
@@ -103,7 +109,7 @@ export function useVideoCaptureFlow() {
   );
 
   const uploadCapture = useCallback(
-    async (caption = DEFAULT_CAPTURE_CAPTION) => {
+    async (caption = DEFAULT_CAPTURE_CAPTION, thumbnail?: Blob) => {
       if (!recorder.blob) {
         setFlowError("Recorded blob is missing");
         return null;
@@ -113,17 +119,19 @@ export function useVideoCaptureFlow() {
         caption,
         recorderMimeType: recorder.mimeType,
         localPreviewUrl: recorder.previewUrl,
+        thumbnail,
       });
     },
     [recorder.blob, recorder.mimeType, recorder.previewUrl, uploadBlob],
   );
 
   const uploadFile = useCallback(
-    async (file: File, caption = DEFAULT_CAPTURE_CAPTION) => {
+    async (file: File, caption = DEFAULT_CAPTURE_CAPTION, thumbnail?: Blob) => {
       return uploadBlob(file, {
         caption,
         recorderMimeType: file.type,
         localPreviewUrl: URL.createObjectURL(file),
+        thumbnail,
       });
     },
     [uploadBlob],

--- a/lib/action/userActionError.ts
+++ b/lib/action/userActionError.ts
@@ -14,6 +14,7 @@ const USER_API_ERROR_MESSAGES: Record<string, string> = {
   TERMS_002: "변경할 약관 항목이 없습니다.",
   NOTIFY_001: "알림 설정을 찾을 수 없습니다.",
   NOTIFY_002: "변경할 알림 설정 항목이 없습니다.",
+  NOTIFY_003: "알림을 찾을 수 없습니다.",
 };
 
 function mapUserApiErrorMessage(error: ApiError): string {

--- a/lib/api/analyticsApi.ts
+++ b/lib/api/analyticsApi.ts
@@ -11,17 +11,20 @@ export async function searchDiscoverAgits(input: {
   page?: number;
   size?: number;
 }): Promise<ApiDiscoverSearchPage> {
-  return apiFetch<ApiDiscoverSearchPage>(API_ENDPOINTS.analytics.search, {
-    method: "GET",
-    baseUrl: getApiUrl(),
-    auth: false,
-    searchParams: {
-      q: input.q,
-      sort: input.sort,
-      page: input.page == null ? undefined : String(input.page),
-      size: input.size == null ? undefined : String(input.size),
-    },
-  });
+  // 게이트웨이 검색은 permitAll이지만, analytics가 X-User-UUID를 요구하면
+  // 세션이 있을 때 JWT를 붙여 500을 피한다. 비로그인 요청은 헤더 없이 그대로 호출한다.
+  return withAuthRetry(() =>
+    apiFetch<ApiDiscoverSearchPage>(API_ENDPOINTS.analytics.search, {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      searchParams: {
+        q: input.q,
+        sort: input.sort,
+        page: input.page == null ? undefined : String(input.page),
+        size: input.size == null ? undefined : String(input.size),
+      },
+    }),
+  );
 }
 
 export async function publishAnalyticsEvent(type: string, agitUuid: string): Promise<void> {

--- a/lib/api/notificationApi.ts
+++ b/lib/api/notificationApi.ts
@@ -1,0 +1,62 @@
+import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { getActorUserHeaders } from "@/lib/api/actorHeaders";
+import { apiFetch } from "@/lib/api/apiFetch";
+import { getApiUrl } from "@/lib/api/env";
+import { withAuthRetry } from "@/lib/api/withAuthRetry";
+import type {
+  ApiNotificationInboxResponse,
+  ApiNotificationItem,
+  ApiNotificationReadAllResponse,
+  ApiNotificationUnreadCountResponse,
+} from "@/types/notification/api";
+
+export async function listNotifications(limit = 30): Promise<ApiNotificationInboxResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiNotificationInboxResponse>(API_ENDPOINTS.users.notifications, {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+      searchParams: { limit: String(limit) },
+    }),
+  );
+}
+
+export async function getUnreadNotificationCount(): Promise<ApiNotificationUnreadCountResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiNotificationUnreadCountResponse>(API_ENDPOINTS.users.notificationUnreadCount, {
+      method: "GET",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function markNotificationRead(id: number): Promise<ApiNotificationItem> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiNotificationItem>(API_ENDPOINTS.users.notificationRead(id), {
+      method: "PATCH",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function markAllNotificationsRead(): Promise<ApiNotificationReadAllResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiNotificationReadAllResponse>(API_ENDPOINTS.users.notificationReadAll, {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}
+
+export async function seedNotifications(): Promise<ApiNotificationInboxResponse> {
+  return withAuthRetry(async () =>
+    apiFetch<ApiNotificationInboxResponse>(API_ENDPOINTS.users.notificationSeed, {
+      method: "POST",
+      baseUrl: getApiUrl(),
+      headers: await getActorUserHeaders(),
+    }),
+  );
+}

--- a/lib/api/videoApi.ts
+++ b/lib/api/videoApi.ts
@@ -12,6 +12,7 @@ import type {
   VideoDownloadUrlProcessingResponse,
   VideoDownloadUrlResponse,
   VideoDownloadUrlResult,
+  VideoThumbnailUploadUrlResponse,
   VideoUploadUrlResponse,
 } from "@/types/video/api";
 
@@ -53,6 +54,23 @@ export async function postUploadUrl(
       contentLengthBytes: String(contentLengthBytes),
     },
   });
+}
+
+export async function postThumbnailUploadUrl(
+  videoUuid: string,
+  contentType: string | undefined,
+  contentLengthBytes: number,
+): Promise<VideoThumbnailUploadUrlResponse> {
+  return videoFetch<VideoThumbnailUploadUrlResponse>(
+    API_ENDPOINTS.video.thumbnailUploadUrl(videoUuid),
+    {
+      method: "POST",
+      searchParams: {
+        contentType,
+        contentLengthBytes: String(contentLengthBytes),
+      },
+    },
+  );
 }
 
 export async function postComplete(

--- a/lib/auth/safe-callback-url.ts
+++ b/lib/auth/safe-callback-url.ts
@@ -1,19 +1,29 @@
 import { ROUTES } from "@/config/routes";
 
+const DEFAULT_AFTER_AUTH = ROUTES.home;
+
+function isLandingPath(path: string): boolean {
+  return path === "/" || path === ROUTES.intro || path === "/intro";
+}
+
 export function getSafeCallbackUrl(raw: string | null | undefined): string {
   if (!raw) {
-    return ROUTES.diary.root;
+    return DEFAULT_AFTER_AUTH;
   }
 
   let decoded = raw;
   try {
     decoded = decodeURIComponent(raw);
   } catch {
-    return ROUTES.diary.root;
+    return DEFAULT_AFTER_AUTH;
   }
 
   if (!decoded.startsWith("/") || decoded.startsWith("//") || decoded.includes("://")) {
-    return ROUTES.diary.root;
+    return DEFAULT_AFTER_AUTH;
+  }
+
+  if (isLandingPath(decoded)) {
+    return DEFAULT_AFTER_AUTH;
   }
 
   return decoded;

--- a/lib/db/loadEnvFile.ts
+++ b/lib/db/loadEnvFile.ts
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ENV_CANDIDATES = [
+  resolve(process.cwd(), "env"),
+  resolve(process.cwd(), ".env"),
+  resolve(process.cwd(), ".env.local"),
+];
+
+function parseEnvFile(contents: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export function loadWorkspaceEnv(): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const filePath of ENV_CANDIDATES) {
+    if (!existsSync(filePath)) continue;
+    Object.assign(merged, parseEnvFile(readFileSync(filePath, "utf8")));
+  }
+  return merged;
+}
+
+export function readEnvValue(name: string, fallback = ""): string {
+  const fromProcess = process.env[name]?.trim();
+  if (fromProcess) return fromProcess;
+  const fromFile = loadWorkspaceEnv()[name]?.trim();
+  return fromFile || fallback;
+}

--- a/lib/db/mysql.ts
+++ b/lib/db/mysql.ts
@@ -1,0 +1,54 @@
+import mysql from "mysql2/promise";
+import { readEnvValue } from "@/lib/db/loadEnvFile";
+
+const DEFAULT_DB_HOST = "192.168.10.144";
+const DEFAULT_DB_PORT = 3308;
+
+export function uuidToBin(uuid: string): Buffer {
+  return Buffer.from(uuid.replace(/-/g, ""), "hex");
+}
+
+export function binToUuid(value: Buffer | Uint8Array | string): string {
+  const hex = Buffer.isBuffer(value)
+    ? value.toString("hex")
+    : typeof value === "string"
+      ? value.replace(/-/g, "")
+      : Buffer.from(value).toString("hex");
+  const normalized = hex.toLowerCase();
+  return `${normalized.slice(0, 8)}-${normalized.slice(8, 12)}-${normalized.slice(12, 16)}-${normalized.slice(16, 20)}-${normalized.slice(20)}`;
+}
+
+function mysqlConfig(): mysql.PoolOptions {
+  return {
+    host: readEnvValue("DB_HOST", DEFAULT_DB_HOST),
+    port: Number(readEnvValue("MYSQL_PORT", String(DEFAULT_DB_PORT))) || DEFAULT_DB_PORT,
+    user: readEnvValue("DB_USERNAME", "root"),
+    password: readEnvValue("DB_PASSWORD"),
+    database: "plip_user",
+    waitForConnections: true,
+    connectionLimit: 4,
+    connectTimeout: 2500,
+    namedPlaceholders: true,
+  };
+}
+
+let pool: mysql.Pool | null = null;
+
+export function getMysqlPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool(mysqlConfig());
+  }
+  return pool;
+}
+
+export async function queryMysql<T extends mysql.RowDataPacket>(
+  sql: string,
+  params?: unknown[],
+): Promise<T[]> {
+  const [rows] = await getMysqlPool().query<T[]>(sql, params);
+  return rows;
+}
+
+export async function executeMysql(sql: string, params?: unknown[]): Promise<void> {
+  await getMysqlPool().query(sql, params);
+}

--- a/lib/notification/localInboxStore.ts
+++ b/lib/notification/localInboxStore.ts
@@ -1,0 +1,165 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  ApiNotificationInboxResponse,
+  ApiNotificationItem,
+  ApiNotificationType,
+} from "@/types/notification/api";
+
+type StoreUser = {
+  seq: number;
+  items: ApiNotificationItem[];
+};
+
+type StoreFile = {
+  users: Record<string, StoreUser>;
+};
+
+const STORE_PATH = path.join(process.cwd(), ".data", "notifications.json");
+
+const SEED_ITEMS: Array<Omit<ApiNotificationItem, "id" | "read" | "createdAt">> = [
+  {
+    type: "CHAT",
+    title: "새 채팅 메시지",
+    body: "아지트에서 새 메시지가 도착했습니다.",
+    deepLink: "/agit",
+    resourceId: "seed-chat",
+    agitUuid: null,
+  },
+  {
+    type: "JOIN_REQUEST",
+    title: "입장 요청",
+    body: "누군가 아지트 입장을 요청했습니다.",
+    deepLink: "/agit",
+    resourceId: "seed-join",
+    agitUuid: null,
+  },
+  {
+    type: "CREATION",
+    title: "아지트가 생성되었습니다",
+    body: "새 아지트가 준비되었습니다.",
+    deepLink: "/agit",
+    resourceId: "seed-creation",
+    agitUuid: null,
+  },
+  {
+    type: "TOPIC",
+    title: "새 토픽",
+    body: "아지트에 새 토픽이 열렸습니다.",
+    deepLink: "/agit",
+    resourceId: "seed-topic",
+    agitUuid: null,
+  },
+  {
+    type: "POST",
+    title: "새로운 글",
+    body: "다이어리·피드에 새 글이 올라왔습니다.",
+    deepLink: "/diary",
+    resourceId: "seed-post",
+    agitUuid: null,
+  },
+];
+
+function emptyStore(): StoreFile {
+  return { users: {} };
+}
+
+function unreadCount(items: ApiNotificationItem[]): number {
+  return items.filter((item) => !item.read).length;
+}
+
+function toInbox(user: StoreUser): ApiNotificationInboxResponse {
+  const items = [...user.items].sort((left, right) => {
+    const leftAt = left.createdAt ?? "";
+    const rightAt = right.createdAt ?? "";
+    return rightAt.localeCompare(leftAt);
+  });
+  return { items, unreadCount: unreadCount(items) };
+}
+
+async function readStore(): Promise<StoreFile> {
+  try {
+    const raw = await readFile(STORE_PATH, "utf8");
+    const parsed = JSON.parse(raw) as StoreFile;
+    if (!parsed || typeof parsed !== "object" || !parsed.users) {
+      return emptyStore();
+    }
+    return parsed;
+  } catch {
+    return emptyStore();
+  }
+}
+
+async function writeStore(store: StoreFile): Promise<void> {
+  await mkdir(path.dirname(STORE_PATH), { recursive: true });
+  await writeFile(STORE_PATH, JSON.stringify(store, null, 2), "utf8");
+}
+
+function userBucket(store: StoreFile, userUuid: string): StoreUser {
+  if (!store.users[userUuid]) {
+    store.users[userUuid] = { seq: 0, items: [] };
+  }
+  return store.users[userUuid];
+}
+
+export async function listLocalInbox(userUuid: string): Promise<ApiNotificationInboxResponse> {
+  const store = await readStore();
+  return toInbox(userBucket(store, userUuid));
+}
+
+export async function countLocalUnread(userUuid: string): Promise<number> {
+  const inbox = await listLocalInbox(userUuid);
+  return inbox.unreadCount;
+}
+
+export async function markLocalRead(userUuid: string, id: number): Promise<ApiNotificationItem> {
+  const store = await readStore();
+  const user = userBucket(store, userUuid);
+  const item = user.items.find((entry) => entry.id === id);
+  if (!item) {
+    throw new Error("알림을 찾을 수 없습니다.");
+  }
+  item.read = true;
+  await writeStore(store);
+  return item;
+}
+
+export async function markLocalAllRead(userUuid: string): Promise<number> {
+  const store = await readStore();
+  const user = userBucket(store, userUuid);
+  let updated = 0;
+  for (const item of user.items) {
+    if (!item.read) {
+      item.read = true;
+      updated += 1;
+    }
+  }
+  await writeStore(store);
+  return updated;
+}
+
+export async function seedLocalInbox(userUuid: string): Promise<ApiNotificationInboxResponse> {
+  const store = await readStore();
+  const user = userBucket(store, userUuid);
+  const existing = new Set(user.items.map((item) => item.resourceId));
+  const now = new Date().toISOString();
+  for (const seed of SEED_ITEMS) {
+    if (existing.has(seed.resourceId)) {
+      continue;
+    }
+    user.seq += 1;
+    user.items.push({
+      id: user.seq,
+      type: seed.type as ApiNotificationType,
+      title: seed.title,
+      body: seed.body,
+      deepLink: seed.deepLink,
+      resourceId: seed.resourceId,
+      agitUuid: seed.agitUuid,
+      read: false,
+      createdAt: now,
+    });
+  }
+  await writeStore(store);
+  return toInbox(user);
+}

--- a/lib/notifications/inbox.ts
+++ b/lib/notifications/inbox.ts
@@ -1,0 +1,161 @@
+import { ROUTES } from "@/config/routes";
+import { binToUuid, executeMysql, queryMysql, uuidToBin } from "@/lib/db/mysql";
+import { INBOX_COPY, type UiInboxNotification, type UiInboxNotificationType } from "@/types/notification/ui";
+import type { RowDataPacket } from "mysql2";
+
+type PendingJoinRow = RowDataPacket & {
+  amp_id: number;
+  requester_uuid: Buffer;
+  requester_nickname: string;
+  agit_uuid: Buffer;
+  agit_name: string;
+  requested_at: Date | string | null;
+};
+
+type StoredInboxRow = RowDataPacket & {
+  id: number;
+  type: string;
+  title: string;
+  body: string | null;
+  link_path: string | null;
+  read_at: Date | string | null;
+  created_at: Date | string | null;
+};
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export async function ensureInboxTable(): Promise<void> {
+  await executeMysql(
+    `CREATE TABLE IF NOT EXISTS plip_user.user_inbox_notifications (
+      id BIGINT PRIMARY KEY AUTO_INCREMENT,
+      user_uuid BINARY(16) NOT NULL,
+      type VARCHAR(40) NOT NULL,
+      title VARCHAR(200) NOT NULL,
+      body VARCHAR(500) NULL,
+      link_path VARCHAR(255) NULL,
+      agit_uuid BINARY(16) NULL,
+      read_at DATETIME NULL,
+      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      KEY idx_inbox_user_created (user_uuid, created_at)
+    )`,
+  );
+}
+
+export async function listLiveJoinRequestNotifications(
+  hostUserUuid: string,
+): Promise<UiInboxNotification[]> {
+  const rows = await queryMysql<PendingJoinRow>(
+    `SELECT
+        m.id AS amp_id,
+        m.user_uuid AS requester_uuid,
+        m.nickname AS requester_nickname,
+        a.agit_uuid AS agit_uuid,
+        a.agit_name AS agit_name,
+        m.updated_at AS requested_at
+      FROM plip_agit.agit_member_profiles m
+      JOIN plip_agit.agits a ON a.id = m.agit_id
+      JOIN plip_agit.agit_member_profiles h
+        ON h.agit_id = a.id AND h.role = 'HOST' AND h.status = 'ACTIVE'
+      WHERE h.user_uuid = ?
+        AND m.status = 'PENDING'
+        AND (a.status = 'ACTIVE' OR a.status IS NULL)
+      ORDER BY m.updated_at DESC
+      LIMIT 200`,
+    [uuidToBin(hostUserUuid)],
+  );
+
+  return rows.map((row) => {
+    const agitId = binToUuid(row.agit_uuid);
+    return {
+      id: `live:${agitId}:${row.amp_id}`,
+      type: "JOIN_REQUESTED",
+      title: INBOX_COPY.JOIN_REQUESTED,
+      body: `${row.requester_nickname}님이 ${row.agit_name}에 입장 요청을 보냈어요`,
+      href: ROUTES.agit.manage(agitId),
+      createdAt: toIso(row.requested_at),
+      unread: true,
+    };
+  });
+}
+
+export async function listStoredInboxNotifications(
+  userUuid: string,
+): Promise<UiInboxNotification[]> {
+  await ensureInboxTable();
+  const rows = await queryMysql<StoredInboxRow>(
+    `SELECT id, type, title, body, link_path, read_at, created_at
+       FROM plip_user.user_inbox_notifications
+      WHERE user_uuid = ?
+      ORDER BY created_at DESC
+      LIMIT 200`,
+    [uuidToBin(userUuid)],
+  );
+
+  return rows.map((row) => ({
+    id: `stored:${row.id}`,
+    type: (row.type as UiInboxNotificationType) || "JOIN_REQUESTED",
+    title: row.title,
+    body: row.body ?? "",
+    href: row.link_path || ROUTES.notifications,
+    createdAt: toIso(row.created_at),
+    unread: !row.read_at,
+  }));
+}
+
+export async function listInboxNotifications(userUuid: string): Promise<UiInboxNotification[]> {
+  const [live, stored] = await Promise.all([
+    listLiveJoinRequestNotifications(userUuid).catch(() => [] as UiInboxNotification[]),
+    listStoredInboxNotifications(userUuid).catch(() => [] as UiInboxNotification[]),
+  ]);
+
+  return [...live, ...stored].sort((left, right) => {
+    const leftTime = left.createdAt ? Date.parse(left.createdAt) : 0;
+    const rightTime = right.createdAt ? Date.parse(right.createdAt) : 0;
+    return rightTime - leftTime;
+  });
+}
+
+export async function countUnreadInbox(userUuid: string): Promise<number> {
+  const items = await listInboxNotifications(userUuid);
+  return items.filter((item) => item.unread).length;
+}
+
+export async function appendInboxNotification(input: {
+  userUuid: string;
+  type: UiInboxNotificationType;
+  title?: string;
+  body: string;
+  href?: string;
+  agitUuid?: string;
+}): Promise<void> {
+  await ensureInboxTable();
+  await executeMysql(
+    `INSERT INTO plip_user.user_inbox_notifications
+      (user_uuid, type, title, body, link_path, agit_uuid, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, NOW())`,
+    [
+      uuidToBin(input.userUuid),
+      input.type,
+      input.title ?? INBOX_COPY[input.type],
+      input.body,
+      input.href ?? null,
+      input.agitUuid ? uuidToBin(input.agitUuid) : null,
+    ],
+  );
+}
+
+export async function markInboxNotificationRead(id: string, userUuid: string): Promise<void> {
+  if (!id.startsWith("stored:")) return;
+  const numericId = Number(id.slice("stored:".length));
+  if (!Number.isInteger(numericId)) return;
+  await executeMysql(
+    `UPDATE plip_user.user_inbox_notifications
+        SET read_at = COALESCE(read_at, NOW())
+      WHERE id = ? AND user_uuid = ?`,
+    [numericId, uuidToBin(userUuid)],
+  );
+}

--- a/lib/user/prepareProfileImage.ts
+++ b/lib/user/prepareProfileImage.ts
@@ -1,0 +1,55 @@
+import { PROFILE_IMAGE_MAX_BYTES, PROFILE_IMAGE_MAX_MB } from "@/lib/user/profileImage";
+
+const MAX_EDGE = 720;
+const JPEG_QUALITY = 0.86;
+
+export async function prepareProfileImageFile(file: File): Promise<File> {
+  if (!file.type.startsWith("image/")) {
+    throw new Error("이미지 파일만 올릴 수 있습니다.");
+  }
+  if (file.size > PROFILE_IMAGE_MAX_BYTES * 4) {
+    throw new Error(`이미지는 ${PROFILE_IMAGE_MAX_MB}MB 이하여야 합니다.`);
+  }
+
+  if (typeof createImageBitmap !== "function" || typeof document === "undefined") {
+    if (file.size > PROFILE_IMAGE_MAX_BYTES) {
+      throw new Error(`이미지는 ${PROFILE_IMAGE_MAX_MB}MB 이하여야 합니다.`);
+    }
+    return file;
+  }
+
+  const bitmap = await createImageBitmap(file);
+  const scale = Math.min(1, MAX_EDGE / Math.max(bitmap.width, bitmap.height));
+  const width = Math.max(1, Math.round(bitmap.width * scale));
+  const height = Math.max(1, Math.round(bitmap.height * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d");
+  if (!context) {
+    bitmap.close();
+    if (file.size > PROFILE_IMAGE_MAX_BYTES) {
+      throw new Error(`이미지는 ${PROFILE_IMAGE_MAX_MB}MB 이하여야 합니다.`);
+    }
+    return file;
+  }
+
+  context.drawImage(bitmap, 0, 0, width, height);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, "image/jpeg", JPEG_QUALITY);
+  });
+  if (!blob) {
+    if (file.size > PROFILE_IMAGE_MAX_BYTES) {
+      throw new Error(`이미지는 ${PROFILE_IMAGE_MAX_MB}MB 이하여야 합니다.`);
+    }
+    return file;
+  }
+  if (blob.size > PROFILE_IMAGE_MAX_BYTES) {
+    throw new Error(`이미지는 ${PROFILE_IMAGE_MAX_MB}MB 이하여야 합니다.`);
+  }
+
+  return new File([blob], "profile.jpg", { type: "image/jpeg" });
+}

--- a/lib/user/profileImage.ts
+++ b/lib/user/profileImage.ts
@@ -1,14 +1,43 @@
 import { DEFAULT_PROFILE_AVATAR } from "@/types/user/ui";
 
+const PROFILE_IMAGE_DIR = "/images/profile";
+
+export const PROFILE_IMAGE_ACCEPT = "image/jpeg,image/png,image/webp";
+export const PROFILE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const PROFILE_IMAGE_MAX_MB = 5;
+
+const EXT_BY_TYPE: Record<string, ".jpg" | ".png" | ".webp"> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+
 export function resolveProfileImageUrl(profileImagePath?: string | null): string {
-  if (!profileImagePath) {
+  if (!profileImagePath?.trim()) {
     return DEFAULT_PROFILE_AVATAR;
   }
-  if (profileImagePath.startsWith("http://") || profileImagePath.startsWith("https://")) {
-    return profileImagePath;
+
+  const trimmed = profileImagePath.trim();
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://") || trimmed.startsWith("/")) {
+    return trimmed;
   }
-  if (profileImagePath.startsWith("/")) {
-    return profileImagePath;
+
+  const basename = trimmed.split("/").pop()?.trim();
+  if (!basename) {
+    return DEFAULT_PROFILE_AVATAR;
   }
-  return DEFAULT_PROFILE_AVATAR;
+
+  return `${PROFILE_IMAGE_DIR}/${basename}`;
+}
+
+export function profileImageExtension(contentType: string): ".jpg" | ".png" | ".webp" | null {
+  return EXT_BY_TYPE[contentType] ?? null;
+}
+
+export function toStoredProfileImagePath(
+  userUuid: string,
+  ext: ".jpg" | ".png" | ".webp",
+  stamp = Date.now(),
+): string {
+  return `${PROFILE_IMAGE_DIR}/${userUuid}_${stamp}${ext}`;
 }

--- a/lib/user/saveProfileImage.ts
+++ b/lib/user/saveProfileImage.ts
@@ -1,0 +1,31 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  PROFILE_IMAGE_MAX_BYTES,
+  PROFILE_IMAGE_MAX_MB,
+  profileImageExtension,
+  toStoredProfileImagePath,
+} from "@/lib/user/profileImage";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function saveProfileImageFile(userUuid: string, file: File): Promise<string> {
+  if (!UUID_RE.test(userUuid)) {
+    throw new Error("사용자 정보를 확인할 수 없습니다.");
+  }
+
+  const ext = profileImageExtension(file.type);
+  if (!ext) {
+    throw new Error("JPG, PNG, WEBP 이미지만 올릴 수 있습니다.");
+  }
+  if (file.size > PROFILE_IMAGE_MAX_BYTES) {
+    throw new Error(`이미지는 ${PROFILE_IMAGE_MAX_MB}MB 이하여야 합니다.`);
+  }
+
+  const dir = path.join(process.cwd(), "public", "images", "profile");
+  await mkdir(dir, { recursive: true });
+  const storedPath = toStoredProfileImagePath(userUuid, ext);
+  const filename = storedPath.slice(storedPath.lastIndexOf("/") + 1);
+  await writeFile(path.join(dir, filename), Buffer.from(await file.arrayBuffer()));
+  return storedPath;
+}

--- a/lib/video/actionPayload.ts
+++ b/lib/video/actionPayload.ts
@@ -2,12 +2,14 @@ import type {
   VideoCompleteActionData,
   VideoDetailActionData,
   VideoDownloadUrlActionData,
+  VideoThumbnailUploadUrlActionData,
   VideoUploadUrlActionData,
 } from "@/types/video/action";
 import type {
   VideoCompleteUi,
   VideoDetailUi,
   VideoDownloadUrlUi,
+  VideoThumbnailUploadUrlUi,
   VideoUploadUrlUi,
 } from "@/types/video/ui";
 
@@ -15,6 +17,17 @@ export function toUploadUrlActionData(data: VideoUploadUrlUi): VideoUploadUrlAct
   return {
     videoUuid: data.videoUuid,
     rawS3Key: data.rawS3Key,
+    uploadUrl: data.uploadUrl,
+    expiresAt: data.expiresAt.toISOString(),
+  };
+}
+
+export function toThumbnailUploadUrlActionData(
+  data: VideoThumbnailUploadUrlUi,
+): VideoThumbnailUploadUrlActionData {
+  return {
+    videoUuid: data.videoUuid,
+    thumbnailS3Key: data.thumbnailS3Key,
     uploadUrl: data.uploadUrl,
     expiresAt: data.expiresAt.toISOString(),
   };

--- a/lib/video/constants.ts
+++ b/lib/video/constants.ts
@@ -36,6 +36,11 @@ export const DEFAULT_CAPTURE_CAPTION = "";
 
 export const CAPTION_MAX_LENGTH = 80;
 
+export const THUMBNAIL_CONTENT_TYPE = "image/jpeg";
+export const THUMBNAIL_MAX_BYTES = 2 * 1024 * 1024;
+export const THUMBNAIL_MAX_MB = THUMBNAIL_MAX_BYTES / (1024 * 1024);
+export const THUMBNAIL_JPEG_QUALITY = 0.86;
+
 /** Drop sample.mp3 at public/plip/video/sample.mp3. Missing file falls back to a click. */
 export const SHUTTER_SOUND_SRC = "/plip/video/sample.mp3";
 

--- a/lib/video/prepareThumbnail.ts
+++ b/lib/video/prepareThumbnail.ts
@@ -1,0 +1,75 @@
+import { waitForVideoFrame } from "@/lib/video/captureCanvas";
+import {
+  CAPTURE_HEIGHT,
+  CAPTURE_WIDTH,
+  THUMBNAIL_CONTENT_TYPE,
+  THUMBNAIL_JPEG_QUALITY,
+  THUMBNAIL_MAX_BYTES,
+  THUMBNAIL_MAX_MB,
+} from "@/lib/video/constants";
+import { drawCoverCrop } from "@/lib/video/coverCrop";
+
+function canvasToJpegFile(canvas: HTMLCanvasElement, name: string): Promise<File> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("썸네일 이미지를 만들지 못했습니다."));
+          return;
+        }
+        if (blob.size > THUMBNAIL_MAX_BYTES) {
+          reject(new Error(`썸네일은 ${THUMBNAIL_MAX_MB}MB 이하여야 합니다.`));
+          return;
+        }
+        resolve(new File([blob], name, { type: THUMBNAIL_CONTENT_TYPE }));
+      },
+      THUMBNAIL_CONTENT_TYPE,
+      THUMBNAIL_JPEG_QUALITY,
+    );
+  });
+}
+
+export async function prepareThumbnailImage(file: File): Promise<File> {
+  if (!file.type.startsWith("image/")) {
+    throw new Error("이미지 파일만 올릴 수 있습니다.");
+  }
+
+  if (typeof createImageBitmap !== "function" || typeof document === "undefined") {
+    if (file.size > THUMBNAIL_MAX_BYTES) {
+      throw new Error(`썸네일은 ${THUMBNAIL_MAX_MB}MB 이하여야 합니다.`);
+    }
+    return new File([file], "thumbnail.jpg", { type: file.type || THUMBNAIL_CONTENT_TYPE });
+  }
+
+  const bitmap = await createImageBitmap(file);
+  const canvas = document.createElement("canvas");
+  canvas.width = CAPTURE_WIDTH;
+  canvas.height = CAPTURE_HEIGHT;
+  const context = canvas.getContext("2d", { alpha: false });
+  if (!context) {
+    bitmap.close();
+    throw new Error("썸네일 이미지를 만들지 못했습니다.");
+  }
+
+  drawCoverCrop(context, bitmap, bitmap.width, bitmap.height, CAPTURE_WIDTH, CAPTURE_HEIGHT);
+  bitmap.close();
+  return canvasToJpegFile(canvas, "thumbnail.jpg");
+}
+
+export async function captureVideoFrame(video: HTMLVideoElement): Promise<File> {
+  await waitForVideoFrame(video);
+  if (video.videoWidth < 2 || video.videoHeight < 2) {
+    throw new Error("영상 장면을 담을 수 없습니다. 영상이 준비된 뒤 다시 시도해 주세요.");
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = CAPTURE_WIDTH;
+  canvas.height = CAPTURE_HEIGHT;
+  const context = canvas.getContext("2d", { alpha: false });
+  if (!context) {
+    throw new Error("썸네일 이미지를 만들지 못했습니다.");
+  }
+
+  drawCoverCrop(context, video, video.videoWidth, video.videoHeight, CAPTURE_WIDTH, CAPTURE_HEIGHT);
+  return canvasToJpegFile(canvas, "thumbnail.jpg");
+}

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -1,9 +1,11 @@
 import {
   completeVideoAction,
   getVideoAction,
+  issueThumbnailUploadUrlAction,
   issueUploadUrlAction,
 } from "@/actions/videoActions";
 import { extractActionError } from "@/lib/video/actionPayload";
+import { THUMBNAIL_CONTENT_TYPE } from "@/lib/video/constants";
 import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";
 import { resolvePlaybackSource, type PlaybackSource } from "@/lib/video/playback";
 import { preparePlaybackMp4IfNeeded } from "@/lib/video/preparePlaybackMp4";
@@ -29,9 +31,28 @@ export type Phase0FUploadResult = VideoUploadPipelineResult & {
   playback: PlaybackSource;
 };
 
+async function uploadThumbnail(
+  videoUuid: string,
+  thumbnail: Blob,
+): Promise<string> {
+  const contentType = thumbnail.type || THUMBNAIL_CONTENT_TYPE;
+  const issued = await issueThumbnailUploadUrlAction(videoUuid, contentType, thumbnail.size);
+  const issuedError = extractActionError(issued);
+  if (issuedError || !issued.ok) {
+    throw new Error(
+      issuedError?.includes("[404]")
+        ? "서버가 아직 썸네일 업로드를 지원하지 않습니다. plip-video thumbnail-upload-url을 배포해 주세요."
+        : (issuedError ?? "thumbnail-upload-url failed"),
+    );
+  }
+
+  await putPresignedUpload(issued.data.uploadUrl, thumbnail, contentType);
+  return issued.data.thumbnailS3Key;
+}
+
 export async function uploadRecordedVideo(
   blob: Blob,
-  options?: { caption?: string; recorderMimeType?: string },
+  options?: { caption?: string; recorderMimeType?: string; thumbnail?: Blob },
 ): Promise<VideoUploadPipelineResult> {
   const prepared = await preparePlaybackMp4IfNeeded(blob);
   assertUploadSize(prepared);
@@ -45,9 +66,13 @@ export async function uploadRecordedVideo(
   }
 
   const { videoUuid, uploadUrl } = uploadUrlResult.data;
-  const putResult = await putPresignedUpload(uploadUrl, prepared, contentType);
+  const thumbnail = options?.thumbnail;
+  const [putResult, thumbnailS3Key] = await Promise.all([
+    putPresignedUpload(uploadUrl, prepared, contentType),
+    thumbnail && thumbnail.size > 0 ? uploadThumbnail(videoUuid, thumbnail) : Promise.resolve(undefined),
+  ]);
 
-  const completeResult = await completeVideoAction(videoUuid, options?.caption);
+  const completeResult = await completeVideoAction(videoUuid, options?.caption, thumbnailS3Key);
   const completeError = extractActionError(completeResult);
   if (completeError || !completeResult.ok) {
     throw new Error(completeError ?? "complete failed");
@@ -74,6 +99,7 @@ export async function runPhase0FUpload(
     caption?: string;
     recorderMimeType?: string;
     localPreviewUrl?: string | null;
+    thumbnail?: Blob;
   },
 ): Promise<Phase0FUploadResult> {
   const base = await uploadRecordedVideo(blob, options);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  serverExternalPackages: ["mysql2"],
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "6mb",
+    },
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,12 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/sockjs-client": "^1.5.4",
+        "bcryptjs": "^3.0.3",
         "eslint": "^9",
         "eslint-config-next": "16.3.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.3.0",
+        "mysql2": "^3.24.2",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -3500,6 +3502,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
@@ -3537,6 +3549,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {
@@ -5480,6 +5502,16 @@
       "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "license": "MIT"
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -6300,6 +6332,13 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7091,6 +7130,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7111,6 +7157,22 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/lucide-react": {
@@ -7293,6 +7355,41 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
+      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -9094,6 +9191,22 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "typecheck": "next typegen && tsc --noEmit",
     "test": "npm run typecheck && npm run lint",
     "prebuild": "npm run test",
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "seed:discover-agits": "node scripts/seed-discover-agits.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -27,6 +28,7 @@
     "framer-motion": "^13.1.1",
     "lucide-react": "^1.31.0",
     "mp4-muxer": "^5.2.2",
+    "mysql2": "^3.24.2",
     "next": "16.3.0",
     "next-auth": "^5.0.0-beta.32",
     "react": "19.2.8",
@@ -43,6 +45,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/sockjs-client": "^1.5.4",
+    "bcryptjs": "^3.0.3",
     "eslint": "^9",
     "eslint-config-next": "16.3.0",
     "husky": "^9.1.7",

--- a/scripts/seed-discover-agits.mjs
+++ b/scripts/seed-discover-agits.mjs
@@ -1,0 +1,585 @@
+/**
+ * Discover / 입장요청 더미 시드 (additive, 기존 DB를 drop 하지 않음)
+ *
+ * Dummy 계정
+ *   email   : dummy+{n}@plip.local   (n = 1..)
+ *   password: Dummy1234!
+ *
+ * 실행
+ *   npm run seed:discover-agits
+ *   node scripts/seed-discover-agits.mjs
+ *
+ * 환경변수(선택)
+ *   SEED_HOST_LIMIT=10          실유저가 50명을 넘으면 기본 10명으로 캡
+ *   SEED_AGITS_PER_HOST=100
+ *   SEED_DUMMY_USERS=20
+ *   API_URL=http://192.168.10.144:8000
+ *   AGIT_DIRECT_URL=http://192.168.10.144:8083
+ *   TOPIC_DIRECT_URL=http://192.168.10.144:8804
+ *
+ * DB_PASSWORD 는 C:\dev\plip-user-app\env 에서 읽습니다. 비밀값은 로그에 찍지 않습니다.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import bcrypt from "bcryptjs";
+import mysql from "mysql2/promise";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const DUMMY_PASSWORD = "Dummy1234!";
+const DUMMY_EMAIL_RE = /^dummy\+\d+@plip\.local$/i;
+const SEED_MARKER = "[seed-discover]";
+const AGITS_PER_HOST = Number(process.env.SEED_AGITS_PER_HOST || 100);
+const DUMMY_USER_COUNT = Number(process.env.SEED_DUMMY_USERS || 20);
+const PENDING_PER_HOST = Number(process.env.SEED_PENDING_AGITS_PER_HOST || 10);
+const DEFAULT_HOST = "192.168.10.144";
+const DEFAULT_API = `http://${DEFAULT_HOST}:8000`;
+const DEFAULT_AGIT_DIRECT = `http://${DEFAULT_HOST}:8083`;
+const DEFAULT_TOPIC_DIRECT = `http://${DEFAULT_HOST}:8804`;
+
+function loadEnvFile() {
+  const out = {};
+  for (const file of [resolve(ROOT, "env"), resolve(ROOT, ".env"), resolve(ROOT, ".env.local")]) {
+    if (!existsSync(file)) continue;
+    for (const raw of readFileSync(file, "utf8").split(/\r?\n/)) {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+      const eq = line.indexOf("=");
+      if (eq <= 0) continue;
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      out[line.slice(0, eq).trim()] = value;
+    }
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+function env(name, fallback = "") {
+  return (process.env[name] || fileEnv[name] || fallback).trim();
+}
+
+function uuidToBin(uuid) {
+  return Buffer.from(uuid.replace(/-/g, ""), "hex");
+}
+
+function binToUuid(value) {
+  const hex = Buffer.isBuffer(value)
+    ? value.toString("hex")
+    : Buffer.from(value).toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function sanitizeNickname(raw, fallback) {
+  const cleaned = String(raw || "").replace(/[^0-9A-Za-z가-힣]/g, "").slice(0, 12);
+  return cleaned.length >= 2 ? cleaned : fallback;
+}
+
+function inviteCode() {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let out = "";
+  for (let i = 0; i < 6; i += 1) {
+    out += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return out;
+}
+
+async function mapPool(items, limit, worker) {
+  const results = [];
+  let index = 0;
+  async function run() {
+    while (index < items.length) {
+      const current = index;
+      index += 1;
+      results[current] = await worker(items[current], current);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, run));
+  return results;
+}
+
+async function jsonFetch(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+  });
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+  }
+  return { ok: response.ok, status: response.status, data };
+}
+
+async function probeUrl(url) {
+  try {
+    const response = await fetch(url, { method: "GET" });
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const dbHost = env("DB_HOST", DEFAULT_HOST);
+  const dbPort = Number(env("MYSQL_PORT", "3308")) || 3308;
+  const dbUser = env("DB_USERNAME", "root");
+  const dbPassword = env("DB_PASSWORD");
+  if (!dbPassword) {
+    throw new Error("DB_PASSWORD 가 env 파일에 없습니다.");
+  }
+
+  const apiUrl = env("API_URL", DEFAULT_API).replace(/\/$/, "");
+  const agitDirect = env("AGIT_DIRECT_URL", DEFAULT_AGIT_DIRECT).replace(/\/$/, "");
+  const topicDirect = env("TOPIC_DIRECT_URL", DEFAULT_TOPIC_DIRECT).replace(/\/$/, "");
+
+  const conn = await mysql.createConnection({
+    host: dbHost,
+    port: dbPort,
+    user: dbUser,
+    password: dbPassword,
+    multipleStatements: true,
+  });
+
+  const stats = {
+    realUsersTotal: 0,
+    hostsUsed: 0,
+    dummyUsersCreated: 0,
+    dummyUsersReused: 0,
+    agitsCreated: 0,
+    agitsReused: 0,
+    activeJoins: 0,
+    pendingRequests: 0,
+    leaves: 0,
+    topicsCreated: 0,
+    notifications: 0,
+    catalogRows: 0,
+    apiCreates: 0,
+    sqlCreates: 0,
+  };
+
+  try {
+    console.log(`[seed] mysql ${dbHost}:${dbPort} (password hidden)`);
+    console.log(`[seed] api ${apiUrl}`);
+
+    await conn.query(`
+      CREATE TABLE IF NOT EXISTS plip_user.user_inbox_notifications (
+        id BIGINT PRIMARY KEY AUTO_INCREMENT,
+        user_uuid BINARY(16) NOT NULL,
+        type VARCHAR(40) NOT NULL,
+        title VARCHAR(200) NOT NULL,
+        body VARCHAR(500) NULL,
+        link_path VARCHAR(255) NULL,
+        agit_uuid BINARY(16) NULL,
+        read_at DATETIME NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        KEY idx_inbox_user_created (user_uuid, created_at)
+      )
+    `);
+
+    const [userRows] = await conn.query(`
+      SELECT
+        u.id,
+        u.user_uuid,
+        u.nickname,
+        u.status,
+        ua.email
+      FROM plip_user.users u
+      LEFT JOIN plip_user.user_auths ua
+        ON ua.user_id = u.id AND ua.auth_type = 'LOCAL' AND ua.deleted_at IS NULL
+      WHERE u.deleted_at IS NULL AND u.status = 'ACTIVE'
+      ORDER BY u.id ASC
+    `);
+
+    const realUsers = userRows
+      .map((row) => ({
+        id: row.id,
+        userUuid: binToUuid(row.user_uuid),
+        nickname: row.nickname,
+        email: row.email || "",
+      }))
+      .filter((row) => row.userUuid && !DUMMY_EMAIL_RE.test(row.email));
+
+    stats.realUsersTotal = realUsers.length;
+    const hostLimitEnv = process.env.SEED_HOST_LIMIT;
+    const hostLimit =
+      hostLimitEnv !== undefined && hostLimitEnv !== ""
+        ? Number(hostLimitEnv)
+        : realUsers.length > 50
+          ? 10
+          : realUsers.length;
+    const hosts = realUsers.slice(0, Math.max(0, hostLimit));
+    stats.hostsUsed = hosts.length;
+    if (realUsers.length > 50 && !hostLimitEnv) {
+      console.log(
+        `[seed] real users=${realUsers.length} → cap first ${hosts.length} (set SEED_HOST_LIMIT to override)`,
+      );
+    } else {
+      console.log(`[seed] real users=${realUsers.length}, hosts used=${hosts.length}`);
+    }
+    if (hosts.length === 0) {
+      throw new Error("시드할 실유저가 없습니다.");
+    }
+
+    const passwordHash = await bcrypt.hash(DUMMY_PASSWORD, 10);
+    const dummyUsers = [];
+    for (let n = 1; n <= DUMMY_USER_COUNT; n += 1) {
+      const email = `dummy+${n}@plip.local`;
+      const [existing] = await conn.query(
+        `SELECT u.id, u.user_uuid, u.nickname, ua.email
+           FROM plip_user.user_auths ua
+           JOIN plip_user.users u ON u.id = ua.user_id
+          WHERE ua.email = ? AND ua.auth_type = 'LOCAL' AND ua.deleted_at IS NULL
+          LIMIT 1`,
+        [email],
+      );
+      if (existing[0]) {
+        dummyUsers.push({
+          id: existing[0].id,
+          userUuid: binToUuid(existing[0].user_uuid),
+          nickname: existing[0].nickname,
+          email,
+        });
+        stats.dummyUsersReused += 1;
+        continue;
+      }
+
+      const userUuid = randomUUID();
+      const nickname = `더미${n}`;
+      const [insertUser] = await conn.query(
+        `INSERT INTO plip_user.users
+          (user_uuid, nickname, profile_image_path, status, created_at, updated_at)
+         VALUES (?, ?, NULL, 'ACTIVE', NOW(), NOW())`,
+        [uuidToBin(userUuid), nickname],
+      );
+      const userId = insertUser.insertId;
+      await conn.query(
+        `INSERT INTO plip_user.user_auths
+          (user_id, auth_type, email, password_hash, created_at, updated_at)
+         VALUES (?, 'LOCAL', ?, ?, NOW(), NOW())`,
+        [userId, email, passwordHash],
+      );
+      await conn.query(
+        `INSERT INTO plip_user.user_notification_settings
+          (user_id, agit_notify_enabled, diary_notify_enabled, diary_notify_time, created_at, updated_at)
+         VALUES (?, 1, 1, '21:00:00', NOW(), NOW())`,
+        [userId],
+      );
+      await conn.query(
+        `INSERT INTO plip_user.user_terms_agreements
+          (user_id, term_id, is_agreed, agreed_at, created_at, updated_at)
+         SELECT ?, id, 1, NOW(), NOW(), NOW()
+           FROM plip_user.terms
+          WHERE is_required = 1 AND status = 'ACTIVE'`,
+        [userId],
+      );
+      dummyUsers.push({ id: userId, userUuid, nickname, email });
+      stats.dummyUsersCreated += 1;
+    }
+    console.log(
+      `[seed] dummy users created=${stats.dummyUsersCreated} reused=${stats.dummyUsersReused} password=Dummy1234!`,
+    );
+
+    const dummyTokens = new Map();
+    for (const dummy of dummyUsers) {
+      const login = await jsonFetch(`${apiUrl}/api/user/api/v1/auth/login/local`, {
+        method: "POST",
+        body: { email: dummy.email, password: DUMMY_PASSWORD },
+      });
+      if (login.ok && login.data?.accessToken) {
+        dummyTokens.set(dummy.userUuid, login.data.accessToken);
+      }
+    }
+    console.log(`[seed] dummy logins via gateway: ${dummyTokens.size}/${dummyUsers.length}`);
+
+    const agitDirectOk = await probeUrl(`${agitDirect}/actuator/health`);
+    const topicDirectOk = await probeUrl(`${topicDirect}/actuator/health`);
+    console.log(`[seed] agit direct ${agitDirect} reachable=${agitDirectOk}`);
+    console.log(`[seed] topic direct ${topicDirect} reachable=${topicDirectOk}`);
+
+    async function createAgitViaApi(host, name, description) {
+      const nickname = sanitizeNickname(host.nickname, `호스트${host.id}`);
+      const body = {
+        agitName: name,
+        description,
+        maximumCapacity: 5,
+        nickname,
+      };
+      if (agitDirectOk) {
+        const created = await jsonFetch(`${agitDirect}/api/v1/agits`, {
+          method: "POST",
+          headers: { "X-User-UUID": host.userUuid },
+          body,
+        });
+        if (created.ok && created.data?.agitUuid) {
+          stats.apiCreates += 1;
+          return created.data;
+        }
+      }
+      return null;
+    }
+
+    async function createAgitViaSql(host, name, description) {
+      const agitUuid = randomUUID();
+      let code = inviteCode();
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        const [dup] = await conn.query(
+          `SELECT id FROM plip_agit.agits WHERE code = ? LIMIT 1`,
+          [code],
+        );
+        if (!dup[0]) break;
+        code = inviteCode();
+      }
+      const [insertAgit] = await conn.query(
+        `INSERT INTO plip_agit.agits
+          (agit_uuid, agit_name, description, maximum_capacity, code, status, created_at, updated_at)
+         VALUES (?, ?, ?, 5, ?, 'ACTIVE', NOW(), NOW())`,
+        [uuidToBin(agitUuid), name, description, code],
+      );
+      const agitId = insertAgit.insertId;
+      await conn.query(
+        `INSERT INTO plip_agit.agit_member_profiles
+          (agit_id, user_uuid, nickname, status, role, created_at, updated_at)
+         VALUES (?, ?, ?, 'ACTIVE', 'HOST', NOW(), NOW())`,
+        [agitId, uuidToBin(host.userUuid), sanitizeNickname(host.nickname, `호스트${host.id}`)],
+      );
+      try {
+        await conn.query(
+          `INSERT INTO plip_analytics.agit_catalog
+            (agit_uuid, agit_name, description, thumbnail_path, status, created_at)
+           VALUES (?, ?, ?, NULL, 'ACTIVE', NOW())
+           ON DUPLICATE KEY UPDATE agit_name = VALUES(agit_name), description = VALUES(description)`,
+          [agitUuid, name, description],
+        );
+        stats.catalogRows += 1;
+      } catch {
+        // analytics schema 가 없으면 건너뜀
+      }
+      stats.sqlCreates += 1;
+      return { agitUuid, code, agitName: name };
+    }
+
+    async function joinByCode(dummy, code, nickname) {
+      const token = dummyTokens.get(dummy.userUuid);
+      if (token) {
+        const joined = await jsonFetch(`${apiUrl}/api/agit/api/v1/agits/${encodeURIComponent(code)}/join`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: { nickname },
+        });
+        if (joined.ok) return true;
+      }
+      if (agitDirectOk) {
+        const joined = await jsonFetch(`${agitDirect}/api/v1/agits/${encodeURIComponent(code)}/join`, {
+          method: "POST",
+          headers: { "X-User-UUID": dummy.userUuid },
+          body: { nickname },
+        });
+        if (joined.ok) return true;
+      }
+      return false;
+    }
+
+    async function requestJoin(dummy, agitUuid, nickname) {
+      const token = dummyTokens.get(dummy.userUuid);
+      if (token) {
+        const requested = await jsonFetch(`${apiUrl}/api/agit/api/v1/agits/${agitUuid}/join-requests`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: { nickname },
+        });
+        if (requested.ok) return true;
+      }
+      if (agitDirectOk) {
+        const requested = await jsonFetch(`${agitDirect}/api/v1/agits/${agitUuid}/join-requests`, {
+          method: "POST",
+          headers: { "X-User-UUID": dummy.userUuid },
+          body: { nickname },
+        });
+        if (requested.ok) return true;
+      }
+      return false;
+    }
+
+    async function leaveAgit(dummy, agitUuid) {
+      const token = dummyTokens.get(dummy.userUuid);
+      if (token) {
+        const left = await jsonFetch(`${apiUrl}/api/agit/api/v1/agits/${agitUuid}/leave`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (left.ok || left.status === 204) return true;
+      }
+      if (agitDirectOk) {
+        const left = await jsonFetch(`${agitDirect}/api/v1/agits/${agitUuid}/leave`, {
+          method: "POST",
+          headers: { "X-User-UUID": dummy.userUuid },
+        });
+        if (left.ok || left.status === 204) return true;
+      }
+      return false;
+    }
+
+    async function createTopic(host, agitUuid, title) {
+      const body = { agitUuid, title };
+      if (topicDirectOk) {
+        const created = await jsonFetch(`${topicDirect}/api/v1/topics`, {
+          method: "POST",
+          headers: { "X-User-UUID": host.userUuid },
+          body,
+        });
+        if (created.ok) return true;
+      }
+      const created = await jsonFetch(`${apiUrl}/api/topic/api/v1/topics`, {
+        method: "POST",
+        headers: { "X-User-UUID": host.userUuid },
+        body,
+      });
+      if (created.ok) return true;
+      try {
+        await conn.query(
+          `INSERT INTO plip_topic.topic
+            (topic_uuid, agit_uuid, creator_uuid, title, start_at, created_at, updated_at)
+           VALUES (?, ?, ?, ?, NOW(), NOW(), NOW())`,
+          [uuidToBin(randomUUID()), uuidToBin(agitUuid), uuidToBin(host.userUuid), title],
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    async function insertNotification(userUuid, type, title, body, linkPath, agitUuid) {
+      await conn.query(
+        `INSERT INTO plip_user.user_inbox_notifications
+          (user_uuid, type, title, body, link_path, agit_uuid, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, NOW())`,
+        [uuidToBin(userUuid), type, title, body, linkPath, agitUuid ? uuidToBin(agitUuid) : null],
+      );
+      stats.notifications += 1;
+    }
+
+    for (const [hostIndex, host] of hosts.entries()) {
+      const [existingSeed] = await conn.query(
+        `SELECT
+            a.id,
+            a.agit_uuid,
+            a.agit_name,
+            a.code,
+            a.description
+           FROM plip_agit.agits a
+           JOIN plip_agit.agit_member_profiles m
+             ON m.agit_id = a.id AND m.role = 'HOST' AND m.user_uuid = ?
+          WHERE a.description LIKE ?
+          ORDER BY a.id ASC`,
+        [uuidToBin(host.userUuid), `${SEED_MARKER}%`],
+      );
+
+      const owned = existingSeed.map((row) => ({
+        agitUuid: binToUuid(row.agit_uuid),
+        agitName: row.agit_name,
+        code: row.code,
+      }));
+      stats.agitsReused += owned.length;
+
+      const missing = Math.max(0, AGITS_PER_HOST - owned.length);
+      console.log(
+        `[seed] host ${hostIndex + 1}/${hosts.length} ${host.nickname} existingSeed=${owned.length} create=${missing}`,
+      );
+
+      const toCreate = Array.from({ length: missing }, (_, offset) => owned.length + offset + 1);
+      await mapPool(toCreate, 4, async (seq) => {
+        const name = `시드${hostIndex + 1}-${String(seq).padStart(3, "0")}`;
+        const description = `${SEED_MARKER} ${host.nickname} 더미 아지트 ${seq}`;
+        let created = await createAgitViaApi(host, name, description);
+        if (!created) {
+          created = await createAgitViaSql(host, name, description);
+        }
+        if (created?.agitUuid) {
+          owned.push({
+            agitUuid: created.agitUuid,
+            agitName: created.agitName || name,
+            code: created.code,
+          });
+          stats.agitsCreated += 1;
+        }
+      });
+
+      await mapPool(owned, 3, async (agit, agitIndex) => {
+        const memberA = dummyUsers[(hostIndex + agitIndex) % dummyUsers.length];
+        const memberB = dummyUsers[(hostIndex + agitIndex + 1) % dummyUsers.length];
+        const pending = dummyUsers[(hostIndex + agitIndex + 2) % dummyUsers.length];
+        const leaver = dummyUsers[(hostIndex + agitIndex + 3) % dummyUsers.length];
+
+        if (memberA && agit.code && memberA.userUuid !== host.userUuid) {
+          if (await joinByCode(memberA, agit.code, memberA.nickname)) {
+            stats.activeJoins += 1;
+          }
+        }
+        if (memberB && agit.code && memberB.userUuid !== host.userUuid && memberB !== memberA) {
+          if (await joinByCode(memberB, agit.code, memberB.nickname)) {
+            stats.activeJoins += 1;
+          }
+        }
+
+        if (agitIndex < PENDING_PER_HOST && pending && pending.userUuid !== host.userUuid) {
+          if (await requestJoin(pending, agit.agitUuid, pending.nickname)) {
+            stats.pendingRequests += 1;
+          }
+        }
+
+        if (agitIndex % 10 === 0 && leaver && agit.code && leaver.userUuid !== host.userUuid) {
+          if (await joinByCode(leaver, agit.code, leaver.nickname)) {
+            stats.activeJoins += 1;
+            if (await leaveAgit(leaver, agit.agitUuid)) {
+              stats.leaves += 1;
+            }
+          }
+        }
+
+        let hasTopic = false;
+        try {
+          const [existingTopic] = await conn.query(
+            `SELECT id FROM plip_topic.topic WHERE agit_uuid = ? AND deleted_at IS NULL LIMIT 1`,
+            [uuidToBin(agit.agitUuid)],
+          );
+          hasTopic = Boolean(existingTopic[0]);
+        } catch {
+          hasTopic = false;
+        }
+        if (!hasTopic && (await createTopic(host, agit.agitUuid, "시드토픽"))) {
+          stats.topicsCreated += 1;
+        }
+      });
+    }
+
+    console.log("[seed] done");
+    console.log(JSON.stringify(stats, null, 2));
+    console.log("[seed] dummy login: dummy+1@plip.local / Dummy1234!");
+    console.log("[seed] 승인 페이지: 호스트 계정으로 로그인 → 아지트 → 메뉴 → 아지트관리");
+    console.log("[seed] 알림함: 종 아이콘 또는 /mypage/inbox");
+  } finally {
+    await conn.end();
+  }
+}
+
+main().catch((error) => {
+  console.error("[seed] failed:", error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -1,0 +1,265 @@
+import { ApiError } from "@/lib/api/apiFetch";
+import * as notificationApi from "@/lib/api/notificationApi";
+import { getServerUserUuid } from "@/lib/auth/server-token";
+import {
+  countLocalUnread,
+  listLocalInbox,
+  markLocalAllRead,
+  markLocalRead,
+  seedLocalInbox,
+} from "@/lib/notification/localInboxStore";
+import {
+  appendInboxNotification,
+  countUnreadInbox,
+  listInboxNotifications,
+  markInboxNotificationRead,
+} from "@/lib/notifications/inbox";
+import type { ApiNotificationInboxResponse, ApiNotificationItem } from "@/types/notification/api";
+import type { UiInboxNotification, UiInboxNotificationType, UiNotificationInbox, UiNotificationItem, UiNotificationType } from "@/types/notification/ui";
+import { INBOX_COPY } from "@/types/notification/ui";
+import { ROUTES } from "@/config/routes";
+
+function isMissingRemoteInbox(error: unknown): boolean {
+  return error instanceof ApiError && (error.status === 404 || error.status === 405 || error.status === 501);
+}
+
+async function requireUserUuid(explicit?: string): Promise<string> {
+  if (explicit) {
+    return explicit;
+  }
+  const userUuid = await getServerUserUuid();
+  if (!userUuid) {
+    throw new Error("로그인이 필요합니다.");
+  }
+  return userUuid;
+}
+
+function mapType(type: string): UiNotificationType {
+  if (type === "JOIN_REQUESTED" || type === "JOIN_REQUEST") {
+    return "JOIN_REQUEST";
+  }
+  if (type === "JOIN_APPROVED" || type === "CREATION") {
+    return "CREATION";
+  }
+  if (type === "TOPIC" || type === "CHAT" || type === "POST") {
+    return type;
+  }
+  if (type === "JOIN_REJECTED") {
+    return "JOIN_REQUEST";
+  }
+  return "POST";
+}
+
+function mapRemoteItem(item: ApiNotificationItem): UiNotificationItem {
+  return {
+    id: `remote:${item.id}`,
+    type: mapType(item.type),
+    title: item.title,
+    body: item.body ?? "",
+    href: item.deepLink && item.deepLink.startsWith("/") ? item.deepLink : ROUTES.notifications,
+    read: item.read,
+    createdAt: item.createdAt,
+  };
+}
+
+function mapLegacyItem(item: UiInboxNotification): UiNotificationItem {
+  return {
+    id: item.id,
+    type: mapType(item.type),
+    title: item.title,
+    body: item.body,
+    href: item.href.startsWith("/") ? item.href : ROUTES.notifications,
+    read: !item.unread,
+    createdAt: item.createdAt,
+  };
+}
+
+function mapLocalInbox(data: ApiNotificationInboxResponse): UiNotificationInbox {
+  return {
+    items: (data.items ?? []).map((item) => ({
+      id: `local:${item.id}`,
+      type: mapType(item.type),
+      title: item.title,
+      body: item.body ?? "",
+      href: item.deepLink && item.deepLink.startsWith("/") ? item.deepLink : ROUTES.notifications,
+      read: item.read,
+      createdAt: item.createdAt,
+    })),
+    unreadCount: data.unreadCount ?? 0,
+  };
+}
+
+function toInbox(items: UiNotificationItem[]): UiNotificationInbox {
+  const sorted = [...items].sort((left, right) => {
+    const leftAt = left.createdAt ? Date.parse(left.createdAt) : 0;
+    const rightAt = right.createdAt ? Date.parse(right.createdAt) : 0;
+    return rightAt - leftAt;
+  });
+  return {
+    items: sorted,
+    unreadCount: sorted.filter((item) => !item.read).length,
+  };
+}
+
+async function loadFallbackInbox(userUuid: string): Promise<UiNotificationInbox> {
+  const [legacy, local] = await Promise.all([
+    listInboxNotifications(userUuid)
+      .then((items) => items.map(mapLegacyItem))
+      .catch(() => []),
+    listLocalInbox(userUuid)
+      .then((data) => mapLocalInbox(data).items)
+      .catch(() => []),
+  ]);
+  return toInbox([...legacy, ...local]);
+}
+
+export async function getNotificationInbox(limit = 30): Promise<UiNotificationInbox> {
+  let remoteItems: UiNotificationItem[] = [];
+  try {
+    const remote = await Promise.race([
+      notificationApi.listNotifications(limit),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("notification-api-timeout")), 2500);
+      }),
+    ]);
+    remoteItems = (remote.items ?? []).map(mapRemoteItem);
+  } catch {
+    remoteItems = [];
+  }
+
+  let liveItems: UiNotificationItem[] = [];
+  try {
+    const userUuid = await getServerUserUuid();
+    if (userUuid) {
+      liveItems = (await listInboxNotifications(userUuid)).map(mapLegacyItem);
+    }
+  } catch {
+    liveItems = [];
+  }
+
+  const merged = toInbox([...liveItems, ...remoteItems]);
+  if (merged.items.length > 0) {
+    return merged;
+  }
+
+  try {
+    return await loadFallbackInbox(await requireUserUuid());
+  } catch {
+    return { items: [], unreadCount: 0 };
+  }
+}
+
+export async function getUnreadNotificationCount(): Promise<number> {
+  try {
+    const result = await notificationApi.getUnreadNotificationCount();
+    return result.unreadCount;
+  } catch (error) {
+    if (!isMissingRemoteInbox(error)) {
+      throw error;
+    }
+    const userUuid = await requireUserUuid();
+    const [legacyCount, localCount] = await Promise.all([
+      countUnreadInbox(userUuid).catch(() => 0),
+      countLocalUnread(userUuid).catch(() => 0),
+    ]);
+    return legacyCount + localCount;
+  }
+}
+
+export async function getInboxUnreadCount(userUuid: string): Promise<number> {
+  try {
+    return await getUnreadNotificationCount();
+  } catch {
+    return countUnreadInbox(userUuid).catch(() => 0);
+  }
+}
+
+export async function getInboxNotifications(userUuid: string): Promise<UiInboxNotification[]> {
+  const inbox = await getNotificationInbox();
+  void userUuid;
+  return inbox.items.map((item) => ({
+    id: item.id,
+    type: item.type === "JOIN_REQUEST" ? "JOIN_REQUESTED" : "JOIN_APPROVED",
+    title: item.title,
+    body: item.body,
+    href: item.href,
+    createdAt: item.createdAt,
+    unread: !item.read,
+  }));
+}
+
+export async function markNotificationRead(id: string): Promise<UiNotificationItem | void> {
+  if (id.startsWith("remote:")) {
+    const numericId = Number(id.slice("remote:".length));
+    const item = await notificationApi.markNotificationRead(numericId);
+    return mapRemoteItem(item);
+  }
+  if (id.startsWith("local:")) {
+    const numericId = Number(id.slice("local:".length));
+    const item = await markLocalRead(await requireUserUuid(), numericId);
+    return mapLocalInbox({ items: [item], unreadCount: 0 }).items[0];
+  }
+  if (id.startsWith("stored:")) {
+    await markInboxNotificationRead(id, await requireUserUuid());
+  }
+}
+
+export async function markInboxRead(id: string, userUuid: string): Promise<void> {
+  await markNotificationRead(id);
+  void userUuid;
+}
+
+export async function markAllNotificationsRead(): Promise<number> {
+  try {
+    const result = await notificationApi.markAllNotificationsRead();
+    return result.updatedCount;
+  } catch (error) {
+    if (!isMissingRemoteInbox(error)) {
+      throw error;
+    }
+    const userUuid = await requireUserUuid();
+    return markLocalAllRead(userUuid);
+  }
+}
+
+export async function seedNotifications(): Promise<UiNotificationInbox> {
+  try {
+    const remote = await notificationApi.seedNotifications();
+    return {
+      items: (remote.items ?? []).map(mapRemoteItem),
+      unreadCount: remote.unreadCount ?? 0,
+    };
+  } catch (error) {
+    if (!isMissingRemoteInbox(error)) {
+      throw error;
+    }
+    return mapLocalInbox(await seedLocalInbox(await requireUserUuid()));
+  }
+}
+
+export async function ensureSeededInbox(): Promise<UiNotificationInbox> {
+  const inbox = await getNotificationInbox();
+  if (inbox.items.length > 0) {
+    return inbox;
+  }
+  return seedNotifications();
+}
+
+export async function notifyJoinOutcome(input: {
+  requesterUserUuid: string;
+  agitId: string;
+  agitName: string;
+  approved: boolean;
+}): Promise<void> {
+  const type: UiInboxNotificationType = input.approved ? "JOIN_APPROVED" : "JOIN_REJECTED";
+  await appendInboxNotification({
+    userUuid: input.requesterUserUuid,
+    type,
+    title: INBOX_COPY[type],
+    body: input.approved
+      ? `${input.agitName} 입장 요청이 승인되었습니다.`
+      : `${input.agitName} 입장 요청이 거절되었습니다.`,
+    href: input.approved ? `/agit/${input.agitId}` : "/agit/search",
+    agitUuid: input.agitId,
+  });
+}

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -6,12 +6,14 @@ import type {
   VideoDestinationResponse,
   VideoDetailResponse,
   VideoDownloadUrlResult,
+  VideoThumbnailUploadUrlResponse,
   VideoUploadUrlResponse,
 } from "@/types/video/api";
 import type {
   VideoCompleteUi,
   VideoDetailUi,
   VideoDownloadUrlUi,
+  VideoThumbnailUploadUrlUi,
   VideoUploadUrlUi,
 } from "@/types/video/ui";
 
@@ -19,6 +21,15 @@ function mapUploadUrl(api: VideoUploadUrlResponse): VideoUploadUrlUi {
   return {
     videoUuid: api.videoUuid,
     rawS3Key: api.rawS3Key,
+    uploadUrl: api.uploadUrl,
+    expiresAt: new Date(api.expiresAt),
+  };
+}
+
+function mapThumbnailUploadUrl(api: VideoThumbnailUploadUrlResponse): VideoThumbnailUploadUrlUi {
+  return {
+    videoUuid: api.videoUuid,
+    thumbnailS3Key: api.thumbnailS3Key,
     uploadUrl: api.uploadUrl,
     expiresAt: new Date(api.expiresAt),
   };
@@ -71,11 +82,28 @@ export async function issueUploadUrl(
   return mapUploadUrl(response);
 }
 
+export async function issueThumbnailUploadUrl(
+  videoUuid: string,
+  contentType: string | undefined,
+  contentLengthBytes: number,
+): Promise<VideoThumbnailUploadUrlUi> {
+  const response = await videoApi.postThumbnailUploadUrl(
+    videoUuid,
+    contentType,
+    contentLengthBytes,
+  );
+  return mapThumbnailUploadUrl(response);
+}
+
 export async function completeVideo(
   videoUuid: string,
   caption?: string,
+  thumbnailS3Key?: string,
 ): Promise<VideoCompleteUi> {
-  const response = await videoApi.postComplete(videoUuid, { caption });
+  const response = await videoApi.postComplete(videoUuid, {
+    caption,
+    ...(thumbnailS3Key ? { thumbnailS3Key } : {}),
+  });
   return mapComplete(response);
 }
 

--- a/types/notification/api.ts
+++ b/types/notification/api.ts
@@ -1,0 +1,26 @@
+export type ApiNotificationType = "CHAT" | "JOIN_REQUEST" | "CREATION" | "TOPIC" | "POST";
+
+export type ApiNotificationItem = {
+  id: number;
+  type: ApiNotificationType;
+  title: string;
+  body: string | null;
+  deepLink: string | null;
+  resourceId: string | null;
+  agitUuid: string | null;
+  read: boolean;
+  createdAt: string | null;
+};
+
+export type ApiNotificationInboxResponse = {
+  items: ApiNotificationItem[];
+  unreadCount: number;
+};
+
+export type ApiNotificationUnreadCountResponse = {
+  unreadCount: number;
+};
+
+export type ApiNotificationReadAllResponse = {
+  updatedCount: number;
+};

--- a/types/notification/ui.ts
+++ b/types/notification/ui.ts
@@ -1,0 +1,44 @@
+export type UiNotificationType = "CHAT" | "JOIN_REQUEST" | "CREATION" | "TOPIC" | "POST";
+
+export type UiNotificationItem = {
+  id: string;
+  type: UiNotificationType;
+  title: string;
+  body: string;
+  href: string;
+  read: boolean;
+  createdAt: string | null;
+};
+
+export type UiNotificationInbox = {
+  items: UiNotificationItem[];
+  unreadCount: number;
+};
+
+export const NOTIFICATION_TYPE_LABEL: Record<UiNotificationType, string> = {
+  CHAT: "채팅",
+  JOIN_REQUEST: "입장 요청",
+  CREATION: "생성",
+  TOPIC: "토픽",
+  POST: "새 글",
+};
+
+/** @deprecated 가입 승인 에이전트 호환. 인박스 단일 타입은 UiNotificationType */
+export type UiInboxNotificationType = "JOIN_REQUESTED" | "JOIN_APPROVED" | "JOIN_REJECTED";
+
+/** @deprecated 가입 승인 에이전트 호환 */
+export type UiInboxNotification = {
+  id: string;
+  type: UiInboxNotificationType;
+  title: string;
+  body: string;
+  href: string;
+  createdAt: string | null;
+  unread: boolean;
+};
+
+export const INBOX_COPY: Record<UiInboxNotificationType, string> = {
+  JOIN_REQUESTED: "입장 요청이 있습니다",
+  JOIN_APPROVED: "입장 요청이 승인되었습니다",
+  JOIN_REJECTED: "입장 요청이 거절되었습니다",
+};

--- a/types/video/action.ts
+++ b/types/video/action.ts
@@ -7,6 +7,13 @@ export type VideoUploadUrlActionData = {
   expiresAt: string;
 };
 
+export type VideoThumbnailUploadUrlActionData = {
+  videoUuid: string;
+  thumbnailS3Key: string;
+  uploadUrl: string;
+  expiresAt: string;
+};
+
 export type VideoCompleteActionData = {
   videoUuid: string;
   caption: string | null;

--- a/types/video/api.ts
+++ b/types/video/api.ts
@@ -7,8 +7,16 @@ export type VideoUploadUrlResponse = {
   expiresAt: string;
 };
 
+export type VideoThumbnailUploadUrlResponse = {
+  videoUuid: string;
+  thumbnailS3Key: string;
+  uploadUrl: string;
+  expiresAt: string;
+};
+
 export type VideoCompleteRequest = {
   caption?: string | null;
+  thumbnailS3Key?: string | null;
 };
 
 export type VideoTopicDestinationRequest = {

--- a/types/video/ui.ts
+++ b/types/video/ui.ts
@@ -5,6 +5,13 @@ export type VideoUploadUrlUi = {
   expiresAt: Date;
 };
 
+export type VideoThumbnailUploadUrlUi = {
+  videoUuid: string;
+  thumbnailS3Key: string;
+  uploadUrl: string;
+  expiresAt: Date;
+};
+
 export type VideoCompleteUi = {
   videoUuid: string;
   caption: string | null;


### PR DESCRIPTION
## Summary
- 로그인·가입 성공 시 다이어리 대신 홈으로 이동하고 헤더 로고를 홈으로 연결합니다.
- 알림 종과 알림함 화면을 추가하고, 촬영 흐름에서 썸네일을 고를 수 있게 합니다.
- 검색 API는 세션이 있을 때 JWT를 붙여 analytics 500을 피합니다.

## Test plan
- [ ] 로그인/가입 후 홈으로 이동하는지 확인
- [ ] 헤더 로고를 누르면 홈으로 가는지 확인
- [ ] 알림 종·알림함에서 목록/읽음 처리가 되는지 확인
- [ ] 촬영 업로드 시 썸네일 선택·미리보기가 동작하는지 확인
- [ ] 로그인 상태에서 공개 검색이 500 없이 되는지 확인