### PR TITLE
Fix: 썸네일 API 미배포 환경에서도 영상 업로드가 진행되도록 수정한다

### DIFF
--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -323,13 +323,13 @@ export function CaptureFlowSection({
     }
 
     setSaveError(null);
-    const uploaded = await uploadCapture(caption.trim() || undefined, thumbnailFile);
-    if (!uploaded) {
-      setSaveError("업로드에 실패했습니다.");
+    const uploadOutcome = await uploadCapture(caption.trim() || undefined, thumbnailFile);
+    if (!uploadOutcome.ok) {
+      setSaveError(uploadOutcome.error);
       return;
     }
 
-    await publishDestination(uploaded.videoUuid, destination);
+    await publishDestination(uploadOutcome.result.videoUuid, destination);
   }, [caption, publishDestination, resolveDestination, thumbnailFile, uploadCapture]);
 
   const handlePickThumbnailFile = useCallback(

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -43,6 +43,10 @@ function mapRecorderStatusToFlowPhase(
   }
 }
 
+export type VideoCaptureUploadOutcome =
+  | { ok: true; result: Phase0FUploadResult }
+  | { ok: false; error: string };
+
 export function useVideoCaptureFlow() {
   const recorder = useVideoRecorder({ autoPrepare: true });
   const [uploading, setUploading] = useState(false);
@@ -82,7 +86,7 @@ export function useVideoCaptureFlow() {
         localPreviewUrl?: string | null;
         thumbnail?: Blob;
       },
-    ) => {
+    ): Promise<VideoCaptureUploadOutcome> => {
       setUploading(true);
       setFlowError(null);
       setUploadResult(null);
@@ -96,11 +100,11 @@ export function useVideoCaptureFlow() {
         });
 
         setUploadResult(result);
-        return result;
+        return { ok: true, result };
       } catch (error) {
         const message = error instanceof Error ? error.message : "Upload failed";
         setFlowError(message);
-        return null;
+        return { ok: false, error: message };
       } finally {
         setUploading(false);
       }
