### PR TITLE
[#175] Fix: server action API 호출 전 accessToken 선제 갱신

### DIFF
--- a/lib/auth/server-token.ts
+++ b/lib/auth/server-token.ts
@@ -3,10 +3,19 @@ import {
   FORWARDED_REFRESH_TOKEN_HEADER,
   FORWARDED_USER_UUID_HEADER,
 } from "@/lib/auth/forwarded-auth-headers";
-import { getRetryAuthHeaders, getRetryRefreshToken } from "@/lib/auth/request-token-cache";
+import { persistSessionTokens } from "@/lib/auth/persist-session-tokens";
+import {
+  applyRetryAuthHeaders,
+  getRetryAuthHeaders,
+  getRetryRefreshToken,
+  reissueTokensOncePerRequest,
+} from "@/lib/auth/request-token-cache";
 import { headers } from "next/headers";
 import { getToken } from "next-auth/jwt";
 import type { JWT } from "next-auth/jwt";
+import type { Session } from "next-auth";
+
+const TOKEN_REFRESH_SKEW_MS = 60_000;
 
 function readForwardedAuthJwt(headerStore: Headers): JWT | null {
   const accessToken = headerStore.get(FORWARDED_ACCESS_TOKEN_HEADER) ?? "";
@@ -22,6 +31,31 @@ function readForwardedAuthJwt(headerStore: Headers): JWT | null {
     refreshToken: refreshToken || undefined,
     userUuid: userUuid || undefined,
   };
+}
+
+function isAccessTokenStale(accessToken: string | undefined, expiresAt: unknown): boolean {
+  if (!accessToken) {
+    return true;
+  }
+
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) {
+    return false;
+  }
+
+  return Date.now() >= expiresAt - TOKEN_REFRESH_SKEW_MS;
+}
+
+async function readAuthSession(): Promise<Session | null> {
+  if (typeof window !== "undefined") {
+    return null;
+  }
+
+  try {
+    const { auth } = await import("@/auth");
+    return (await auth()) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function getServerAuthJwt() {
@@ -52,45 +86,58 @@ async function getServerAuthJwtSafe() {
   }
 }
 
+type ResolvedSessionTokens = {
+  accessToken?: string;
+  refreshToken?: string;
+  userUuid?: string;
+};
+
+async function resolveSessionTokens(): Promise<ResolvedSessionTokens> {
+  const retryHeaders = getRetryAuthHeaders();
+  const retryAccessToken = retryHeaders?.Authorization?.replace(/^Bearer\s+/i, "").trim();
+  const retryRefreshToken = getRetryRefreshToken();
+
+  const [session, jwt] = await Promise.all([readAuthSession(), getServerAuthJwtSafe()]);
+
+  let accessToken = retryAccessToken || session?.accessToken || jwt?.accessToken;
+  let refreshToken = retryRefreshToken || session?.refreshToken || jwt?.refreshToken;
+  const userUuid = session?.userUuid || jwt?.userUuid;
+
+  const needsRefresh =
+    isAccessTokenStale(accessToken, jwt?.accessTokenExpiresAt) &&
+    typeof refreshToken === "string" &&
+    refreshToken.length > 0;
+
+  if (needsRefresh) {
+    const refreshed = await reissueTokensOncePerRequest();
+    if (refreshed) {
+      applyRetryAuthHeaders(refreshed);
+      await persistSessionTokens(refreshed);
+      accessToken = refreshed.accessToken;
+      refreshToken = refreshed.refreshToken;
+    }
+  }
+
+  return { accessToken, refreshToken, userUuid };
+}
+
 export async function getServerUserUuid(): Promise<string | undefined> {
-  const jwt = await getServerAuthJwtSafe();
-  return typeof jwt?.userUuid === "string" && jwt.userUuid.length > 0 ? jwt.userUuid : undefined;
+  const { userUuid } = await resolveSessionTokens();
+  return typeof userUuid === "string" && userUuid.length > 0 ? userUuid : undefined;
 }
 
 export async function getServerAccessToken(): Promise<string | undefined> {
-  const retryHeaders = getRetryAuthHeaders();
-  const retryToken = retryHeaders?.Authorization?.replace(/^Bearer\s+/i, "").trim();
-  if (retryToken) {
-    return retryToken;
-  }
-
-  const jwt = await getServerAuthJwtSafe();
-  const token = jwt?.accessToken;
-  return typeof token === "string" && token.length > 0 ? token : undefined;
+  const { accessToken } = await resolveSessionTokens();
+  return typeof accessToken === "string" && accessToken.length > 0 ? accessToken : undefined;
 }
 
 export async function getServerRefreshToken(): Promise<string | undefined> {
-  const retryRefreshToken = getRetryRefreshToken();
-  if (retryRefreshToken) {
-    return retryRefreshToken;
-  }
-
-  const jwt = await getServerAuthJwtSafe();
-  const token = jwt?.refreshToken;
-  return typeof token === "string" && token.length > 0 ? token : undefined;
+  const { refreshToken } = await resolveSessionTokens();
+  return typeof refreshToken === "string" && refreshToken.length > 0 ? refreshToken : undefined;
 }
 
 export async function getSessionAuthHeaders(): Promise<Record<string, string>> {
-  const jwt = await getServerAuthJwtSafe();
-  const retryHeaders = getRetryAuthHeaders();
-
-  const accessToken =
-    retryHeaders?.Authorization?.replace(/^Bearer\s+/i, "").trim() ||
-    (typeof jwt?.accessToken === "string" && jwt.accessToken.length > 0
-      ? jwt.accessToken
-      : undefined);
-  const userUuid =
-    typeof jwt?.userUuid === "string" && jwt.userUuid.length > 0 ? jwt.userUuid : undefined;
+  const { accessToken, userUuid } = await resolveSessionTokens();
 
   const sessionHeaders: Record<string, string> = {};
   if (accessToken) {


### PR DESCRIPTION
## 작업 내용

PR #174 머지 후에도 `/video` 업로드 설정에서 「인증이 필요합니다」 401이 발생하는 문제를 수정했습니다.
UI는 `auth()`로 로그인 상태처럼 보이지만, Server Action은 `getToken()`만 사용해 **만료된 accessToken**이 gateway로 전달되던 것이 원인이었습니다.
API 호출 전 `auth()` + refresh reissue로 토큰을 갱신하고 쿠키에 반영하도록 `getSessionAuthHeaders()`를 보강했습니다.

## 관련 이슈

Close #N

## 변경 사항

### 1. Server Action API 호출 전 accessToken 선제 갱신

- **파일:** `lib/auth/server-token.ts`
- **설명:** `resolveSessionTokens()`를 추가해 `auth()` 세션과 JWT 쿠키를 함께 확인하고, accessToken이 없거나 만료 임박이면 reissue 후 `persistSessionTokens()`로 쿠키를 갱신합니다. 업로드 파이프라인의 연속 Server Action에서도 유효한 `Authorization` 헤더가 붙습니다.

```typescript
// lib/auth/server-token.ts
async function resolveSessionTokens(): Promise<ResolvedSessionTokens> {
  const [session, jwt] = await Promise.all([readAuthSession(), getServerAuthJwtSafe()]);

  let accessToken = retryAccessToken || session?.accessToken || jwt?.accessToken;
  let refreshToken = retryRefreshToken || session?.refreshToken || jwt?.refreshToken;

  const needsRefresh =
    isAccessTokenStale(accessToken, jwt?.accessTokenExpiresAt) &&
    typeof refreshToken === "string" &&
    refreshToken.length > 0;

  if (needsRefresh) {
    const refreshed = await reissueTokensOncePerRequest();
    if (refreshed) {
      applyRetryAuthHeaders(refreshed);
      await persistSessionTokens(refreshed);
      accessToken = refreshed.accessToken;
    }
  }

  return { accessToken, refreshToken, userUuid };
}
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint` (기존 warning만, error 없음)
- [ ] `npm run build`
- [ ] prod `/video` 촬영 → 업로드 설정 → **업로드 시작** → destination 연결 E2E

## 머지 전 체크

- [ ] PR 제목 형식: `[#N] Fix : 작업 내용`
- [ ] 커밋 메시지 형식: `Fix: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인