### PR TITLE
[#174] Fix : 영상 업로드 complete 실패·강제 로그아웃 수정

### DIFF
--- a/actions/videoActions.ts
+++ b/actions/videoActions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { actionFailure, actionSessionExpired, actionSuccess, type ActionResult } from "@/types/action-result";
+import { actionFailure, actionSuccess, type ActionResult } from "@/types/action-result";
 import type {
   VideoCompleteActionData,
   VideoDestinationActionData,
@@ -13,12 +13,7 @@ import type { VideoDestinationRequest } from "@/types/video/api";
 import type { VideoDestination } from "@/types/video/destination";
 import { getApiUrl, isVideoDestinationNotWiredFallbackEnabled } from "@/lib/api/env";
 import { ApiError } from "@/lib/api/apiFetch";
-import { persistSessionTokens } from "@/lib/auth/persist-session-tokens";
-import {
-  applyRetryAuthHeaders,
-  reissueTokensOncePerRequest,
-} from "@/lib/auth/request-token-cache";
-import { getServerAccessToken, getServerUserUuid } from "@/lib/auth/server-token";
+import { getServerUserUuid } from "@/lib/auth/server-token";
 import {
   VIDEO_DESTINATION_INVALID,
   VIDEO_LOGIN_REQUIRED,
@@ -41,7 +36,7 @@ const ALLOWED_THUMBNAIL_CONTENT_TYPES = new Set(["image/jpeg"]);
 const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
 
 async function requireSessionUserUuid(): Promise<
-  { ok: true; userUuid: string } | { ok: false; error: string; sessionExpired?: boolean }
+  { ok: true; userUuid: string } | { ok: false; error: string }
 > {
   const userUuid = await getServerUserUuid();
   if (!userUuid) {
@@ -50,17 +45,6 @@ async function requireSessionUserUuid(): Promise<
 
   if (!UUID_PATTERN.test(userUuid)) {
     return { ok: false, error: VIDEO_SESSION_INVALID };
-  }
-
-  const accessToken = await getServerAccessToken();
-  if (!accessToken) {
-    const refreshed = await reissueTokensOncePerRequest();
-    if (!refreshed) {
-      return { ok: false, error: "", sessionExpired: true };
-    }
-
-    applyRetryAuthHeaders(refreshed);
-    await persistSessionTokens(refreshed);
   }
 
   return { ok: true, userUuid };
@@ -92,7 +76,7 @@ function resolveThumbnailContentType(contentType?: string): string | undefined {
 function toActionError(error: unknown): ActionResult<never> {
   if (error instanceof ApiError) {
     if (error.status === 401) {
-      return actionSessionExpired();
+      return actionFailure("인증이 필요합니다. 잠시 후 다시 시도하거나 다시 로그인해 주세요.");
     }
     return actionFailure(`[${error.status}] ${error.message}`);
   }
@@ -117,7 +101,7 @@ export async function issueUploadUrlAction(
 ): Promise<ActionResult<VideoUploadUrlActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
+    return actionFailure(session.error);
   }
 
   const resolvedContentType = resolveContentType(contentType);
@@ -152,7 +136,7 @@ export async function issueThumbnailUploadUrlAction(
 
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
+    return actionFailure(session.error);
   }
 
   const resolvedContentType = resolveThumbnailContentType(contentType);
@@ -192,7 +176,7 @@ export async function completeVideoAction(
 
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
+    return actionFailure(session.error);
   }
 
   const normalizedCaption = caption?.trim() || undefined;
@@ -215,7 +199,7 @@ export async function getVideoAction(
 ): Promise<ActionResult<VideoDetailActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
+    return actionFailure(session.error);
   }
 
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);
@@ -261,7 +245,7 @@ export async function publishVideoDestinationAction(
 
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
+    return actionFailure(session.error);
   }
 
   const payload = toDestinationPayload(destination);
@@ -300,7 +284,7 @@ export async function getDownloadUrlAction(
 ): Promise<ActionResult<VideoDownloadUrlActionData>> {
   const session = await requireSessionUserUuid();
   if (!session.ok) {
-    return session.sessionExpired ? actionSessionExpired() : actionFailure(session.error);
+    return actionFailure(session.error);
   }
 
   const resolvedVideoUuid = resolveVideoUuid(videoUuid);

--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -333,9 +333,7 @@ export function CaptureFlowSection({
     setSaveError(null);
     const uploadOutcome = await uploadCapture(caption.trim() || undefined, thumbnailFile);
     if (!uploadOutcome.ok) {
-      if (!uploadOutcome.sessionExpired) {
-        setSaveError(uploadOutcome.error);
-      }
+      setSaveError(uploadOutcome.error);
       return;
     }
 

--- a/hooks/useVideoCaptureFlow.ts
+++ b/hooks/useVideoCaptureFlow.ts
@@ -1,14 +1,10 @@
 "use client";
 
-import { logoutAction } from "@/actions/authActions";
 import { useVideoRecorder } from "@/hooks/useVideoRecorder";
-import { ROUTES } from "@/config/routes";
 import { DEFAULT_CAPTURE_CAPTION } from "@/lib/video/constants";
-import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { createOversizeUploadBlob } from "@/lib/video/uploadLimits";
 import { runPhase0FUpload, type Phase0FUploadResult } from "@/lib/video/uploadPipeline";
 import type { CaptureFlowPhase } from "@/types/video/ui";
-import { useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
 function mapRecorderStatusToFlowPhase(
@@ -49,10 +45,9 @@ function mapRecorderStatusToFlowPhase(
 
 export type VideoCaptureUploadOutcome =
   | { ok: true; result: Phase0FUploadResult }
-  | { ok: false; error: string; sessionExpired?: boolean };
+  | { ok: false; error: string };
 
 export function useVideoCaptureFlow() {
-  const router = useRouter();
   const recorder = useVideoRecorder({ autoPrepare: true });
   const [uploading, setUploading] = useState(false);
   const [flowError, setFlowError] = useState<string | null>(null);
@@ -107,13 +102,6 @@ export function useVideoCaptureFlow() {
         setUploadResult(result);
         return { ok: true, result };
       } catch (error) {
-        if (error instanceof VideoSessionExpiredError) {
-          await logoutAction().catch(() => undefined);
-          router.push(ROUTES.login);
-          router.refresh();
-          return { ok: false, error: error.message, sessionExpired: true };
-        }
-
         const message = error instanceof Error ? error.message : "Upload failed";
         setFlowError(message);
         return { ok: false, error: message };
@@ -121,7 +109,7 @@ export function useVideoCaptureFlow() {
         setUploading(false);
       }
     },
-    [router],
+    [],
   );
 
   const uploadCapture = useCallback(

--- a/lib/video/downloadUrlPoll.ts
+++ b/lib/video/downloadUrlPoll.ts
@@ -1,5 +1,4 @@
 import { getDownloadUrlAction } from "@/actions/videoActions";
-import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { DOWNLOAD_URL_MAX_ATTEMPTS } from "@/lib/video/constants";
 import type { VideoDownloadUrlActionData } from "@/types/video/action";
 
@@ -24,10 +23,6 @@ export async function pollDownloadUrl(
     const response = await getDownloadUrlAction(videoUuid);
 
     if (!response.ok) {
-      if (response.sessionExpired) {
-        throw new VideoSessionExpiredError();
-      }
-
       throw new Error(response.error || "download-url failed");
     }
 

--- a/lib/video/uploadPipeline.ts
+++ b/lib/video/uploadPipeline.ts
@@ -4,7 +4,6 @@ import {
   issueThumbnailUploadUrlAction,
   issueUploadUrlAction,
 } from "@/actions/videoActions";
-import { VideoSessionExpiredError } from "@/lib/video/actionErrors";
 import { THUMBNAIL_CONTENT_TYPE } from "@/lib/video/constants";
 import { pollDownloadUrl } from "@/lib/video/downloadUrlPoll";
 import { resolvePlaybackSource, type PlaybackSource } from "@/lib/video/playback";
@@ -17,6 +16,7 @@ import type {
   VideoDetailActionData,
   VideoDownloadUrlActionData,
 } from "@/types/video/action";
+import type { ActionResult } from "@/types/action-result";
 
 export type VideoUploadPipelineResult = {
   videoUuid: string;
@@ -32,18 +32,72 @@ export type Phase0FUploadResult = VideoUploadPipelineResult & {
 };
 
 function assertActionSuccess<T>(
-  payload: { ok: true; data: T } | { ok: false; error: string; sessionExpired?: boolean },
+  payload: { ok: true; data: T } | { ok: false; error: string },
   fallbackMessage: string,
 ): asserts payload is { ok: true; data: T } {
-  if (payload.ok) {
-    return;
+  if (!payload.ok) {
+    throw new Error(payload.error || fallbackMessage);
+  }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function isRetryableCompleteError(error: string): boolean {
+  const normalized = error.toLowerCase();
+  return (
+    normalized.includes("raw video not found") ||
+    normalized.includes("not found in s3")
+  );
+}
+
+function detailFromComplete(complete: VideoCompleteActionData): VideoDetailActionData {
+  return {
+    videoUuid: complete.videoUuid,
+    userUuid: "",
+    caption: complete.caption,
+    createdAt: complete.createdAt,
+    rawPlaybackUrl: "",
+    thumbnailUrl: null,
+    overlayTime: complete.overlayTime,
+    downloadReady: false,
+  };
+}
+
+function processingDownloadState(videoUuid: string): VideoDownloadUrlActionData {
+  return {
+    status: "processing",
+    videoUuid,
+    retryAfterSeconds: 3,
+    message: "영상 처리 중입니다.",
+  };
+}
+
+async function completeVideoWithRetry(
+  videoUuid: string,
+  caption?: string,
+  thumbnailS3Key?: string,
+): Promise<ActionResult<VideoCompleteActionData>> {
+  const maxAttempts = 4;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await completeVideoAction(videoUuid, caption, thumbnailS3Key);
+    if (result.ok) {
+      return result;
+    }
+
+    if (isRetryableCompleteError(result.error) && attempt < maxAttempts) {
+      await wait(750 * attempt);
+      continue;
+    }
+
+    return result;
   }
 
-  if (payload.sessionExpired) {
-    throw new VideoSessionExpiredError();
-  }
-
-  throw new Error(payload.error || fallbackMessage);
+  return completeVideoAction(videoUuid, caption, thumbnailS3Key);
 }
 
 async function uploadThumbnailBestEffort(
@@ -53,14 +107,10 @@ async function uploadThumbnailBestEffort(
   const contentType = thumbnail.type || THUMBNAIL_CONTENT_TYPE;
   const issued = await issueThumbnailUploadUrlAction(videoUuid, contentType, thumbnail.size);
   if (!issued.ok) {
-    if (issued.sessionExpired) {
-      throw new VideoSessionExpiredError();
-    }
-
     const issuedError = issued.error;
-    if (issuedError.includes("[404]")) {
+    if (issuedError.includes("[404]") || issuedError.includes("401")) {
       console.warn(
-        "thumbnail-upload-url unavailable; continuing without client thumbnail (Lambda will generate)",
+        "thumbnail-upload-url unavailable or unauthorized; continuing without client thumbnail",
       );
       return undefined;
     }
@@ -68,7 +118,13 @@ async function uploadThumbnailBestEffort(
     throw new Error(issuedError ?? "thumbnail-upload-url failed");
   }
 
-  await putPresignedUpload(issued.data.uploadUrl, thumbnail, contentType);
+  try {
+    await putPresignedUpload(issued.data.uploadUrl, thumbnail, contentType);
+  } catch (error) {
+    console.warn("thumbnail PUT failed; continuing without client thumbnail", error);
+    return undefined;
+  }
+
   return issued.data.thumbnailS3Key;
 }
 
@@ -93,17 +149,19 @@ export async function uploadRecordedVideo(
       ? await uploadThumbnailBestEffort(videoUuid, thumbnail)
       : undefined;
 
-  const completeResult = await completeVideoAction(videoUuid, options?.caption, thumbnailS3Key);
+  const completeResult = await completeVideoWithRetry(videoUuid, options?.caption, thumbnailS3Key);
   assertActionSuccess(completeResult, "complete failed");
 
   const detailResult = await getVideoAction(videoUuid);
-  assertActionSuccess(detailResult, "get video failed");
+  const detail = detailResult.ok
+    ? detailResult.data
+    : detailFromComplete(completeResult.data);
 
   return {
     videoUuid,
     putResult,
     complete: completeResult.data,
-    detail: detailResult.data,
+    detail,
   };
 }
 
@@ -118,12 +176,22 @@ export async function runPhase0FUpload(
   },
 ): Promise<Phase0FUploadResult> {
   const base = await uploadRecordedVideo(blob, options);
-  const poll = await pollDownloadUrl(base.videoUuid);
+
+  let download = processingDownloadState(base.videoUuid);
+  let downloadPollAttempts = 0;
+
+  try {
+    const poll = await pollDownloadUrl(base.videoUuid);
+    download = poll.data;
+    downloadPollAttempts = poll.attempts;
+  } catch (error) {
+    console.warn("download-url poll failed after complete; upload is still saved", error);
+  }
 
   return {
     ...base,
-    download: poll.data,
-    downloadPollAttempts: poll.attempts,
+    download,
+    downloadPollAttempts,
     playback: resolvePlaybackSource(options?.localPreviewUrl, base.detail.rawPlaybackUrl),
   };
 }


### PR DESCRIPTION
## 작업 내용

프로덕션 `/video` 저장 시 S3 PUT은 성공하지만 `complete`/`destination` 반영 전에 강제 로그아웃되던 문제를 수정했습니다.
S3 PUT 이후 `getVideo`·`download-url` poll 단계의 401을 sessionExpired로 처리하며 `logoutAction()`을 호출하던 흐름을 제거하고, `complete` 성공을 기준으로 destination publish까지 이어지도록 업로드 파이프라인을 보강했습니다.

## 관련 이슈

Close #N

## 변경 사항

### 1. 업로드 중 강제 로그아웃 제거

- **파일:** `hooks/useVideoCaptureFlow.ts`, `components/organisms/CaptureFlowSection.tsx`
- **설명:** `VideoSessionExpiredError` 발생 시 `logoutAction()` + 로그인 리다이렉트를 제거하고, 다른 업로드 오류와 동일하게 화면에 에러 메시지를 표시합니다.

```typescript
// hooks/useVideoCaptureFlow.ts
} catch (error) {
  const message = error instanceof Error ? error.message : "Upload failed";
  setFlowError(message);
  return { ok: false, error: message };
}
```

### 2. complete 이후 단계 best-effort 처리

- **파일:** `lib/video/uploadPipeline.ts`, `lib/video/downloadUrlPoll.ts`
- **설명:** `complete` 성공 후 `getVideo`/`download-url` poll 실패 시에도 업로드 성공으로 처리합니다. destination publish가 이어질 수 있도록 `videoUuid`를 반환합니다.

```typescript
// lib/video/uploadPipeline.ts
const detailResult = await getVideoAction(videoUuid);
const detail = detailResult.ok
  ? detailResult.data
  : detailFromComplete(completeResult.data);

try {
  const poll = await pollDownloadUrl(base.videoUuid);
  download = poll.data;
} catch (error) {
  console.warn("download-url poll failed after complete; upload is still saved", error);
}
```

### 3. 썸네일·complete 안정화 및 세션 처리 완화

- **파일:** `lib/video/uploadPipeline.ts`, `actions/videoActions.ts`
- **설명:** 썸네일 401/PUT 실패 시 Lambda fallback으로 `complete` 진행. S3 eventual consistency 대비 complete 재시도(최대 4회). 401을 sessionExpired로 매핑하던 처리와 server action 선제 reissue를 제거해 `withAuthRetry`에 위임합니다.

```typescript
// lib/video/uploadPipeline.ts
if (issuedError.includes("[404]") || issuedError.includes("401")) {
  console.warn("thumbnail-upload-url unavailable or unauthorized; continuing without client thumbnail");
  return undefined;
}

const completeResult = await completeVideoWithRetry(videoUuid, options?.caption, thumbnailS3Key);
```

```typescript
// actions/videoActions.ts
function toActionError(error: unknown): ActionResult<never> {
  if (error instanceof ApiError) {
    if (error.status === 401) {
      return actionFailure("인증이 필요합니다. 잠시 후 다시 시도하거나 다시 로그인해 주세요.");
    }
    return actionFailure(`[${error.status}] ${error.message}`);
  }
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint` (기존 warning만, error 없음)
- [ ] `npm run build`
- [ ] prod `/video` 촬영 → 저장 → destination 연결 E2E

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Fix : 작업 내용`
- [ ] 커밋 메시지 형식: `Fix: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인