### PR TITLE
[#176] Fix: 촬영 중 플리커링 및 캡션 입력 시 영상 재로드 수정

### DIFF
--- a/components/organisms/CaptureFlowSection.tsx
+++ b/components/organisms/CaptureFlowSection.tsx
@@ -98,6 +98,7 @@ export function CaptureFlowSection({
   } = useVideoCaptureFlow();
   const [previewStep, setPreviewStep] = useState<PreviewStep>("confirm");
   const [caption, setCaption] = useState("");
+  const [overlayCaption, setOverlayCaption] = useState("");
   const [destinationKind, setDestinationKind] = useState<DestinationId>(
     resolveInitialDestinationKind(initialDestinationKind, initialAgitUuid, initialThemeId),
   );
@@ -136,7 +137,9 @@ export function CaptureFlowSection({
   const showConfirm = isPreview && previewStep === "confirm";
   const containPreview = showConfirm && !originalView;
   const mirrorVideo = shouldMirrorVideo(facingMode, status);
-  const frameMetrics = usePreviewFrameMetrics(containPreview, sectionRef, slotRef);
+  const frameMetrics = usePreviewFrameMetrics(containPreview, sectionRef, slotRef, {
+    freeze: containPreview,
+  });
   const loadTopics = useCallback(async (agitUuid: string, preferredTopicId = "") => {
     if (!agitUuid) {
       setTopics([]);
@@ -239,6 +242,7 @@ export function CaptureFlowSection({
 
   const handleRetake = useCallback(() => {
     setCaption("");
+    setOverlayCaption("");
     setSaveError(null);
     setInlineCreateError(null);
     setPendingPublishVideoUuid(null);
@@ -367,6 +371,10 @@ export function CaptureFlowSection({
     }
   }, [replaceThumbnail]);
 
+  const commitOverlayCaption = useCallback(() => {
+    setOverlayCaption(caption.trim());
+  }, [caption]);
+
   const handleContinueToSettings = useCallback(() => {
     if (!thumbnailFile) {
       setThumbnailError("썸네일을 등록해 주세요. 이미지를 고르거나 현재 장면을 담아 주세요.");
@@ -374,9 +382,10 @@ export function CaptureFlowSection({
     }
 
     setThumbnailError(null);
+    setOverlayCaption(caption.trim());
     setOriginalView(false);
     setPreviewStep("settings");
-  }, [thumbnailFile]);
+  }, [caption, thumbnailFile]);
 
   const handleRetryPublish = useCallback(async () => {
     if (!pendingPublishVideoUuid) {
@@ -486,7 +495,7 @@ export function CaptureFlowSection({
           }}
         />
         {showConfirm ? (
-          <CaptureClipOverlays capturedAt={capturedAt} caption={caption} />
+          <CaptureClipOverlays capturedAt={capturedAt} caption={overlayCaption} />
         ) : null}
       </div>
     </div>
@@ -515,6 +524,7 @@ export function CaptureFlowSection({
           thumbnailSource={thumbnailSource}
           thumbnailError={thumbnailError}
           onCaptionChange={setCaption}
+          onCaptionCommit={commitOverlayCaption}
           onPickThumbnailFile={(file) => void handlePickThumbnailFile(file)}
           onCaptureThumbnailFrame={() => void handleCaptureThumbnailFrame()}
           onBack={handleRetake}

--- a/components/organisms/CapturePreviewStage.tsx
+++ b/components/organisms/CapturePreviewStage.tsx
@@ -13,6 +13,7 @@ type CapturePreviewStageProps = {
   thumbnailSource: "file" | "frame" | null;
   thumbnailError: string | null;
   onCaptionChange: (value: string) => void;
+  onCaptionCommit: () => void;
   onPickThumbnailFile: (file: File) => void;
   onCaptureThumbnailFrame: () => void;
   onBack: () => void;
@@ -29,6 +30,7 @@ export function CapturePreviewStage({
   thumbnailSource,
   thumbnailError,
   onCaptionChange,
+  onCaptionCommit,
   onPickThumbnailFile,
   onCaptureThumbnailFrame,
   onBack,
@@ -73,6 +75,7 @@ export function CapturePreviewStage({
             placeholder="영상에 올릴 문구"
             variant="daily"
             onChange={(event) => onCaptionChange(event.target.value)}
+            onBlur={onCaptionCommit}
           />
         </div>
         <CaptureThumbnailField

--- a/hooks/usePreviewFrameMetrics.ts
+++ b/hooks/usePreviewFrameMetrics.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLayoutEffect, useState, type RefObject } from "react";
+import { useLayoutEffect, useRef, useState, type RefObject } from "react";
 
 export type PreviewFrameMetrics = {
   width: number;
@@ -10,15 +10,24 @@ export type PreviewFrameMetrics = {
 
 const EMPTY: PreviewFrameMetrics = { width: 0, height: 0, scale: 1 };
 
+type UsePreviewFrameMetricsOptions = {
+  /** First valid metrics snapshot is kept; ResizeObserver disconnects. */
+  freeze?: boolean;
+};
+
 export function usePreviewFrameMetrics(
   enabled: boolean,
   sectionRef: RefObject<HTMLElement | null>,
   slotRef: RefObject<HTMLElement | null>,
+  options: UsePreviewFrameMetricsOptions = {},
 ): PreviewFrameMetrics {
+  const freeze = options.freeze ?? false;
   const [metrics, setMetrics] = useState<PreviewFrameMetrics>(EMPTY);
+  const frozenRef = useRef(false);
 
   useLayoutEffect(() => {
     if (!enabled) {
+      frozenRef.current = false;
       return;
     }
 
@@ -28,7 +37,13 @@ export function usePreviewFrameMetrics(
       return;
     }
 
+    let observer: ResizeObserver | null = null;
+
     const update = () => {
+      if (frozenRef.current) {
+        return;
+      }
+
       const originW = section.clientWidth;
       const originH = section.clientHeight;
       const slotW = slot.clientWidth;
@@ -46,15 +61,23 @@ export function usePreviewFrameMetrics(
         }
         return { width, height, scale };
       });
+
+      if (freeze) {
+        frozenRef.current = true;
+        observer?.disconnect();
+        observer = null;
+      }
     };
 
-    const observer = new ResizeObserver(update);
+    observer = new ResizeObserver(update);
     observer.observe(section);
     observer.observe(slot);
     update();
 
-    return () => observer.disconnect();
-  }, [enabled, sectionRef, slotRef]);
+    return () => {
+      observer?.disconnect();
+    };
+  }, [enabled, freeze, sectionRef, slotRef]);
 
   return metrics;
 }

--- a/hooks/useVideoRecorder.ts
+++ b/hooks/useVideoRecorder.ts
@@ -91,9 +91,37 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
   const tickTimerRef = useRef<number | null>(null);
   const startedAtRef = useRef<number>(0);
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const feederVideoRef = useRef<HTMLVideoElement | null>(null);
+  const recordingDisplayStreamRef = useRef<MediaStream | null>(null);
   const autoPrepareStartedRef = useRef(false);
   const prepareGenerationRef = useRef(0);
   const prepareAbortRef = useRef<AbortController | null>(null);
+
+  const getFeederVideo = useCallback((): HTMLVideoElement => {
+    if (!feederVideoRef.current) {
+      const feeder = document.createElement("video");
+      feeder.muted = true;
+      feeder.playsInline = true;
+      feeder.setAttribute("playsinline", "");
+      feederVideoRef.current = feeder;
+    }
+    return feederVideoRef.current;
+  }, []);
+
+  const attachFeederStream = useCallback(
+    (stream: MediaStream) => {
+      const feeder = getFeederVideo();
+      if (feeder.srcObject === stream && feeder.videoWidth > 0) {
+        return;
+      }
+
+      feeder.pause();
+      feeder.srcObject = stream;
+      feeder.muted = true;
+      safeVideoPlay(feeder);
+    },
+    [getFeederVideo],
+  );
 
   const syncVideoElement = useCallback(
     (node: HTMLVideoElement | null) => {
@@ -102,10 +130,15 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
         return;
       }
 
-      if (
-        liveStream &&
-        (status === "requesting" || status === "ready" || status === "recording")
-      ) {
+      if (status === "recording") {
+        const recordingStream = recordingDisplayStreamRef.current;
+        if (recordingStream) {
+          attachLiveStream(node, recordingStream);
+        }
+        return;
+      }
+
+      if (liveStream && (status === "requesting" || status === "ready")) {
         attachLiveStream(node, liveStream);
         return;
       }
@@ -195,6 +228,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
 
       const stream = await requestCameraStream(facingMode);
       streamRef.current = stream;
+      attachFeederStream(stream);
       setLiveStream(stream);
       setStatus("ready");
     } catch (cause) {
@@ -206,18 +240,19 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       setError(message);
       setStatus("error");
     }
-  }, [facingMode, resetPreview, stopStream]);
+  }, [attachFeederStream, facingMode, resetPreview, stopStream]);
 
   const restoreLiveCamera = useCallback(async () => {
     try {
       stopStream();
       const stream = await requestCameraStream(facingMode);
       streamRef.current = stream;
+      attachFeederStream(stream);
       setLiveStream(stream);
     } catch {
       /* keep conversion error */
     }
-  }, [facingMode, stopStream]);
+  }, [attachFeederStream, facingMode, stopStream]);
 
   const convertThenPreview = useCallback(
     async (source: Blob, generation: number, signal: AbortSignal) => {
@@ -283,9 +318,11 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     chunksRef.current = [];
     stopCapture();
     abortPrepare();
+    recordingDisplayStreamRef.current = null;
 
-    await waitForVideoFrame(previewNode);
-    const capture = startCaptureCanvas(previewNode);
+    const feeder = getFeederVideo();
+    await waitForVideoFrame(feeder);
+    const capture = startCaptureCanvas(feeder);
     if (!capture) {
       setError("영상을 720p로 녹화할 수 없습니다.");
       setStatus("error");
@@ -293,6 +330,8 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     }
 
     captureRef.current = capture;
+    recordingDisplayStreamRef.current = capture.stream;
+    attachLiveStream(previewNode, capture.stream);
 
     const recorder = new MediaRecorder(capture.stream, {
       mimeType: selectedMimeType,
@@ -311,6 +350,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
     recorder.onstop = () => {
       clearTimers();
       stopCapture();
+      recordingDisplayStreamRef.current = null;
 
       const maxChunks = Math.ceil(maxDurationMs / RECORD_TIMESLICE_MS);
       const trimmedChunks = chunksRef.current.slice(0, maxChunks);
@@ -363,17 +403,19 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       stopRecording();
     }, recordStopMs);
   }, [
+    abortPrepare,
+    applyPreviewBlob,
+    attachFeederStream,
     clearTimers,
+    convertThenPreview,
+    getFeederVideo,
     maxDurationMs,
     prepareCamera,
     recordStopMs,
     resetPreview,
+    stopCapture,
     stopRecording,
     stopStream,
-    stopCapture,
-    convertThenPreview,
-    applyPreviewBlob,
-    abortPrepare,
   ]);
 
   const discardRecording = useCallback(async () => {
@@ -423,6 +465,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
 
       const stream = await requestCameraStream(nextFacing);
       streamRef.current = stream;
+      attachFeederStream(stream);
       setLiveStream(stream);
       setStatus("ready");
     } catch (cause) {
@@ -434,7 +477,7 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       }
       setStatus("error");
     }
-  }, [facingMode, resetPreview, status, stopStream]);
+  }, [attachFeederStream, facingMode, resetPreview, status, stopStream]);
 
   useEffect(() => {
     syncVideoElement(videoRef.current);
@@ -454,6 +497,9 @@ export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
       clearTimers();
       stopCapture();
       abortPrepare();
+      recordingDisplayStreamRef.current = null;
+      feederVideoRef.current?.pause();
+      feederVideoRef.current = null;
       stopStream();
       setPreviewUrl((current) => {
         if (current) {


### PR DESCRIPTION
녹화 중 canvas stream을 프리뷰에 표시하고 confirm 단계 frame metrics를 고정하며, 캡션 오버레이는 blur 시에만 반영한다.

## 작업 내용

<!-- 무엇을 왜 바꿨는지 (2–4문장) -->

## 관련 이슈

Close #176 

## 변경 사항

<!-- 변경마다: 제목 → 파일 → 설명 → 코드 스니펫 -->

### 1. {변경 제목}

- **파일:** `path/to/file.ts`
- **설명:** …

```typescript
// path/to/file.ts
// 핵심 변경 코드 (10~30줄 이내)
```

### 2. {변경 제목}

- **파일:** …
- **설명:** …

```yaml
# 설정/워크플로 예시
```

## 테스트

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 로컬 수동 확인 (`npm run dev`)

## 머지 전 체크

- [x] PR 제목 형식: `[#N] Type : 작업 내용`
- [ ] 커밋 메시지 형식: `Type: 변경 요약`
- [ ] base branch: **develop**
- [ ] CI Test workflow 통과
- [ ] @headdrop 승인
