### PR TITLE
Fix/video capture flicker session

### DIFF
--- a/actions/videoActions.ts
+++ b/actions/videoActions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
+import { actionFailure, actionSessionExpired, actionSuccess, type ActionResult } from "@/types/action-result";
 import type {
   VideoCompleteActionData,
   VideoDestinationActionData,
@@ -13,7 +13,12 @@ import type { VideoDestinationRequest } from "@/types/video/api";
 import type { VideoDestination } from "@/types/video/destination";
 import { getApiUrl, isVideoDestinationNotWiredFallbackEnabled } from "@/lib/api/env";
 import { ApiError } from "@/lib/api/apiFetch";
-import { getServerUserUuid } from "@/lib/auth/server-token";
+import { persistSessionTokens } from "@/lib/auth/persist-session-tokens";
+import {
+  applyRetryAuthHeaders,
+  reissueTokensOncePerRequest,
+} from "@/lib/auth/request-token-cache";
+import { getServerAccessToken, getServerUserUuid } from "@/lib/auth/server-token";
 import {
   VIDEO_DESTINATION_INVALID,
   VIDEO_LOGIN_REQUIRED,
@@ -36,7 +41,7 @@ const ALLOWED_THUMBNAIL_CONTENT_TYPES = new Set(["image/jpeg"]);
 const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
 
 async function requireSessionUserUuid(): Promise<
-  { ok: true; userUuid: string } | { ok: false; error: string }
+  { ok: true; userUuid: string } | { ok: false; error: string; sessionExpired?: boolean }
 > {
   const userUuid = await getServerUserUuid();
   if (!userUuid) {
@@ -45,6 +50,17 @@ async function requireSessionUserUuid(): Promise<
 
   if (!UUID_PATTERN.test(userUuid)) {
     return { ok: false, error: VIDEO_SESSION_INVALID };
+  }
+
+  const accessToken = await getServerAccessToken();
+  if (!accessToken) {
+    const refreshed = await reissueTokensOncePerRequest();
+    if (!refreshed) {
+      return { ok: false, error: "", sessionExpired: true };
+    }
+
+    applyRetryAuthHeaders(refreshed);
+    await persistSessionTokens(refreshed);
   }
 
   return { ok: true, userUuid };
@@ -75,6 +91,9 @@ function resolveThumbnailContentType(contentType?: string): string | undefined {
 
 function toActionError(error: unknown): ActionResult<never> {
   if (error instanceof ApiError) {
+    if (error.status === 401) {
+      return actionSessionExpired();
+    }
     return actionFailure(`[${error.status}] ${error.message}`);
   }
 
@@ -98,7 +117,7 @@ export async function issueUploadUrlAction(
 ): Promise<ActionResult<VideoUploadUrlActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return actionFailure(session.error);
+    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
   }
 
   const resolvedContentType = resolveContentType(contentType);
@@ -133,7 +152,7 @@ export async function issueThumbnailUploadUrlAction(
 
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return actionFailure(session.error);
+    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
   }
 
   const resolvedContentType = resolveThumbnailContentType(contentType);
@@ -173,7 +192,7 @@ export async function completeVideoAction(
 
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return actionFailure(session.error);
+    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
   }
 
   const normalizedCaption = caption?.trim() || undefined;
@@ -196,7 +215,7 @@ export async function getVideoAction(
 ): Promise<ActionResult<VideoDetailActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return actionFailure(session.error);
+    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
   }
 
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);
@@ -242,7 +261,7 @@ export async function publishVideoDestinationAction(
 
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return actionFailure(session.error);
+    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
   }
 
   const payload = toDestinationPayload(destination);
@@ -281,7 +300,7 @@ export async function getDownloadUrlAction(
 ): Promise<ActionResult<VideoDownloadUrlActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return actionFailure(session.error);
+    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
   }
 
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);

--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -123,6 +123,14 @@ export function CaptureFlowSection({
   const slotRef = useRef<HTMLDivElement>(null);
   const previewVideoElRef = useRef<HTMLVideoElement | null>(null);
 
+  const bindCaptureVideoRef = useCallback(
+    (node: HTMLVideoElement | null) => {
+      videoRef(node);
+      previewVideoElRef.current = node;
+    },
+    [videoRef],
+  );
+
   const isPreview = status === "preview" || flowPhase === "uploading" || flowPhase === "complete";
   const showSettings = isPreview && previewStep === "settings";
   const showConfirm = isPreview && previewStep === "confirm";
@@ -325,7 +333,9 @@ export function CaptureFlowSection({
     setSaveError(null);
     const uploadOutcome = await uploadCapture(caption.trim() || undefined, thumbnailFile);
     if (!uploadOutcome.ok) {
-      setSaveError(uploadOutcome.error);
+      if (!uploadOutcome.sessionExpired) {
+        setSaveError(uploadOutcome.error);
+      }
       return;
     }
 
@@ -458,10 +468,7 @@ export function CaptureFlowSection({
         }
       >
         <video
-          ref={(node) => {
-            videoRef(node);
-            previewVideoElRef.current = node;
-          }}
+          ref={bindCaptureVideoRef}
           className={`h-full w-full object-cover ${mirrorVideo ? "-scale-x-100" : ""}`}
           autoPlay
           playsInline

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -1,10 +1,14 @@
 "use client";
 
+import { logoutAction } from "@/actions/authActions";
 import { useVideoRecorder } from "@/hooks/useVideoRecorder";
+import { ROUTES } from "@/config/routes";
 import { DEFAULT_CAPTURE_CAPTION } from "@/lib/video/constants";
+import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { createOversizeUploadBlob } from "@/lib/video/uploadLimits";
 import { runPhase0FUpload, type Phase0FUploadResult } from "@/lib/video/uploadPipeline";
 import type { CaptureFlowPhase } from "@/types/video/ui";
+import { useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
 function mapRecorderStatusToFlowPhase(
@@ -45,9 +49,10 @@ function mapRecorderStatusToFlowPhase(
 
 export type VideoCaptureUploadOutcome =
   | { ok: true; result: Phase0FUploadResult }
-  | { ok: false; error: string };
+  | { ok: false; error: string; sessionExpired?: boolean };
 
 export function useVideoCaptureFlow() {
+  const router = useRouter();
   const recorder = useVideoRecorder({ autoPrepare: true });
   const [uploading, setUploading] = useState(false);
   const [flowError, setFlowError] = useState<string | null>(null);
@@ -102,6 +107,13 @@ export function useVideoCaptureFlow() {
         setUploadResult(result);
         return { ok: true, result };
       } catch (error) {
+        if (error instanceof VideoSessionExpiredError) {
+          await logoutAction().catch(() => undefined);
+          router.push(ROUTES.login);
+          router.refresh();
+          return { ok: false, error: error.message, sessionExpired: true };
+        }
+
         const message = error instanceof Error ? error.message : "Upload failed";
         setFlowError(message);
         return { ok: false, error: message };
@@ -109,7 +121,7 @@ export function useVideoCaptureFlow() {
         setUploading(false);
       }
     },
-    [],
+    [router],
   );
 
   const uploadCapture = useCallback(

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -36,6 +36,10 @@ export type UseVideoRecorderOptions = {
 };
 
 function attachLiveStream(node: HTMLVideoElement, stream: MediaStream) {
+  if (node.srcObject === stream && !node.paused && !node.ended) {
+    return;
+  }
+
   node.pause();
   node.removeAttribute("src");
   node.srcObject = stream;
@@ -45,6 +49,10 @@ function attachLiveStream(node: HTMLVideoElement, stream: MediaStream) {
 }
 
 function attachPreviewUrl(node: HTMLVideoElement, previewUrl: string) {
+  if (node.src === previewUrl && node.srcObject === null && !node.paused) {
+    return;
+  }
+
   node.pause();
   node.srcObject = null;
   if (node.src !== previewUrl) {

--- a/lib/video/actionErrors.ts
+++ b/lib/video/actionErrors.ts
@@ -3,3 +3,10 @@ export const VIDEO_SESSION_INVALID = "세션의 userUuid가 올바르지 않습�
 export const VIDEO_DESTINATION_INVALID = "업로드 대상이 올바르지 않습니다.";
 export const VIDEO_DESTINATION_NOT_WIRED =
   "영상은 저장됐습니다. 토픽/다이어리 연결은 백엔드 카프카 토픽 확정 후 이어집니다.";
+
+export class VideoSessionExpiredError extends Error {
+  constructor() {
+    super("세션이 만료되었습니다. 다시 로그인해 주세요.");
+    this.name = "VideoSessionExpiredError";
+  }
+}

--- a/lib/video/actionPayload.ts
+++ b/lib/video/actionPayload.ts
@@ -117,6 +117,13 @@ export function extractVideoUuidFromActionResult(payload: unknown): string | nul
 }
 
 export function extractActionError(payload: unknown): string | null {
+  const failure = extractActionFailure(payload);
+  return failure?.error ?? null;
+}
+
+export function extractActionFailure(
+  payload: unknown,
+): { error: string; sessionExpired?: boolean } | null {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -125,9 +132,17 @@ export function extractActionError(payload: unknown): string | null {
     return null;
   }
 
-  if (!("error" in payload) || typeof payload.error !== "string") {
-    return "Unknown error";
+  if ("sessionExpired" in payload && payload.sessionExpired === true) {
+    return { error: "", sessionExpired: true };
   }
 
-  return payload.error;
+  if (!("error" in payload) || typeof payload.error !== "string") {
+    return { error: "Unknown error" };
+  }
+
+  return { error: payload.error };
+}
+
+export function isSessionExpiredAction(payload: unknown): boolean {
+  return extractActionFailure(payload)?.sessionExpired === true;
 }

--- a/lib/video/downloadUrlPoll.ts
+++ b/lib/video/downloadUrlPoll.ts
@@ -1,5 +1,5 @@
 import { getDownloadUrlAction } from "@/actions/videoActions";
-import { extractActionError } from "@/lib/video/actionPayload";
+import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { DOWNLOAD_URL_MAX_ATTEMPTS } from "@/lib/video/constants";
 import type { VideoDownloadUrlActionData } from "@/types/video/action";
 
@@ -22,10 +22,13 @@ export async function pollDownloadUrl(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const response = await getDownloadUrlAction(videoUuid);
-    const error = extractActionError(response);
 
-    if (error || !response.ok) {
-      throw new Error(error ?? "download-url failed");
+    if (!response.ok) {
+      if (response.sessionExpired) {
+        throw new VideoSessionExpiredError();
+      }
+
+      throw new Error(response.error || "download-url failed");
     }
 
     lastResult = response.data;

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -4,7 +4,6 @@ import {
   issueThumbnailUploadUrlAction,
   issueUploadUrlAction,
 } from "@/actions/videoActions";
-import { extractActionFailure } from "@/lib/video/actionPayload";
 import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { THUMBNAIL_CONTENT_TYPE } from "@/lib/video/constants";
 import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -4,7 +4,8 @@ import {
   issueThumbnailUploadUrlAction,
   issueUploadUrlAction,
 } from "@/actions/videoActions";
-import { extractActionError } from "@/lib/video/actionPayload";
+import { extractActionFailure } from "@/lib/video/actionPayload";
+import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { THUMBNAIL_CONTENT_TYPE } from "@/lib/video/constants";
 import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";
 import { resolvePlaybackSource, type PlaybackSource } from "@/lib/video/playback";
@@ -31,15 +32,34 @@ export type Phase0FUploadResult = VideoUploadPipelineResult & {
   playback: PlaybackSource;
 };
 
+function assertActionSuccess<T>(
+  payload: { ok: true; data: T } | { ok: false; error: string; sessionExpired?: boolean },
+  fallbackMessage: string,
+): asserts payload is { ok: true; data: T } {
+  if (payload.ok) {
+    return;
+  }
+
+  if (payload.sessionExpired) {
+    throw new VideoSessionExpiredError();
+  }
+
+  throw new Error(payload.error || fallbackMessage);
+}
+
 async function uploadThumbnailBestEffort(
   videoUuid: string,
   thumbnail: Blob,
 ): Promise<string | undefined> {
   const contentType = thumbnail.type || THUMBNAIL_CONTENT_TYPE;
   const issued = await issueThumbnailUploadUrlAction(videoUuid, contentType, thumbnail.size);
-  const issuedError = extractActionError(issued);
-  if (issuedError || !issued.ok) {
-    if (issuedError?.includes("[404]")) {
+  if (!issued.ok) {
+    if (issued.sessionExpired) {
+      throw new VideoSessionExpiredError();
+    }
+
+    const issuedError = issued.error;
+    if (issuedError.includes("[404]")) {
       console.warn(
         "thumbnail-upload-url unavailable; continuing without client thumbnail (Lambda will generate)",
       );
@@ -63,10 +83,7 @@ export async function uploadRecordedVideo(
   const contentType = resolveUploadContentType(prepared.type || options?.recorderMimeType);
 
   const uploadUrlResult = await issueUploadUrlAction(contentType, prepared.size);
-  const uploadUrlError = extractActionError(uploadUrlResult);
-  if (uploadUrlError || !uploadUrlResult.ok) {
-    throw new Error(uploadUrlError ?? "upload-url failed");
-  }
+  assertActionSuccess(uploadUrlResult, "upload-url failed");
 
   const { videoUuid, uploadUrl } = uploadUrlResult.data;
   const thumbnail = options?.thumbnail;
@@ -78,16 +95,10 @@ export async function uploadRecordedVideo(
       : undefined;
 
   const completeResult = await completeVideoAction(videoUuid, options?.caption, thumbnailS3Key);
-  const completeError = extractActionError(completeResult);
-  if (completeError || !completeResult.ok) {
-    throw new Error(completeError ?? "complete failed");
-  }
+  assertActionSuccess(completeResult, "complete failed");
 
   const detailResult = await getVideoAction(videoUuid);
-  const detailError = extractActionError(detailResult);
-  if (detailError || !detailResult.ok) {
-    throw new Error(detailError ?? "get video failed");
-  }
+  assertActionSuccess(detailResult, "get video failed");
 
   return {
     videoUuid,


### PR DESCRIPTION
## 작업 내용

`/video` 촬영 중 화면이 깜박이는 문제와 저장 시 `[401] 인증이 필요합니다` 오류를 수정했습니다.  
촬영 타이머(50ms)마다 inline video ref가 재생성되며 `attachLiveStream`이 반복 호출되던 것이 깜박임 원인이었고, accessToken 만료 시 video API만 raw 401 메시지를 표시하던 것이 인증 UX 문제였습니다.

## 관련 이슈

Close #N

## 변경 사항

### 1. 촬영 화면 깜박임 제거

- **파일:** `hooks/useVideoRecorder.ts`, `components/organisms/CaptureFlowSection.tsx`
- **설명:** 동일 MediaStream이면 `attachLiveStream` skip, video ref를 `useCallback`으로 고정

```typescript
// hooks/useVideoRecorder.ts
if (node.srcObject === stream && !node.paused && !node.ended) {
  return;
}
```

```typescript
// components/organisms/CaptureFlowSection.tsx
const bindCaptureVideoRef = useCallback(
  (node) => {
    videoRef(node);
    previewVideoElRef.current = node;
  },
  [videoRef],
);
```

### 2. 업로드 401 세션 처리

- **파일:** `actions/videoActions.ts`, `lib/video/uploadPipeline.ts`, `hooks/useVideoCaptureFlow.ts`
- **설명:** accessToken 없으면 reissue 시도, 401 → `actionSessionExpired()`, 세션 만료 시 logout 후 로그인 페이지 이동

```typescript
// actions/videoActions.ts
if (error.status === 401) {
  return actionSessionExpired();
}
```

## 테스트

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `/video` 촬영 중 화면 깜박임 없음
- [ ] 로그인 상태에서 촬영 → 저장 → 업로드 성공
- [ ] accessToken 만료 시 `[401]...` 대신 로그인 페이지로 이동

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인