@@ -109,10 +113,14 @@ export function useVideoCaptureFlow() {
   );
 
   const uploadCapture = useCallback(
-    async (caption = DEFAULT_CAPTURE_CAPTION, thumbnail?: Blob) => {
+    async (
+      caption = DEFAULT_CAPTURE_CAPTION,
+      thumbnail?: Blob,
+    ): Promise<VideoCaptureUploadOutcome> => {
       if (!recorder.blob) {
-        setFlowError("Recorded blob is missing");
-        return null;
+        const message = "Recorded blob is missing";
+        setFlowError(message);
+        return { ok: false, error: message };
       }
 
       return uploadBlob(recorder.blob, {
@@ -126,7 +134,11 @@ export function useVideoCaptureFlow() {
   );
 
   const uploadFile = useCallback(
-    async (file: File, caption = DEFAULT_CAPTURE_CAPTION, thumbnail?: Blob) => {
+    async (
+      file: File,
+      caption = DEFAULT_CAPTURE_CAPTION,
+      thumbnail?: Blob,
+    ): Promise<VideoCaptureUploadOutcome> => {
       return uploadBlob(file, {
         caption,
         recorderMimeType: file.type,
@@ -137,7 +149,7 @@ export function useVideoCaptureFlow() {
     [uploadBlob],
   );
 
-  const uploadOversizeTest = useCallback(async () => {
+  const uploadOversizeTest = useCallback(async (): Promise<VideoCaptureUploadOutcome> => {
     return uploadBlob(createOversizeUploadBlob(), {
       caption: "oversize-limit-test",
       recorderMimeType: "video/mp4",

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -31,19 +31,22 @@ export type Phase0FUploadResult = VideoUploadPipelineResult & {
   playback: PlaybackSource;
 };
 
-async function uploadThumbnail(
+async function uploadThumbnailBestEffort(
   videoUuid: string,
   thumbnail: Blob,
-): Promise<string> {
+): Promise<string | undefined> {
   const contentType = thumbnail.type || THUMBNAIL_CONTENT_TYPE;
   const issued = await issueThumbnailUploadUrlAction(videoUuid, contentType, thumbnail.size);
   const issuedError = extractActionError(issued);
   if (issuedError || !issued.ok) {
-    throw new Error(
-      issuedError?.includes("[404]")
-        ? "서버가 아직 썸네일 업로드를 지원하지 않습니다. plip-video thumbnail-upload-url을 배포해 주세요."
-        : (issuedError ?? "thumbnail-upload-url failed"),
-    );
+    if (issuedError?.includes("[404]")) {
+      console.warn(
+        "thumbnail-upload-url unavailable; continuing without client thumbnail (Lambda will generate)",
+      );
+      return undefined;
+    }
+
+    throw new Error(issuedError ?? "thumbnail-upload-url failed");
   }
 
   await putPresignedUpload(issued.data.uploadUrl, thumbnail, contentType);
@@ -67,10 +70,12 @@ export async function uploadRecordedVideo(
 
   const { videoUuid, uploadUrl } = uploadUrlResult.data;
   const thumbnail = options?.thumbnail;
-  const [putResult, thumbnailS3Key] = await Promise.all([
-    putPresignedUpload(uploadUrl, prepared, contentType),
-    thumbnail && thumbnail.size > 0 ? uploadThumbnail(videoUuid, thumbnail) : Promise.resolve(undefined),
-  ]);
+
+  const putResult = await putPresignedUpload(uploadUrl, prepared, contentType);
+  const thumbnailS3Key =
+    thumbnail && thumbnail.size > 0
+      ? await uploadThumbnailBestEffort(videoUuid, thumbnail)
+      : undefined;
 
   const completeResult = await completeVideoAction(videoUuid, options?.caption, thumbnailS3Key);
   const completeError = extractActionError(completeResult);


### PR DESCRIPTION
## 작업 내용

프로덕션 `/video` 저장 시 프론트가 호출하는 `thumbnail-upload-url` API가 백엔드에 없어 404가 나고, 영상 PUT과 썸네일 PUT이 `Promise.all`로 묶여 전체 업로드가 실패하고 있었습니다.  
영상 PUT을 먼저 수행하고 썸네일은 best-effort로 처리하며, API 404 시 Lambda 자동 썸네일로 fallback합니다.  
업로드 실패 시 React stale closure로 메시지가 사라지던 문제도 `{ ok, error }` 반환으로 수정했습니다.

## 관련 이슈

Close #N

## 변경 사항

### 1. 썸네일 404 fallback 및 업로드 순서 분리

- **파일:** `lib/video/uploadPipeline.ts`
- **설명:** `Promise.all` 제거 → 영상 S3 PUT 후 썸네일 업로드. `thumbnail-upload-url` 404면 경고만 남기고 `complete` 진행.

```typescript
// lib/video/uploadPipeline.ts
const putResult = await putPresignedUpload(uploadUrl, prepared, contentType);
const thumbnailS3Key =
  thumbnail && thumbnail.size > 0
    ? await uploadThumbnailBestEffort(videoUuid, thumbnail)
    : undefined;
```

### 2. 업로드 결과 타입 및 에러 반환

- **파일:** `hooks/useVideoCaptureFlow.ts`
- **설명:** `uploadCapture`가 `null` 대신 `{ ok: true, result } | { ok: false, error }` 반환.

```typescript
// hooks/useVideoCaptureFlow.ts
export type VideoCaptureUploadOutcome =
  | { ok: true; result: Phase0FUploadResult }
  | { ok: false; error: string };
```

### 3. 저장 실패 메시지 개선

- **파일:** `components/organisms/CaptureFlowSection.tsx`
- **설명:** 업로드 실패 시 `uploadOutcome.error`를 `saveError`에 표시.

```typescript
// components/organisms/CaptureFlowSection.tsx
if (!uploadOutcome.ok) {
  setSaveError(uploadOutcome.error);
  return;
}
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 로컬 `/video` — 촬영 → 썸네일 선택 → 저장 → destination publish 성공
- [ ] (백엔드 미배포) `thumbnail-upload-url` 404여도 업로드 complete까지 성공

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인