### PR TITLE
Feature: 인증 후 이동과 헤더 홈 링크를 인트로로 통일한다

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -209,7 +209,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const isLoggedIn = session?.isLoggedIn === true;
 
       if (matchesPrefix(pathname, GUEST_ONLY_PREFIXES) && isLoggedIn) {
-        return Response.redirect(new URL(ROUTES.home, request.nextUrl));
+        return Response.redirect(new URL(ROUTES.intro, request.nextUrl));
       }
 
       // 방 가입 랜딩 페이지(/agit/join/[code])는 비로그인 상태에서도 접근 허용

--- a/components/molecules/ExploreNav.tsx
+++ b/components/molecules/ExploreNav.tsx
@@ -8,7 +8,7 @@ type ExploreNavProps = {
 };
 
 const TABS: { id: ExploreNavTab; label: string; href: string }[] = [
-  { id: "home", label: "홈", href: ROUTES.home },
+  { id: "home", label: "홈", href: ROUTES.intro },
   { id: "explore", label: "탐색", href: ROUTES.agit.root },
   { id: "rooms", label: "내 방", href: ROUTES.agit.detail("agit-walk") },
   { id: "profile", label: "프로필", href: ROUTES.mypage.root },

--- a/components/molecules/FeedTopBar.tsx
+++ b/components/molecules/FeedTopBar.tsx
@@ -12,7 +12,7 @@ export function FeedTopBar({ activeTab = "myAgits" }: FeedTopBarProps) {
   return (
     <header className={`${leftoverStyles.plipTtFeedTop} pointer-events-none absolute inset-x-0 top-0 z-[4] grid grid-cols-[auto_1fr_auto] items-center gap-2 px-[0.85rem] pt-[0.7rem]`}>
       <TextLink
-        href={ROUTES.home}
+        href={ROUTES.intro}
         aria-label="홈"
         className="pointer-events-auto relative z-[3] w-[5.4rem] !no-underline"
       >

--- a/components/molecules/ScreenHeader.tsx
+++ b/components/molecules/ScreenHeader.tsx
@@ -122,7 +122,7 @@ export function HeaderSearchButton({ onClick, label = "검색" }: { onClick: () 
 }
 
 export function HeaderHomeLink({
-  href = ROUTES.home,
+  href = ROUTES.intro,
   label = "홈",
 }: {
   href?: string;

--- a/components/molecules/SocialAuthButtons.tsx
+++ b/components/molecules/SocialAuthButtons.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ROUTES } from "@/config/routes";
 import { getSafeCallbackUrl } from "@/lib/auth/safe-callback-url";
 import { cn } from "@/lib/utils";
 import type { SocialProvider } from "@/types/auth/ui";
@@ -48,7 +47,7 @@ export function SocialAuthButtons({
   disabled,
   className,
 }: SocialAuthButtonsProps) {
-  const targetUrl = getSafeCallbackUrl(callbackUrl ?? ROUTES.home);
+  const targetUrl = getSafeCallbackUrl(callbackUrl);
 
   function handleSignIn(provider: SocialProvider) {
     void signIn(provider, { callbackUrl: targetUrl });

--- a/components/organisms/MainLandingSection.tsx
+++ b/components/organisms/MainLandingSection.tsx
@@ -93,7 +93,7 @@ export function MainLandingSection({
       <header className="flex items-center justify-between gap-3">
         {isLoggedIn ? (
           <TextLink
-            href={ROUTES.home}
+            href={ROUTES.intro}
             aria-label="홈"
             className="m-0 text-lg font-bold text-[var(--dl-color-text-primary)] !no-underline"
           >

--- a/components/organisms/ProfileSetupForm.tsx
+++ b/components/organisms/ProfileSetupForm.tsx
@@ -60,7 +60,7 @@ export function ProfileSetupForm() {
       return;
     }
 
-    router.push(ROUTES.home);
+    router.push(ROUTES.intro);
     router.refresh();
   }
 

--- a/components/organisms/SignUpForm.tsx
+++ b/components/organisms/SignUpForm.tsx
@@ -215,7 +215,7 @@ export function SignUpForm() {
         return;
       }
 
-      router.push(ROUTES.home);
+      router.push(ROUTES.intro);
       router.refresh();
       return;
     }
@@ -286,7 +286,7 @@ export function SignUpForm() {
           onOpenChange={setRestoreOpen}
           payload={restorePayload}
           onCompleted={() => {
-            router.push(ROUTES.home);
+            router.push(ROUTES.intro);
             router.refresh();
           }}
         />

--- a/lib/auth/safe-callback-url.ts
+++ b/lib/auth/safe-callback-url.ts
@@ -1,9 +1,27 @@
 import { ROUTES } from "@/config/routes";
 
-const DEFAULT_AFTER_AUTH = ROUTES.home;
+const DEFAULT_AFTER_AUTH = ROUTES.intro;
 
 function isLandingPath(path: string): boolean {
-  return path === "/" || path === ROUTES.intro || path === "/intro";
+  const pathname = path.split("?")[0] ?? path;
+  return pathname === "/" || pathname === ROUTES.intro || pathname === "/intro";
+}
+
+function toInternalPath(raw: string): string | null {
+  if (raw.includes("://")) {
+    try {
+      const url = new URL(raw);
+      return `${url.pathname}${url.search}`;
+    } catch {
+      return null;
+    }
+  }
+
+  if (!raw.startsWith("/") || raw.startsWith("//")) {
+    return null;
+  }
+
+  return raw;
 }
 
 export function getSafeCallbackUrl(raw: string | null | undefined): string {
@@ -18,13 +36,10 @@ export function getSafeCallbackUrl(raw: string | null | undefined): string {
     return DEFAULT_AFTER_AUTH;
   }
 
-  if (!decoded.startsWith("/") || decoded.startsWith("//") || decoded.includes("://")) {
+  const path = toInternalPath(decoded);
+  if (!path || isLandingPath(path)) {
     return DEFAULT_AFTER_AUTH;
   }
 
-  if (isLandingPath(decoded)) {
-    return DEFAULT_AFTER_AUTH;
-  }
-
-  return decoded;
+  return path;
 }


### PR DESCRIPTION
## Summary
- 로그인/가입 완료와 게스트 전용 페이지 리다이렉트를 `ROUTES.intro`로 맞춘다.
- 헤더·탐색 탭·피드 로고의 홈 링크를 인트로로 보낸다.
- `getSafeCallbackUrl`이 절대 URL과 쿼리를 내부 경로로 정규화하고, 랜딩 경로는 인트로로 되돌린다.

## Test plan
- [ ] 로그인된 상태로 게스트 전용 페이지(로그인/가입)에 들어가면 인트로로 이동한다
- [ ] 이메일/소셜 가입 또는 프로필 설정 완료 후 인트로로 이동한다
- [ ] 탐색 탭·피드 로고·스크린 헤더 홈을 누르면 인트로가 열린다
- [ ] 소셜 로그인 callbackUrl이 없거나 랜딩(/)이면 인트로로 간다
- [ ] 유효한 내부 경로 callbackUrl(예: /agit/...)은 그대로 유지된다

Made with [Cursor](https://cursor.com)